### PR TITLE
Add a diagnostic message to ip forwading code

### DIFF
--- a/drivers/bridge/setup_ip_forwarding.go
+++ b/drivers/bridge/setup_ip_forwarding.go
@@ -15,6 +15,11 @@ func SetupIPForwarding(i *Interface) error {
 	if i.Config.EnableIPForwarding == false {
 		return fmt.Errorf("Unexpected request to enable IP Forwarding for: %v", *i)
 	}
+
 	// Enable IPv4 forwarding
-	return ioutil.WriteFile(IPV4_FORW_CONF_FILE, []byte{'1', '\n'}, PERM)
+	if err := ioutil.WriteFile(IPV4_FORW_CONF_FILE, []byte{'1', '\n'}, PERM); err != nil {
+		return fmt.Errorf("Setup IP forwarding failed: %v", err)
+	}
+
+	return nil
 }

--- a/drivers/bridge/setup_ip_forwarding_test.go
+++ b/drivers/bridge/setup_ip_forwarding_test.go
@@ -3,6 +3,7 @@ package bridge
 import (
 	"bytes"
 	"io/ioutil"
+	"strings"
 	"testing"
 )
 
@@ -51,7 +52,9 @@ func TestUnexpectedSetupIPForwarding(t *testing.T) {
 
 	// Attempt Set IP Forwarding
 	if err := SetupIPForwarding(br); err == nil {
-		t.Fatalf(err.Error())
+		t.Fatal("Setup IP forwarding was expected to fail")
+	} else if !strings.Contains(err.Error(), "Unexpected request") {
+		t.Fatalf("Setup IP forwarding failed with unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
- Provide context when writing to the file fails
- Verify that the `TestUnexpectedSetupIPForwarding` fails for the expected reason when it does

Ping @aboch: sounds good to you?
