### PR TITLE
Fix issues when customizing docker bridge

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -205,7 +205,7 @@ func (c *controller) DestroyNetworks() {
 	for _, n := range c.Networks() {
 		err := n.Delete()
 		if err != nil {
-			logrus.Errorf("Failed to destroy network %%s: %v", n.Name, err)
+			logrus.Errorf("Failed to destroy network %s: %v", n.Name, err)
 		}
 	}
 }

--- a/controller.go
+++ b/controller.go
@@ -205,7 +205,7 @@ func (c *controller) DestroyNetworks() {
 	for _, n := range c.Networks() {
 		err := n.Delete()
 		if err != nil {
-			logrus.Errorf("Failed to destroy network %s: %v", n.Name, err)
+			logrus.Errorf("Failed to destroy network %s: %v", n.Name(), err)
 		}
 	}
 }

--- a/controller.go
+++ b/controller.go
@@ -201,7 +201,7 @@ func (c *controller) WalkNetworks(walker NetworkWalker) {
 }
 
 func (c *controller) DestroyNetworks() {
-	logrus.Debugf("Destroy all networks")
+	logrus.Info("Destroy all networks")
 	for _, n := range c.Networks() {
 		err := n.Delete()
 		if err != nil {

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -274,6 +274,8 @@ func Exists(table Table, chain string, rule ...string) bool {
 	if _, err := Raw(append([]string{
 		"-t", string(table), "-C", chain}, rule...)...); err == nil {
 		return true
+	} else if strings.Contains(err.Error(), "iptables: No chain/target/match by that name") {
+		return false
 	}
 
 	// parse "iptables -S" for the rule (this checks rules in a specific chain


### PR DESCRIPTION
On the front: 
This is my first PR, so please notify me if I missed the courtesy obviously in this community.

When customizing docker bridge with --bip, I found two issues here:
1. docker daemon failed when creating docker0 bridge
2. After manually delete original docker0 bridge, docker instance network cannot reach outside

This PR try to address above issues automatically for docker in libnetwork by:
a. Provide DestroyNetworks for docker daemon to cleanup networks from different drivers
b. Take advantage of negative case of iptable -C to check exist of nat rule

The test has been done based on https://github.com/mrjana/docker/tree/cnm_integ,
and once libnetwork got merged, I will update docker daemon Shutdown procedure. 

