### PR TITLE
Refactor NetworkController interface

### DIFF
--- a/cmd/readme_test/readme.go
+++ b/cmd/readme_test/readme.go
@@ -10,15 +10,17 @@ func main() {
 	// Create a new controller instance
 	controller := libnetwork.New()
 
+	// Select and configure the network driver
+	networkType := "bridge"
 	option := options.Generic{}
-	driver, err := controller.NewNetworkDriver("bridge", option)
+	err := controller.ConfigureNetworkDriver(networkType, option)
 	if err != nil {
 		return
 	}
 
 	netOptions := options.Generic{}
 	// Create a network for containers to join.
-	network, err := controller.NewNetwork(driver, "network1", netOptions)
+	network, err := controller.NewNetwork(networkType, "network1", netOptions)
 	if err != nil {
 		return
 	}

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -15,8 +15,9 @@ func main() {
 
 	options := options.Generic{"AddressIPv4": net}
 	controller := libnetwork.New()
-	driver, _ := controller.NewNetworkDriver("bridge", options)
-	netw, err := controller.NewNetwork(driver, "dummy", "")
+	netType := "bridge"
+	err := controller.ConfigureNetworkDriver(netType, options)
+	netw, err := controller.NewNetwork(netType, "dummy", "")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -39,4 +39,7 @@ type Driver interface {
 	// DeleteEndpoint invokes the driver method to delete an endpoint
 	// passing the network id and endpoint id.
 	DeleteEndpoint(nid, eid types.UUID) error
+
+	// Type returns the the type of this driver, the network type this driver manages
+	Type() string
 }

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -475,6 +475,10 @@ func (d *driver) DeleteEndpoint(nid, eid types.UUID) error {
 	return nil
 }
 
+func (d *driver) Type() string {
+	return networkType
+}
+
 func parseEndpointOptions(epOptions interface{}) (*EndpointConfiguration, error) {
 	if epOptions == nil {
 		return nil, nil


### PR DESCRIPTION
- To reflect work flow. NewDriver() => ConfigureDriver()
  and no NetworkDriver returned.
  libnetwork clients would refer to a driver/network type, then
  internally controller will retrieve the correspondent driver
  instance, but this is not a concern of the clients.
- Remove NetworkDriver interface
- Removed stale blank dependency on bridge in libnetwork_test.go
- Taken care of @mrjana comments

Signed-off-by: Alessandro Boch <aboch@docker.com>