### PR TITLE
Issue #68: In bridge.go driver remove veth on endpoint delete

### DIFF
--- a/drivers/bridge/error.go
+++ b/drivers/bridge/error.go
@@ -17,21 +17,18 @@ var (
 	ErrNetworkExists = errors.New("network already exists, simplebridge can only have one network")
 
 	// ErrIfaceName error is returned when a new name could not be generated.
-	ErrIfaceName = errors.New("Failed to find name for new interface")
+	ErrIfaceName = errors.New("failed to find name for new interface")
 
 	// ErrNoIPAddr error is returned when bridge has no IPv4 address configured.
-	ErrNoIPAddr = errors.New("Bridge has no IPv4 address configured")
+	ErrNoIPAddr = errors.New("bridge has no IPv4 address configured")
 )
 
 // ActiveEndpointsError is returned when there are
-// already active endpoints in the network being deleted.
-type ActiveEndpointsError struct {
-	nid string
-	eid string
-}
+// still active endpoints in the network being deleted.
+type ActiveEndpointsError string
 
-func (aee *ActiveEndpointsError) Error() string {
-	return fmt.Sprintf("Network %s has active endpoint %s", aee.nid, aee.eid)
+func (aee ActiveEndpointsError) Error() string {
+	return fmt.Sprintf("network %s has active endpoint", string(aee))
 }
 
 // InvalidNetworkIDError is returned when the passed
@@ -39,15 +36,31 @@ func (aee *ActiveEndpointsError) Error() string {
 type InvalidNetworkIDError string
 
 func (inie InvalidNetworkIDError) Error() string {
-	return fmt.Sprintf("invalid network id %s", inie)
+	return fmt.Sprintf("invalid network id %s", string(inie))
 }
 
 // InvalidEndpointIDError is returned when the passed
-// endpoint id for an existing endpoint is not a known id.
+// endpoint id is not valid.
 type InvalidEndpointIDError string
 
 func (ieie InvalidEndpointIDError) Error() string {
-	return fmt.Sprintf("invalid endpoint id %s", ieie)
+	return fmt.Sprintf("invalid endpoint id: %s", string(ieie))
+}
+
+// InvalidSandboxIDError is returned when the passed
+// sandbox id valid.
+type InvalidSandboxIDError string
+
+func (isie InvalidSandboxIDError) Error() string {
+	return fmt.Sprintf("invalid sanbox id: %s", string(isie))
+}
+
+// EndpointNotFoundError is returned when the no endpoint
+// with the passed endpoint id is found.
+type EndpointNotFoundError string
+
+func (enfe EndpointNotFoundError) Error() string {
+	return fmt.Sprintf("endpoint not found: %s", string(enfe))
 }
 
 // NonDefaultBridgeExistError is returned when a non-default
@@ -55,7 +68,7 @@ func (ieie InvalidEndpointIDError) Error() string {
 type NonDefaultBridgeExistError string
 
 func (ndbee NonDefaultBridgeExistError) Error() string {
-	return fmt.Sprintf("bridge device with non default name %s must be created manually", ndbee)
+	return fmt.Sprintf("bridge device with non default name %s must be created manually", string(ndbee))
 }
 
 // FixedCIDRv4Error is returned when fixed-cidrv4 configuration
@@ -67,7 +80,7 @@ type FixedCIDRv4Error struct {
 }
 
 func (fcv4 *FixedCIDRv4Error) Error() string {
-	return fmt.Sprintf("Setup FixedCIDRv4 failed for subnet %s in %s: %v", fcv4.subnet, fcv4.net, fcv4.err)
+	return fmt.Sprintf("setup FixedCIDRv4 failed for subnet %s in %s: %v", fcv4.subnet, fcv4.net, fcv4.err)
 }
 
 // FixedCIDRv6Error is returned when fixed-cidrv6 configuration
@@ -78,26 +91,26 @@ type FixedCIDRv6Error struct {
 }
 
 func (fcv6 *FixedCIDRv6Error) Error() string {
-	return fmt.Sprintf("Setup FixedCIDRv6 failed for subnet %s in %s: %v", fcv6.net, fcv6.net, fcv6.err)
+	return fmt.Sprintf("setup FixedCIDRv6 failed for subnet %s in %s: %v", fcv6.net, fcv6.net, fcv6.err)
 }
 
 type ipForwardCfgError bridgeInterface
 
 func (i *ipForwardCfgError) Error() string {
-	return fmt.Sprintf("Unexpected request to enable IP Forwarding for: %v", *i)
+	return fmt.Sprintf("unexpected request to enable IP Forwarding for: %v", *i)
 }
 
 type ipTableCfgError string
 
 func (name ipTableCfgError) Error() string {
-	return fmt.Sprintf("Unexpected request to set IP tables for interface: %s", name)
+	return fmt.Sprintf("unexpected request to set IP tables for interface: %s", string(name))
 }
 
 // IPv4AddrRangeError is returned when a valid IP address range couldn't be found.
 type IPv4AddrRangeError string
 
 func (name IPv4AddrRangeError) Error() string {
-	return fmt.Sprintf("can't find an address range for interface %q", name)
+	return fmt.Sprintf("can't find an address range for interface %q", string(name))
 }
 
 // IPv4AddrAddError is returned when IPv4 address could not be added to the bridge.
@@ -107,7 +120,7 @@ type IPv4AddrAddError struct {
 }
 
 func (ipv4 *IPv4AddrAddError) Error() string {
-	return fmt.Sprintf("Failed to add IPv4 address %s to bridge: %v", ipv4.ip, ipv4.err)
+	return fmt.Sprintf("failed to add IPv4 address %s to bridge: %v", ipv4.ip, ipv4.err)
 }
 
 // IPv6AddrAddError is returned when IPv6 address could not be added to the bridge.
@@ -117,7 +130,7 @@ type IPv6AddrAddError struct {
 }
 
 func (ipv6 *IPv6AddrAddError) Error() string {
-	return fmt.Sprintf("Failed to add IPv6 address %s to bridge: %v", ipv6.ip, ipv6.err)
+	return fmt.Sprintf("failed to add IPv6 address %s to bridge: %v", ipv6.ip, ipv6.err)
 }
 
 // IPv4AddrNoMatchError is returned when the bridge's IPv4 address does not match configured.
@@ -127,12 +140,12 @@ type IPv4AddrNoMatchError struct {
 }
 
 func (ipv4 *IPv4AddrNoMatchError) Error() string {
-	return fmt.Sprintf("Bridge IPv4 (%s) does not match requested configuration %s", ipv4.ip, ipv4.cfgIP)
+	return fmt.Sprintf("bridge IPv4 (%s) does not match requested configuration %s", ipv4.ip, ipv4.cfgIP)
 }
 
 // IPv6AddrNoMatchError is returned when the bridge's IPv6 address does not match configured.
 type IPv6AddrNoMatchError net.IPNet
 
 func (ipv6 *IPv6AddrNoMatchError) Error() string {
-	return fmt.Sprintf("Bridge IPv6 addresses do not match the expected bridge configuration %s", ipv6)
+	return fmt.Sprintf("bridge IPv6 addresses do not match the expected bridge configuration %s", ipv6)
 }

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -67,7 +67,7 @@ func TestSimplebridge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ep, err := network.CreateEndpoint("testep", "", "")
+	ep, err := network.CreateEndpoint("testep", "sb1", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,6 +91,7 @@ func TestSimplebridge(t *testing.T) {
 
 func TestUnknownDriver(t *testing.T) {
 	defer netutils.SetupTestNetNS(t)()
+
 	_, err := createTestNetwork("unknowndriver", "testnetwork", options.Generic{})
 	if err == nil {
 		t.Fatal("Expected to fail. But instead succeeded")
@@ -204,7 +205,7 @@ func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ep, err := network.CreateEndpoint("testep", "", "")
+	ep, err := network.CreateEndpoint("testep", "sb2", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,7 +273,7 @@ func TestUnknownEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ep, err := network.CreateEndpoint("testep", "", "")
+	ep, err := network.CreateEndpoint("testep", "sb1", "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Store *Interface on endpoint create
- Remove from bridgeEndpoint ip params now available in Interface
- On endpoint delete attempt a removal of veth plugged into bridge
- (tested disabling defer netutils.SetupTestNetNS(t)() in libnetwrok_test)
- Fix bridge to  store endpoints per sandbox
- Fix bug in error.go which causes stack overflow

Signed-off-by: Alessandro Boch <aboch@docker.com>