### PR TITLE
Add Driver interface

### DIFF
--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -6,17 +6,23 @@ import (
 	"net"
 
 	"github.com/docker/libnetwork"
-	_ "github.com/docker/libnetwork/drivers/bridge"
+	"github.com/docker/libnetwork/drivers/bridge"
 )
 
 func main() {
 	ip, net, _ := net.ParseCIDR("192.168.100.1/24")
 	net.IP = ip
 
-	options := libnetwork.DriverParams{"AddressIPv4": net}
-	netw, err := libnetwork.NewNetwork("simplebridge", "dummy", options)
+	drv, err := libnetwork.NewDriver("simplebridge")
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	options := bridge.Configuration{AddressIPv4: net}
+	netw, err := drv.NewNetwork("dummy", options)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fmt.Printf("Network=%#v\n", netw)
 }

--- a/drivers.go
+++ b/drivers.go
@@ -1,65 +1,41 @@
 package libnetwork
 
-import (
-	"fmt"
+import "fmt"
 
-	"github.com/docker/libnetwork/pkg/options"
-)
+var drivers = map[string]DriverCreator{}
 
-// DriverParams are a generic structure to hold driver specific settings.
-type DriverParams options.Generic
+// DriverCreator returns a new Driver instance.
+type DriverCreator func() (Driver, error)
 
-// DriverInterface is an interface that every plugin driver needs to implement.
-type DriverInterface interface {
-	CreateNetwork(string, interface{}) (Network, error)
-}
-
-var drivers = map[string]struct {
-	creatorFn  DriverInterface
-	creatorArg interface{}
-}{}
-
-// RegisterNetworkType associates a textual identifier with a way to create a
-// new network. It is called by the various network implementations, and used
+// RegisterNetworkDriver associates a textual identifier with a way to create a
+// new driver. It is called by the various network implementations, and used
 // upon invokation of the libnetwork.NetNetwork function.
-//
-// creatorFn must implement DriverInterface
 //
 // For example:
 //
 //    type driver struct{}
 //
-//    func (d *driver) CreateNetwork(name string, config *TestNetworkConfig) (Network, error) {
+//    func CreateDriver() (Driver, error) {
+//        return &driver{}, nil
 //    }
 //
 //    func init() {
-//        RegisterNetworkType("test", &driver{}, &TestNetworkConfig{})
+//        RegisterNetworkDriver("test", CreateDriver)
 //    }
 //
-func RegisterNetworkType(name string, creatorFn DriverInterface, creatorArg interface{}) error {
+func RegisterNetworkDriver(name string, creatorFn DriverCreator) error {
 	// Store the new driver information to invoke at creation time.
 	if _, ok := drivers[name]; ok {
 		return fmt.Errorf("a driver for network type %q is already registed", name)
 	}
 
-	drivers[name] = struct {
-		creatorFn  DriverInterface
-		creatorArg interface{}
-	}{creatorFn, creatorArg}
-
+	drivers[name] = creatorFn
 	return nil
 }
 
-func createNetwork(networkType, name string, generic DriverParams) (Network, error) {
-	d, ok := drivers[networkType]
-	if !ok {
-		return nil, fmt.Errorf("unknown driver %q", networkType)
+func createNetworkDriver(networkType string) (Driver, error) {
+	if d, ok := drivers[networkType]; ok {
+		return d()
 	}
-
-	config, err := options.GenerateFromModel(options.Generic(generic), d.creatorArg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate driver config: %v", err)
-	}
-
-	return d.creatorFn.CreateNetwork(name, config)
+	return nil, fmt.Errorf("unknown driver %q", networkType)
 }

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/docker/libnetwork"
@@ -27,12 +28,21 @@ type Configuration struct {
 type driver struct{}
 
 func init() {
-	libnetwork.RegisterNetworkType(networkType, &driver{}, &Configuration{})
+	libnetwork.RegisterNetworkDriver(networkType, NewDriver)
+}
+
+// NewDriver returns a new instance of a bridge driver.
+func NewDriver() (libnetwork.Driver, error) {
+	return &driver{}, nil
 }
 
 // Create a new network using simplebridge plugin
-func (d *driver) CreateNetwork(name string, opaqueConfig interface{}) (libnetwork.Network, error) {
-	config := opaqueConfig.(*Configuration)
+func (d *driver) NewNetwork(name string, opaqueConfig interface{}) (libnetwork.Network, error) {
+	config, ok := opaqueConfig.(*Configuration)
+	if !ok {
+		return nil, fmt.Errorf("Invalid configuration type received")
+	}
+
 	bridgeIntfc := newInterface(config)
 	bridgeSetup := newBridgeSetup(bridgeIntfc)
 

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -12,7 +12,7 @@ func TestCreate(t *testing.T) {
 	d := &driver{}
 
 	config := &Configuration{BridgeName: DefaultBridgeName}
-	netw, err := d.CreateNetwork("dummy", config)
+	netw, err := d.NewNetwork("dummy", config)
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestCreateFail(t *testing.T) {
 	d := &driver{}
 
 	config := &Configuration{BridgeName: "dummy0"}
-	if _, err := d.CreateNetwork("dummy", config); err == nil {
+	if _, err := d.NewNetwork("dummy", config); err == nil {
 		t.Fatal("Bridge creation was expected to fail")
 	}
 }
@@ -45,7 +45,7 @@ func TestCreateFullOptions(t *testing.T) {
 	}
 	_, config.FixedCIDRv6, _ = net.ParseCIDR("2001:db8::/48")
 
-	netw, err := d.CreateNetwork("dummy", config)
+	netw, err := d.NewNetwork("dummy", config)
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}

--- a/network.go
+++ b/network.go
@@ -1,17 +1,23 @@
 // Package libnetwork provides basic fonctionalities and extension points to
 // create network namespaces and allocate interfaces for containers to use.
 //
-//    // Create a network for containers to join.
-//    network, err := libnetwork.NewNetwork("simplebridge", &Options{})
+//    // Create a network driver
+//    drv, err := libnetwork.NewDriver("simplebridge")
 //    if err != nil {
-//    	return err
+//        return err
+//    }
+//
+//    // Create a network for containers to join.
+//    network, err := drv.NewNetwork("foo", &Options{})
+//    if err != nil {
+//        return err
 //    }
 //
 //    // For a new container: create network namespace (providing the path).
 //    networkPath := "/var/lib/docker/.../4d23e"
 //    networkNamespace, err := libnetwork.NewNetworkNamespace(networkPath)
 //    if err != nil {
-//    	return err
+//        return err
 //    }
 //
 //    // For each new container: allocate IP and interfaces. The returned network
@@ -19,14 +25,14 @@
 //    // iptables rules for port publishing.
 //    interfaces, err := network.Link(containerID)
 //    if err != nil {
-//    	return err
+//        return err
 //    }
 //
 //    // Add interfaces to the namespace.
 //    for _, interface := range interfaces {
-//    	if err := networkNamespace.AddInterface(interface); err != nil {
-//    		return err
-//    	}
+//        if err := networkNamespace.AddInterface(interface); err != nil {
+//            return err
+//        }
 //    }
 //
 package libnetwork
@@ -96,10 +102,17 @@ type Namespace interface {
 	AddInterface(*Interface) error
 }
 
-// NewNetwork creates a new network of the specified networkType. The options
-// are driver specific and modeled in a generic way.
-func NewNetwork(networkType, name string, options DriverParams) (Network, error) {
-	return createNetwork(networkType, name, options)
+// Driver represents a network driver capable of creating networks of a certain
+// type.
+type Driver interface {
+	// NewNetwork creates a new network of the specified networkType. The
+	// options are driver specific and modeled in a generic way.
+	NewNetwork(name string, options interface{}) (Network, error)
+}
+
+// NewDriver creates a network driver of the specified type.
+func NewDriver(driverType string) (Driver, error) {
+	return createNetworkDriver(driverType)
 }
 
 // NewNetworkNamespace creates a new network namespace mounted on the specified


### PR DESCRIPTION
As per this morning discussion, add a new `Driver` top-level interface, and kill all generic code.
