### PR TITLE
Control scope of JoinOption functions

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -43,8 +43,9 @@ type ContainerData struct {
 }
 
 // JoinOption is a option setter function type used to pass varios options to
-// endpoint Join method.
-type JoinOption func(ep Endpoint)
+// endpoint Join method. The various setter functions of type JoinOption are
+// provided by libnetwork, they look like JoinOption[...](...)
+type JoinOption func(ep *endpoint)
 
 type containerConfig struct {
 	Hostname   string
@@ -241,8 +242,7 @@ func (ep *endpoint) buildHostsFiles() error {
 // JoinOptionHostname function returns an option setter for hostname option to
 // be passed to endpoint Join method.
 func JoinOptionHostname(name string) JoinOption {
-	return func(e Endpoint) {
-		ep := e.(*endpoint)
+	return func(ep *endpoint) {
 		ep.container.Config.Hostname = name
 	}
 }
@@ -250,8 +250,7 @@ func JoinOptionHostname(name string) JoinOption {
 // JoinOptionDomainname function returns an option setter for domainname option to
 // be passed to endpoint Join method.
 func JoinOptionDomainname(name string) JoinOption {
-	return func(e Endpoint) {
-		ep := e.(*endpoint)
+	return func(ep *endpoint) {
 		ep.container.Config.Domainname = name
 	}
 }


### PR DESCRIPTION
ISSUE:
- JoinOption type takes the exported interface Endpoint as parameter.
  This does not allows libnetwork to control the setter functions
  which will be executed by processOptions(). Client can now craft
  any func (e Endpoint), pass it to Endpoint.Join() and have it executed.
  Beside the fact this allows the client to shot himself in the foot,
  there seem not to be a real need in having the JoinOption take the
  Endpoint interface as parameter.

CHANGE:
- Changing the JoinOption signature to take a pointer to the unexported
  endpoint structure. So now libnetwork is the only one that can define
  the Join() method's options setter functions via the self referenced
  JoinOption[...] functions.

Signed-off-by: Alessandro Boch <aboch@docker.com>