### PR TITLE
Add support for Join/Leave methods to Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,54 +19,33 @@ Please refer to the [roadmap](ROADMAP.md) for more information.
 
 There are many networking solutions available to suit a broad range of use-cases. libnetwork uses a driver / plugin model to support all of these solutions while abstracting the complexity of the driver implementations by exposing a simple and consistent Network Model to users.
 
+
 ```go
- // Create a new controller instance
- controller := libnetwork.New()
+    // Create a new controller instance
+    controller := libnetwork.New()
 
- // This option is only needed for in-tree drivers. Plugins(in future) will get
- // their options through plugin infrastructure.
- option := options.Generic{}
- driver, err := controller.NewNetworkDriver("bridge", option)
- if err != nil {
-    return
- }
+    // This option is only needed for in-tree drivers. Plugins(in future) will get
+    // their options through plugin infrastructure.
+    option := options.Generic{}
+    err := controller.NewNetworkDriver("bridge", option)
+    if err != nil {
+        return
+    }
 
- netOptions := options.Generic{}
- // Create a network for containers to join.
- network, err := controller.NewNetwork(driver, "network1", netOptions)
- if err != nil {
-    return
- }
+    netOptions := options.Generic{}
+    // Create a network for containers to join.
+    network, err := controller.NewNetwork("bridge", "network1", netOptions)
+    if err != nil {
+    	return
+    }
 
- // For a new container: create a sandbox instance (providing a unique key).
- // For linux it is a filesystem path
- networkPath := "/var/lib/docker/.../4d23e"
- networkNamespace, err := sandbox.NewSandbox(networkPath)
- if err != nil {
-    return
- }
-
- // For each new container: allocate IP and interfaces. The returned network
- // settings will be used for container infos (inspect and such), as well as
- // iptables rules for port publishing. This info is contained or accessible
- // from the returned endpoint.
- ep, err := network.CreateEndpoint("Endpoint1", networkNamespace.Key(), "")
- if err != nil {
-    return
- }
-
- // Add interfaces to the namespace.
- sinfo := ep.SandboxInfo()
- for _, iface := range sinfo.Interfaces {
-     if err := networkNamespace.AddInterface(iface); err != nil {
-     	    return
-     }
- }
-
- // Set the gateway IP
- if err := networkNamespace.SetGateway(sinfo.Gateway); err != nil {
-    return
- }
+    // For each new container: allocate IP and interfaces. The returned network
+    // settings will be used for container infos (inspect and such), as well as
+    // iptables rules for port publishing.
+    ep, err := network.CreateEndpoint("Endpoint1", nil)
+    if err != nil {
+	    return
+    }
 ```
 
 ## Future

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ To suggest changes to the roadmap, including additions, please write the change 
 #### Concepts
 
 1. Sandbox: An isolated environment. This is more or less a standard docker container.
-2. Endpoint: An addressable endpoint used for communication over a specific network. Endpoints join exactly one network and are expected to create a method of network communication for a container. Endpoints are garbage collected when they no longer belong to any Sandboxes. Example : veth pair
+2. Endpoint: An addressable endpoint used for communication over a specific network. Endpoints join exactly one network and are expected to create a method of network communication for a container. Example : veth pair
 3. Network: A collection of endpoints that are able to communicate to each other. Networks are intended to be isolated from each other and to not cross communicate.
 
 #### axioms

--- a/cmd/readme_test/readme.go
+++ b/cmd/readme_test/readme.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/docker/libnetwork"
 	"github.com/docker/libnetwork/pkg/options"
-	"github.com/docker/libnetwork/sandbox"
 )
 
 func main() {
@@ -25,33 +24,20 @@ func main() {
 		return
 	}
 
-	// For a new container: create a sandbox instance (providing a unique key).
-	// For linux it is a filesystem path
-	networkPath := "/var/lib/docker/.../4d23e"
-	networkNamespace, err := sandbox.NewSandbox(networkPath)
-	if err != nil {
-		return
-	}
-
 	// For each new container: allocate IP and interfaces. The returned network
 	// settings will be used for container infos (inspect and such), as well as
 	// iptables rules for port publishing. This info is contained or accessible
 	// from the returned endpoint.
-	ep, err := network.CreateEndpoint("Endpoint1", networkNamespace.Key(), nil)
+	ep, err := network.CreateEndpoint("Endpoint1", nil)
 	if err != nil {
 		return
 	}
 
-	// Add interfaces to the namespace.
-	sinfo := ep.SandboxInfo()
-	for _, iface := range sinfo.Interfaces {
-		if err := networkNamespace.AddInterface(iface); err != nil {
-			return
-		}
-	}
-
-	// Set the gateway IP
-	if err := networkNamespace.SetGateway(sinfo.Gateway); err != nil {
+	// A container can join the endpoint by providing the container ID to the join
+	// api which returns the sandbox key which can be used to access the sandbox
+	// created for the container during join.
+	_, err = ep.Join("container1")
+	if err != nil {
 		return
 	}
 }

--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -31,10 +31,10 @@ type Driver interface {
 	DeleteNetwork(nid types.UUID) error
 
 	// CreateEndpoint invokes the driver method to create an endpoint
-	// passing the network id, endpoint id, sandbox key and driver
+	// passing the network id, endpoint id and driver
 	// specific config. The config mechanism will eventually be replaced
 	// with labels which are yet to be introduced.
-	CreateEndpoint(nid, eid types.UUID, key string, config interface{}) (*sandbox.Info, error)
+	CreateEndpoint(nid, eid types.UUID, config interface{}) (*sandbox.Info, error)
 
 	// DeleteEndpoint invokes the driver method to delete an endpoint
 	// passing the network id and endpoint id.

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -76,7 +76,7 @@ func TestCreateLinkWithOptions(t *testing.T) {
 	mac := net.HardwareAddr([]byte{0x1e, 0x67, 0x66, 0x44, 0x55, 0x66})
 	epConf := &EndpointConfiguration{MacAddress: mac}
 
-	sinfo, err := d.CreateEndpoint("net1", "ep", "s1", epConf)
+	sinfo, err := d.CreateEndpoint("net1", "ep", epConf)
 	if err != nil {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}
@@ -207,7 +207,7 @@ func TestSetDefaultGw(t *testing.T) {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
-	sinfo, err := d.CreateEndpoint("dummy", "ep", "sb2", nil)
+	sinfo, err := d.CreateEndpoint("dummy", "ep", nil)
 	if err != nil {
 		t.Fatalf("Failed to create endpoint: %v", err)
 	}

--- a/drivers/bridge/network_test.go
+++ b/drivers/bridge/network_test.go
@@ -28,7 +28,7 @@ func TestLinkCreate(t *testing.T) {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
-	sinfo, err := d.CreateEndpoint("dummy", "", "sb1", nil)
+	sinfo, err := d.CreateEndpoint("dummy", "", nil)
 	if err != nil {
 		if _, ok := err.(InvalidEndpointIDError); !ok {
 			t.Fatalf("Failed with a wrong error :%s", err.Error())
@@ -37,17 +37,8 @@ func TestLinkCreate(t *testing.T) {
 		t.Fatalf("Failed to detect invalid config")
 	}
 
-	sinfo, err = d.CreateEndpoint("dummy", "ep", "", nil)
-	if err != nil {
-		if _, ok := err.(InvalidSandboxIDError); !ok {
-			t.Fatalf("Failed with a wrong error :%s", err.Error())
-		}
-	} else {
-		t.Fatalf("Failed to detect invalid config")
-	}
-
 	// Good endpoint creation
-	sinfo, err = d.CreateEndpoint("dummy", "ep", "cc", nil)
+	sinfo, err = d.CreateEndpoint("dummy", "ep", nil)
 	if err != nil {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}
@@ -63,14 +54,9 @@ func TestLinkCreate(t *testing.T) {
 	// TODO: if we could get peer name from (sboxLnk.(*netlink.Veth)).PeerName
 	// then we could check the MTU on hostLnk as well.
 
-	_, err = d.CreateEndpoint("dummy", "ep", "cc2", nil)
+	_, err = d.CreateEndpoint("dummy", "ep", nil)
 	if err == nil {
 		t.Fatalf("Failed to detect duplicate endpoint id on same network")
-	}
-
-	_, err = d.CreateEndpoint("dummy", "ep2", "cc", nil)
-	if err == nil {
-		t.Fatalf("Failed to detect addition of more than one endpoint to same sandbox")
 	}
 
 	interfaces := sinfo.Interfaces
@@ -125,12 +111,12 @@ func TestLinkCreateTwo(t *testing.T) {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
-	_, err = d.CreateEndpoint("dummy", "ep", "s1", nil)
+	_, err = d.CreateEndpoint("dummy", "ep", nil)
 	if err != nil {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}
 
-	_, err = d.CreateEndpoint("dummy", "ep", "s1", nil)
+	_, err = d.CreateEndpoint("dummy", "ep", nil)
 	if err != nil {
 		if err != driverapi.ErrEndpointExists {
 			t.Fatalf("Failed with a wrong error :%s", err.Error())
@@ -155,7 +141,7 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
-	sinfo, err := d.CreateEndpoint("dummy", "ep", "sb2", nil)
+	sinfo, err := d.CreateEndpoint("dummy", "ep", nil)
 	if err != nil {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}
@@ -186,7 +172,7 @@ func TestLinkDelete(t *testing.T) {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
-	_, err = d.CreateEndpoint("dummy", "ep1", "s1", nil)
+	_, err = d.CreateEndpoint("dummy", "ep1", nil)
 	if err != nil {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}

--- a/drivers/bridge/setup_ipv6.go
+++ b/drivers/bridge/setup_ipv6.go
@@ -29,8 +29,15 @@ func setupBridgeIPv6(config *Configuration, i *bridgeInterface) error {
 		return fmt.Errorf("Unable to enable IPv6 addresses on bridge: %v", err)
 	}
 
-	if err := netlink.AddrAdd(i.Link, &netlink.Addr{IPNet: bridgeIPv6}); err != nil {
-		return &IPv6AddrAddError{ip: bridgeIPv6, err: err}
+	_, addrsv6, err := i.addresses()
+	if err != nil {
+		return err
+	}
+
+	if len(addrsv6) == 0 {
+		if err := netlink.AddrAdd(i.Link, &netlink.Addr{IPNet: bridgeIPv6}); err != nil {
+			return &IPv6AddrAddError{ip: bridgeIPv6, err: err}
+		}
 	}
 
 	// Store bridge network and default gateway

--- a/error.go
+++ b/error.go
@@ -12,6 +12,9 @@ var (
 	// ErrInvalidNetworkDriver is returned if an invalid driver
 	// instance is passed.
 	ErrInvalidNetworkDriver = errors.New("invalid driver bound to network")
+	// ErrInvalidJoin is returned if a join is attempted on an endpoint
+	// which already has a container joined.
+	ErrInvalidJoin = errors.New("A container has already joined the endpoint")
 )
 
 // NetworkTypeError type is returned when the network type string is not
@@ -60,4 +63,12 @@ type UnknownEndpointError struct {
 
 func (uee *UnknownEndpointError) Error() string {
 	return fmt.Sprintf("unknown endpoint %s id %s", uee.name, uee.id)
+}
+
+// InvalidContainerIDError is returned when an invalid container id is passed
+// in Join/Leave
+type InvalidContainerIDError string
+
+func (id InvalidContainerIDError) Error() string {
+	return fmt.Sprintf("invalid container id %s", string(id))
 }

--- a/sandbox/configure_linux.go
+++ b/sandbox/configure_linux.go
@@ -51,9 +51,15 @@ func programGateway(path string, gw net.IP) error {
 	}
 	defer netns.Set(origns)
 
+	gwRoutes, err := netlink.RouteGet(gw)
+	if err != nil {
+		return fmt.Errorf("route for the gateway could not be found: %v", err)
+	}
+
 	return netlink.RouteAdd(&netlink.Route{
-		Scope: netlink.SCOPE_UNIVERSE,
-		Gw:    gw,
+		Scope:     netlink.SCOPE_UNIVERSE,
+		LinkIndex: gwRoutes[0].LinkIndex,
+		Gw:        gw,
 	})
 }
 

--- a/sandbox/sandbox_linux_test.go
+++ b/sandbox/sandbox_linux_test.go
@@ -54,7 +54,8 @@ func newInfo(t *testing.T) (*Info, error) {
 	intf.Address = addr
 	intf.Address.IP = ip4
 
-	ip6, addrv6, err := net.ParseCIDR("2001:DB8::ABCD/48")
+	// ip6, addrv6, err := net.ParseCIDR("2001:DB8::ABCD/48")
+	ip6, addrv6, err := net.ParseCIDR("fe80::2/64")
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +64,8 @@ func newInfo(t *testing.T) (*Info, error) {
 
 	sinfo := &Info{Interfaces: []*Interface{intf}}
 	sinfo.Gateway = net.ParseIP("192.168.1.1")
-	sinfo.GatewayIPv6 = net.ParseIP("2001:DB8::1")
+	// sinfo.GatewayIPv6 = net.ParseIP("2001:DB8::1")
+	sinfo.GatewayIPv6 = net.ParseIP("fe80::1")
 
 	return sinfo, nil
 }


### PR DESCRIPTION
- Added support for Join/Leave methods to Endpoint.
- Removed sandbox key argument from CreateEndpoint.
- Refactored bridge driver code to remove sandbox key.
- Fixed bridge driver code for gaps in ipv6 behavior
  observed during docker integration.
- Updated test code, readme code, README.md according
  api change.
- Fixed some sandbox issues while testing docker ipv6
  integration.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>