### PR TITLE
change the type of ports form PortBinding to TransportPort in link.go

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -50,6 +50,7 @@ type Configuration struct {
 type EndpointConfiguration struct {
 	MacAddress   net.HardwareAddr
 	PortBindings []netutils.PortBinding
+	ExposedPorts []netutils.TransportPort
 }
 
 // ContainerConfiguration represents the user specified configuration for a container
@@ -663,7 +664,7 @@ func (d *driver) link(nid, eid types.UUID, options map[string]interface{}, enabl
 		return nil
 	}
 
-	if endpoint.config != nil && endpoint.config.PortBindings != nil {
+	if endpoint.config != nil && endpoint.config.ExposedPorts != nil {
 		for _, p := range cc.parentEndpoints {
 			var parentEndpoint *bridgeEndpoint
 			parentEndpoint, err = network.getEndpoint(p)
@@ -677,7 +678,7 @@ func (d *driver) link(nid, eid types.UUID, options map[string]interface{}, enabl
 
 			l := newLink(parentEndpoint.intf.Address.IP.String(),
 				endpoint.intf.Address.IP.String(),
-				endpoint.config.PortBindings, d.config.BridgeName)
+				endpoint.config.ExposedPorts, d.config.BridgeName)
 			if enable {
 				err = l.Enable()
 				if err != nil {
@@ -704,12 +705,12 @@ func (d *driver) link(nid, eid types.UUID, options map[string]interface{}, enabl
 			err = InvalidEndpointIDError(string(c))
 			return err
 		}
-		if childEndpoint.config == nil || childEndpoint.config.PortBindings == nil {
+		if childEndpoint.config == nil || childEndpoint.config.ExposedPorts == nil {
 			continue
 		}
 		l := newLink(endpoint.intf.Address.IP.String(),
 			childEndpoint.intf.Address.IP.String(),
-			childEndpoint.config.PortBindings, d.config.BridgeName)
+			childEndpoint.config.ExposedPorts, d.config.BridgeName)
 		if enable {
 			err = l.Enable()
 			if err != nil {
@@ -749,6 +750,14 @@ func parseEndpointOptions(epOptions map[string]interface{}) (*EndpointConfigurat
 	if opt, ok := epOptions[options.PortMap]; ok {
 		if bs, ok := opt.([]netutils.PortBinding); ok {
 			ec.PortBindings = bs
+		} else {
+			return nil, ErrInvalidEndpointConfig
+		}
+	}
+
+	if opt, ok := epOptions[options.ExposedPorts]; ok {
+		if ports, ok := opt.([]netutils.TransportPort); ok {
+			ec.ExposedPorts = ports
 		} else {
 			return nil, ErrInvalidEndpointConfig
 		}

--- a/drivers/bridge/link.go
+++ b/drivers/bridge/link.go
@@ -12,7 +12,7 @@ import (
 type link struct {
 	parentIP string
 	childIP  string
-	ports    []netutils.PortBinding
+	ports    []netutils.TransportPort
 	bridge   string
 }
 
@@ -20,7 +20,7 @@ func (l *link) String() string {
 	return fmt.Sprintf("%s <-> %s [%v] on %s", l.parentIP, l.childIP, l.ports, l.bridge)
 }
 
-func newLink(parentIP, childIP string, ports []netutils.PortBinding, bridge string) *link {
+func newLink(parentIP, childIP string, ports []netutils.TransportPort, bridge string) *link {
 	return &link{
 		childIP:  childIP,
 		parentIP: parentIP,
@@ -45,7 +45,7 @@ func (l *link) Disable() {
 	// that returns typed errors
 }
 
-func linkContainers(action, parentIP, childIP string, ports []netutils.PortBinding, bridge string,
+func linkContainers(action, parentIP, childIP string, ports []netutils.TransportPort, bridge string,
 	ignoreErrors bool) error {
 	var nfAction iptables.Action
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -14,6 +14,8 @@ const (
 	PortMap = "io.docker.network.endpoint.portmap"
 	// MacAddress constant represents Mac Address config of a Container
 	MacAddress = "io.docker.network.endpoint.macaddress"
+	// ExposedPorts constant represents exposedports of a Container
+	ExposedPorts = "io.docker.network.endpoint.exposedports"
 )
 
 // NoSuchFieldError is the error returned when the generic parameters hold a


### PR DESCRIPTION
I think the netutils.TransportPort is better  than netutils.PortBinding.

In the Docker link operation. We just need the child container's ExposedPorts.

@mavenugo  @aboch @mrjana  @resouer
Signed-off-by: Mingzhen Feng <fmzhen@zju.edu.cn>