### PR TITLE
Create build image with dependencies installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ _testmain.go
 
 # IDE files
 .project
+
+libnetwork-build.created


### PR DESCRIPTION
Make builds run faster by making an image with the build dependencies already installed. This comes at the expense of that image potentially being out-of-date with respect to the build dependencies, unless care is taken.
