### PR TITLE
Don't fail the build on coveralls upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install-deps:
 	go get github.com/mattn/goveralls
 
 coveralls:
-	@goveralls -service circleci -coverprofile=coverage.coverprofile -repotoken $$COVERALLS_TOKEN
+	-@goveralls -service circleci -coverprofile=coverage.coverprofile -repotoken $$COVERALLS_TOKEN
 
 # CircleCI's Docker fails when cleaning up using the --rm flag
 # The following target is a workaround for this


### PR DESCRIPTION
If we can't upload to coveralls, don't fail the build.

Goveralls and Coveralls have been a little flaky and started throwing
http 422 errors, although I still see coverage being reported.

It's best in the interim to ignore these, although this should be
removed in future when the service is more stable

Signed-off-by: Dave Tucker <dt@docker.com>