### PR TITLE
Port Allocator as a libnetwork package

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -23,16 +23,9 @@ const (
 )
 
 var (
-	once        sync.Once
 	ipAllocator *ipallocator.IPAllocator
 	portMapper  *portmapper.PortMapper
 )
-
-func initPortMapper() {
-	once.Do(func() {
-		portMapper = portmapper.New()
-	})
-}
 
 // Configuration info for the "simplebridge" driver.
 type Configuration struct {
@@ -70,7 +63,7 @@ type driver struct {
 
 func init() {
 	ipAllocator = ipallocator.New()
-	initPortMapper()
+	portMapper = portmapper.New()
 }
 
 // New provides a new instance of bridge driver instance

--- a/pkg/portallocator/portallocator_test.go
+++ b/pkg/portallocator/portallocator_test.go
@@ -5,8 +5,13 @@ import (
 	"testing"
 )
 
+func resetPortAllocator() {
+	instance = newInstance()
+}
+
 func TestRequestNewPort(t *testing.T) {
 	p := New()
+	defer resetPortAllocator()
 
 	port, err := p.RequestPort(defaultIP, "tcp", 0)
 	if err != nil {
@@ -20,11 +25,13 @@ func TestRequestNewPort(t *testing.T) {
 
 func TestRequestSpecificPort(t *testing.T) {
 	p := New()
+	defer resetPortAllocator()
 
 	port, err := p.RequestPort(defaultIP, "tcp", 5000)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if port != 5000 {
 		t.Fatalf("Expected port 5000 got %d", port)
 	}
@@ -48,6 +55,7 @@ func TestReleasePort(t *testing.T) {
 
 func TestReuseReleasedPort(t *testing.T) {
 	p := New()
+	defer resetPortAllocator()
 
 	port, err := p.RequestPort(defaultIP, "tcp", 5000)
 	if err != nil {
@@ -69,6 +77,7 @@ func TestReuseReleasedPort(t *testing.T) {
 
 func TestReleaseUnreadledPort(t *testing.T) {
 	p := New()
+	defer resetPortAllocator()
 
 	port, err := p.RequestPort(defaultIP, "tcp", 5000)
 	if err != nil {
@@ -95,6 +104,7 @@ func TestUnknowProtocol(t *testing.T) {
 
 func TestAllocateAllPorts(t *testing.T) {
 	p := New()
+	defer resetPortAllocator()
 
 	for i := 0; i <= p.End-p.Begin; i++ {
 		port, err := p.RequestPort(defaultIP, "tcp", 0)
@@ -145,6 +155,7 @@ func TestAllocateAllPorts(t *testing.T) {
 
 func BenchmarkAllocatePorts(b *testing.B) {
 	p := New()
+	defer resetPortAllocator()
 
 	for i := 0; i < b.N; i++ {
 		for i := 0; i <= p.End-p.Begin; i++ {
@@ -163,6 +174,7 @@ func BenchmarkAllocatePorts(b *testing.B) {
 
 func TestPortAllocation(t *testing.T) {
 	p := New()
+	defer resetPortAllocator()
 
 	ip := net.ParseIP("192.168.0.1")
 	ip2 := net.ParseIP("192.168.0.2")
@@ -224,6 +236,7 @@ func TestPortAllocation(t *testing.T) {
 
 func TestNoDuplicateBPR(t *testing.T) {
 	p := New()
+	defer resetPortAllocator()
 
 	if port, err := p.RequestPort(defaultIP, "tcp", p.Begin); err != nil {
 		t.Fatal(err)

--- a/portmapper/mapper.go
+++ b/portmapper/mapper.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/iptables"
-	"github.com/docker/libnetwork/portallocator"
+	"github.com/docker/libnetwork/pkg/portallocator"
 )
 
 type mapping struct {


### PR DESCRIPTION
DESCRIPTION:
  As part of bringing libnetwork bridge driver features
  in parity with docker/daemon/network/driver/bridge
  features (Issue #46), this commit addresses the
  bridge.RequestPort() API.

  Currenlty docker/api/server.go needs an hold of port
  allocator in order to reserve a transport port which
  will be used by the http server on the host machine,
  so that portallocator does not give out that port when
  queried by portmapper as part of network driver operations.

ISSUE:
  Current implementation in docker is server.go directly
  access portmapper and then portallocator from bridge pkg
  calling bridge.RequestPort(). This also forces that function
  to trigger portmapper initialization (in case bridge init()
  was not executed yet), while portmapper life cycle should
  only be controlled by bridge network driver.
  We cannot mantain this behavior with libnetwrok as this
  violates the modularization of networking code which
  libnetwork is bringing in.

FIX:
- Treat port allocator as a package and have it instantiated
  by docker daemon (This change will happen when docker code
  will migrate to use libnetwork), given it is being used for
  host specific needs.

- Have bridge receive the instance of port allocator as part
  of bridge.Configuration{} via the execution of driverapi.Config()
  Once that happens the needed components (portmapper, ...) will be
  initialized.

Signed-off-by: Alessandro Boch <aboch@docker.com>