### PR TITLE
Rename setGatewayIP() in sandbox pkg

### DIFF
--- a/sandbox/configure_linux.go
+++ b/sandbox/configure_linux.go
@@ -29,7 +29,7 @@ func configureInterface(iface netlink.Link, settings *Interface) error {
 	return nil
 }
 
-func setGatewayIP(path string, gw net.IP) error {
+func programGateway(path string, gw net.IP) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 

--- a/sandbox/namespace_linux.go
+++ b/sandbox/namespace_linux.go
@@ -130,7 +130,7 @@ func (n *networkNamespace) AddInterface(i *Interface) error {
 }
 
 func (n *networkNamespace) SetGateway(gw net.IP) error {
-	err := setGatewayIP(n.path, gw)
+	err := programGateway(n.path, gw)
 	if err == nil {
 		n.sinfo.Gateway = gw
 	}
@@ -143,7 +143,7 @@ func (n *networkNamespace) SetGatewayIPv6(gw net.IP) error {
 		return nil
 	}
 
-	err := setGatewayIP(n.path, gw)
+	err := programGateway(n.path, gw)
 	if err == nil {
 		n.sinfo.GatewayIPv6 = gw
 	}


### PR DESCRIPTION
- setGatewayIP() => programGateway() becsause it is
  causing confusion with setGateway() and setGatewayIPv6()

Signed-off-by: Alessandro Boch <aboch@docker.com>