### PR TITLE
Ignore the OldHash if the resolvConfPath is invalid

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -526,20 +526,22 @@ func (ep *endpoint) updateDNS(resolvConf []byte) error {
 		return ErrNoContainer
 	}
 
+	oldHash := []byte{}
 	hashFile := container.config.resolvConfPath + ".hash"
-	oldHash, err := ioutil.ReadFile(hashFile)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-
-		oldHash = []byte{}
-	}
 
 	resolvBytes, err := ioutil.ReadFile(container.config.resolvConfPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return err
+		}
+	} else {
+		oldHash, err = ioutil.ReadFile(hashFile)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+
+			oldHash = []byte{}
 		}
 	}
 

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -995,6 +995,7 @@ func TestEnableIPv6(t *testing.T) {
 	}
 
 	resolvConfPath := "/tmp/libnetwork_test/resolv.conf"
+	defer os.Remove(resolvConfPath)
 
 	_, err = ep1.Join(containerID,
 		libnetwork.JoinOptionResolvConfPath(resolvConfPath))
@@ -1061,6 +1062,7 @@ func TestResolvConf(t *testing.T) {
 	}
 
 	resolvConfPath := "/tmp/libnetwork_test/resolv.conf"
+	defer os.Remove(resolvConfPath)
 
 	_, err = ep1.Join(containerID,
 		libnetwork.JoinOptionResolvConfPath(resolvConfPath))


### PR DESCRIPTION
If resolvConfPath is unavailable and if the internally generated .hash file
is still present, then updateDNS should not consider the presence of internally
generated .hash. Rather, it must handle it as a case of using this
resolvConfPath for the first time.

Signed-off-by: Madhu Venugopal <madhu@docker.com>