### PR TITLE
Link integration fixes

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -54,8 +54,8 @@ type EndpointConfiguration struct {
 
 // ContainerConfiguration represents the user specified configuration for a container
 type ContainerConfiguration struct {
-	parentEndpoints []types.UUID
-	childEndpoints  []types.UUID
+	ParentEndpoints []string
+	ChildEndpoints  []string
 }
 
 type bridgeEndpoint struct {
@@ -664,14 +664,14 @@ func (d *driver) link(nid, eid types.UUID, options map[string]interface{}, enabl
 	}
 
 	if endpoint.config != nil && endpoint.config.PortBindings != nil {
-		for _, p := range cc.parentEndpoints {
+		for _, p := range cc.ParentEndpoints {
 			var parentEndpoint *bridgeEndpoint
-			parentEndpoint, err = network.getEndpoint(p)
+			parentEndpoint, err = network.getEndpoint(types.UUID(p))
 			if err != nil {
 				return err
 			}
 			if parentEndpoint == nil {
-				err = InvalidEndpointIDError(string(p))
+				err = InvalidEndpointIDError(p)
 				return err
 			}
 
@@ -694,14 +694,14 @@ func (d *driver) link(nid, eid types.UUID, options map[string]interface{}, enabl
 		}
 	}
 
-	for _, c := range cc.childEndpoints {
+	for _, c := range cc.ChildEndpoints {
 		var childEndpoint *bridgeEndpoint
-		childEndpoint, err = network.getEndpoint(c)
+		childEndpoint, err = network.getEndpoint(types.UUID(c))
 		if err != nil {
 			return err
 		}
 		if childEndpoint == nil {
-			err = InvalidEndpointIDError(string(c))
+			err = InvalidEndpointIDError(c)
 			return err
 		}
 		if childEndpoint.config == nil || childEndpoint.config.PortBindings == nil {

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/pkg/iptables"
 	"github.com/docker/libnetwork/netutils"
 	"github.com/docker/libnetwork/pkg/options"
-	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 )
 
@@ -226,8 +225,8 @@ func TestLinkContainers(t *testing.T) {
 		t.Fatalf("No Ipv4 address assigned to the endpoint:  ep2")
 	}
 
-	ce := []types.UUID{"ep1"}
-	cConfig := &ContainerConfiguration{childEndpoints: ce}
+	ce := []string{"ep1"}
+	cConfig := &ContainerConfiguration{ChildEndpoints: ce}
 	genericOption = make(map[string]interface{})
 	genericOption[options.GenericData] = cConfig
 
@@ -276,8 +275,8 @@ func TestLinkContainers(t *testing.T) {
 	}
 
 	// Error condition test with an invalid endpoint-id "ep4"
-	ce = []types.UUID{"ep1", "ep4"}
-	cConfig = &ContainerConfiguration{childEndpoints: ce}
+	ce = []string{"ep1", "ep4"}
+	cConfig = &ContainerConfiguration{ChildEndpoints: ce}
 	genericOption = make(map[string]interface{})
 	genericOption[options.GenericData] = cConfig
 


### PR DESCRIPTION
- Changed ContainerConfiguration to simply use strings
- Made ContainerConfiguration fields to be exported so
  options package can access them.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>