### PR TITLE
Make endpoint Join and Leave multi-thread safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ run-tests:
 	@echo "mode: count" > coverage.coverprofile
 	@for dir in $$(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -type d); do \
 	    if ls $$dir/*.go &> /dev/null; then \
-            	$(shell which godep) go test -test.v -covermode=count -coverprofile=$$dir/profile.tmp $$dir ; \
+            	$(shell which godep) go test -test.parallel 3 -test.v -covermode=count -coverprofile=$$dir/profile.tmp $$dir ; \
 		if [ $$? -ne 0 ]; then exit $$?; fi ;\
 	        if [ -f $$dir/profile.tmp ]; then \
 		        cat $$dir/profile.tmp | tail -n +2 >> coverage.coverprofile ; \

--- a/error.go
+++ b/error.go
@@ -15,6 +15,9 @@ var (
 	// ErrInvalidJoin is returned if a join is attempted on an endpoint
 	// which already has a container joined.
 	ErrInvalidJoin = errors.New("A container has already joined the endpoint")
+	// ErrNoContainer is returned when the endpoint has no container
+	// attached to it.
+	ErrNoContainer = errors.New("no container attached to the endpoint")
 )
 
 // NetworkTypeError type is returned when the network type string is not

--- a/sandbox/namespace_linux.go
+++ b/sandbox/namespace_linux.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vishvananda/netns"
 )
 
-const prefix = "/var/lib/docker/netns"
+const prefix = "/var/run/netns"
 
 var once sync.Once
 
@@ -148,8 +148,8 @@ func (n *networkNamespace) RemoveInterface(i *Interface) error {
 		return err
 	}
 
-	// Move the network interface to init namespace.
-	if err := netlink.LinkSetNsPid(iface, 1); err != nil {
+	// Move the network interface to caller namespace.
+	if err := netlink.LinkSetNsFd(iface, int(origns)); err != nil {
 		fmt.Println("LinkSetNsPid failed: ", err)
 		return err
 	}


### PR DESCRIPTION
    - Refactored the Join/Leave code so they are synchronized across multiple go-routines
    - Added parallel test coverage to test mult-thread access to Join/Leave
    - Updated sandbox code to revert back to caller namespace when removing interfaces
    - Changed the netns path to /var/run/netns so the cleanup is simpler on machine
      reboot scenario

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>