### PR TITLE
Incorrect assumption with golang net package causes Overlapping IP

### DIFF
--- a/drivers/bridge/setup_ipv4.go
+++ b/drivers/bridge/setup_ipv4.go
@@ -35,7 +35,7 @@ func init() {
 			log.Errorf("Failed to parse address %s", addr)
 			continue
 		}
-		net.IP = ip
+		net.IP = ip.To4()
 		bridgeNetworks = append(bridgeNetworks, net)
 	}
 }

--- a/netutils/utils.go
+++ b/netutils/utils.go
@@ -192,7 +192,9 @@ func CheckRouteOverlaps(toCheck *net.IPNet) error {
 
 // NetworkOverlaps detects overlap between one IPNet and another
 func NetworkOverlaps(netX *net.IPNet, netY *net.IPNet) bool {
-	if len(netX.IP) == len(netY.IP) {
+	// Check if both netX and netY are ipv4 or ipv6
+	if (netX.IP.To4() != nil && netY.IP.To4() != nil) ||
+		(netX.IP.To4() == nil && netY.IP.To4() == nil) {
 		if firstIP, _ := NetworkRange(netX); netY.Contains(firstIP) {
 			return true
 		}


### PR DESCRIPTION
using a len(net.IP) to check for ipv4 or ipv6 is a bad idea.
And that was exactly done in NetworkOverlaps() function with the
assumption that any ipv4 net.IP will be of 4 bytes. Golang Net package
makes no such assumptions.

This assumption actually broke a particular use-case where the
NetworkOverlaps fails to identify a genuine overlap and that causes
datapath issues.

With this fix, we explicitely check for v4 or v6

Signed-off-by: Madhu Venugopal <madhu@docker.com>