### PR TITLE
Client / API integration & dnet tool

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -26,7 +26,7 @@
 			"Rev": "a9172f572e13086859c652e2d581950e910d63d4"
 		},
 		{
-			"ImportPath": "github.com/docker/docker/pkg/parsers/kernel",
+			"ImportPath": "github.com/docker/docker/pkg/parsers",
 			"Comment": "v1.4.1-3479-ga9172f5",
 			"Rev": "a9172f572e13086859c652e2d581950e910d63d4"
 		},
@@ -47,6 +47,11 @@
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/stringid",
+			"Comment": "v1.4.1-3479-ga9172f5",
+			"Rev": "a9172f572e13086859c652e2d581950e910d63d4"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/term",
 			"Comment": "v1.4.1-3479-ga9172f5",
 			"Rev": "a9172f572e13086859c652e2d581950e910d63d4"
 		},

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/filters/parse.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/filters/parse.go
@@ -1,0 +1,116 @@
+package filters
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strings"
+)
+
+type Args map[string][]string
+
+// Parse the argument to the filter flag. Like
+//
+//   `docker ps -f 'created=today' -f 'image.name=ubuntu*'`
+//
+// If prev map is provided, then it is appended to, and returned. By default a new
+// map is created.
+func ParseFlag(arg string, prev Args) (Args, error) {
+	var filters Args = prev
+	if prev == nil {
+		filters = Args{}
+	}
+	if len(arg) == 0 {
+		return filters, nil
+	}
+
+	if !strings.Contains(arg, "=") {
+		return filters, ErrorBadFormat
+	}
+
+	f := strings.SplitN(arg, "=", 2)
+	name := strings.ToLower(strings.TrimSpace(f[0]))
+	value := strings.TrimSpace(f[1])
+	filters[name] = append(filters[name], value)
+
+	return filters, nil
+}
+
+var ErrorBadFormat = errors.New("bad format of filter (expected name=value)")
+
+// packs the Args into an string for easy transport from client to server
+func ToParam(a Args) (string, error) {
+	// this way we don't URL encode {}, just empty space
+	if len(a) == 0 {
+		return "", nil
+	}
+
+	buf, err := json.Marshal(a)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+// unpacks the filter Args
+func FromParam(p string) (Args, error) {
+	args := Args{}
+	if len(p) == 0 {
+		return args, nil
+	}
+	if err := json.NewDecoder(strings.NewReader(p)).Decode(&args); err != nil {
+		return nil, err
+	}
+	return args, nil
+}
+
+func (filters Args) MatchKVList(field string, sources map[string]string) bool {
+	fieldValues := filters[field]
+
+	//do not filter if there is no filter set or cannot determine filter
+	if len(fieldValues) == 0 {
+		return true
+	}
+
+	if sources == nil || len(sources) == 0 {
+		return false
+	}
+
+outer:
+	for _, name2match := range fieldValues {
+		testKV := strings.SplitN(name2match, "=", 2)
+
+		for k, v := range sources {
+			if len(testKV) == 1 {
+				if k == testKV[0] {
+					continue outer
+				}
+			} else if k == testKV[0] && v == testKV[1] {
+				continue outer
+			}
+		}
+
+		return false
+	}
+
+	return true
+}
+
+func (filters Args) Match(field, source string) bool {
+	fieldValues := filters[field]
+
+	//do not filter if there is no filter set or cannot determine filter
+	if len(fieldValues) == 0 {
+		return true
+	}
+	for _, name2match := range fieldValues {
+		match, err := regexp.MatchString(name2match, source)
+		if err != nil {
+			continue
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/filters/parse_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/filters/parse_test.go
@@ -1,0 +1,78 @@
+package filters
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestParseArgs(t *testing.T) {
+	// equivalent of `docker ps -f 'created=today' -f 'image.name=ubuntu*' -f 'image.name=*untu'`
+	flagArgs := []string{
+		"created=today",
+		"image.name=ubuntu*",
+		"image.name=*untu",
+	}
+	var (
+		args = Args{}
+		err  error
+	)
+	for i := range flagArgs {
+		args, err = ParseFlag(flagArgs[i], args)
+		if err != nil {
+			t.Errorf("failed to parse %s: %s", flagArgs[i], err)
+		}
+	}
+	if len(args["created"]) != 1 {
+		t.Errorf("failed to set this arg")
+	}
+	if len(args["image.name"]) != 2 {
+		t.Errorf("the args should have collapsed")
+	}
+}
+
+func TestParam(t *testing.T) {
+	a := Args{
+		"created":    []string{"today"},
+		"image.name": []string{"ubuntu*", "*untu"},
+	}
+
+	v, err := ToParam(a)
+	if err != nil {
+		t.Errorf("failed to marshal the filters: %s", err)
+	}
+	v1, err := FromParam(v)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	for key, vals := range v1 {
+		if _, ok := a[key]; !ok {
+			t.Errorf("could not find key %s in original set", key)
+		}
+		sort.Strings(vals)
+		sort.Strings(a[key])
+		if len(vals) != len(a[key]) {
+			t.Errorf("value lengths ought to match")
+			continue
+		}
+		for i := range vals {
+			if vals[i] != a[key][i] {
+				t.Errorf("expected %s, but got %s", a[key][i], vals[i])
+			}
+		}
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	a := Args{}
+	v, err := ToParam(a)
+	if err != nil {
+		t.Errorf("failed to marshal the filters: %s", err)
+	}
+	v1, err := FromParam(v)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	if len(a) != len(v1) {
+		t.Errorf("these should both be empty sets")
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_linux.go
@@ -1,0 +1,40 @@
+package operatingsystem
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+)
+
+var (
+	// file to use to detect if the daemon is running in a container
+	proc1Cgroup = "/proc/1/cgroup"
+
+	// file to check to determine Operating System
+	etcOsRelease = "/etc/os-release"
+)
+
+func GetOperatingSystem() (string, error) {
+	b, err := ioutil.ReadFile(etcOsRelease)
+	if err != nil {
+		return "", err
+	}
+	if i := bytes.Index(b, []byte("PRETTY_NAME")); i >= 0 {
+		b = b[i+13:]
+		return string(b[:bytes.IndexByte(b, '"')]), nil
+	}
+	return "", errors.New("PRETTY_NAME not found")
+}
+
+func IsContainerized() (bool, error) {
+	b, err := ioutil.ReadFile(proc1Cgroup)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range bytes.Split(b, []byte{'\n'}) {
+		if len(line) > 0 && !bytes.HasSuffix(line, []byte{'/'}) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_test.go
@@ -1,0 +1,124 @@
+package operatingsystem
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetOperatingSystem(t *testing.T) {
+	var (
+		backup       = etcOsRelease
+		ubuntuTrusty = []byte(`NAME="Ubuntu"
+VERSION="14.04, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`)
+		gentoo = []byte(`NAME=Gentoo
+ID=gentoo
+PRETTY_NAME="Gentoo/Linux"
+ANSI_COLOR="1;32"
+HOME_URL="http://www.gentoo.org/"
+SUPPORT_URL="http://www.gentoo.org/main/en/support.xml"
+BUG_REPORT_URL="https://bugs.gentoo.org/"
+`)
+		noPrettyName = []byte(`NAME="Ubuntu"
+VERSION="14.04, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`)
+	)
+
+	dir := os.TempDir()
+	etcOsRelease = filepath.Join(dir, "etcOsRelease")
+
+	defer func() {
+		os.Remove(etcOsRelease)
+		etcOsRelease = backup
+	}()
+
+	for expect, osRelease := range map[string][]byte{
+		"Ubuntu 14.04 LTS": ubuntuTrusty,
+		"Gentoo/Linux":     gentoo,
+		"":                 noPrettyName,
+	} {
+		if err := ioutil.WriteFile(etcOsRelease, osRelease, 0600); err != nil {
+			t.Fatalf("failed to write to %s: %v", etcOsRelease, err)
+		}
+		s, err := GetOperatingSystem()
+		if s != expect {
+			if expect == "" {
+				t.Fatalf("Expected error 'PRETTY_NAME not found', but got %v", err)
+			} else {
+				t.Fatalf("Expected '%s', but got '%s'. Err=%v", expect, s, err)
+			}
+		}
+	}
+}
+
+func TestIsContainerized(t *testing.T) {
+	var (
+		backup                      = proc1Cgroup
+		nonContainerizedProc1Cgroup = []byte(`14:name=systemd:/
+13:hugetlb:/
+12:net_prio:/
+11:perf_event:/
+10:bfqio:/
+9:blkio:/
+8:net_cls:/
+7:freezer:/
+6:devices:/
+5:memory:/
+4:cpuacct:/
+3:cpu:/
+2:cpuset:/
+`)
+		containerizedProc1Cgroup = []byte(`9:perf_event:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+8:blkio:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+7:net_cls:/
+6:freezer:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+5:devices:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+4:memory:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+3:cpuacct:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+2:cpu:/docker/3cef1b53c50b0fa357d994f8a1a8cd783c76bbf4f5dd08b226e38a8bd331338d
+1:cpuset:/`)
+	)
+
+	dir := os.TempDir()
+	proc1Cgroup = filepath.Join(dir, "proc1Cgroup")
+
+	defer func() {
+		os.Remove(proc1Cgroup)
+		proc1Cgroup = backup
+	}()
+
+	if err := ioutil.WriteFile(proc1Cgroup, nonContainerizedProc1Cgroup, 0600); err != nil {
+		t.Fatalf("failed to write to %s: %v", proc1Cgroup, err)
+	}
+	inContainer, err := IsContainerized()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inContainer {
+		t.Fatal("Wrongly assuming containerized")
+	}
+
+	if err := ioutil.WriteFile(proc1Cgroup, containerizedProc1Cgroup, 0600); err != nil {
+		t.Fatalf("failed to write to %s: %v", proc1Cgroup, err)
+	}
+	inContainer, err = IsContainerized()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inContainer {
+		t.Fatal("Wrongly assuming non-containerized")
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_windows.go
@@ -1,0 +1,47 @@
+package operatingsystem
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// See https://code.google.com/p/go/source/browse/src/pkg/mime/type_windows.go?r=d14520ac25bf6940785aabb71f5be453a286f58c
+// for a similar sample
+
+func GetOperatingSystem() (string, error) {
+
+	var h syscall.Handle
+
+	// Default return value
+	ret := "Unknown Operating System"
+
+	if err := syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE,
+		syscall.StringToUTF16Ptr(`SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\`),
+		0,
+		syscall.KEY_READ,
+		&h); err != nil {
+		return ret, err
+	}
+	defer syscall.RegCloseKey(h)
+
+	var buf [1 << 10]uint16
+	var typ uint32
+	n := uint32(len(buf) * 2) // api expects array of bytes, not uint16
+
+	if err := syscall.RegQueryValueEx(h,
+		syscall.StringToUTF16Ptr("ProductName"),
+		nil,
+		&typ,
+		(*byte)(unsafe.Pointer(&buf[0])),
+		&n); err != nil {
+		return ret, err
+	}
+	ret = syscall.UTF16ToString(buf[:])
+
+	return ret, nil
+}
+
+// No-op on Windows
+func IsContainerized() (bool, error) {
+	return false, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/parsers.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/parsers.go
@@ -1,0 +1,157 @@
+package parsers
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// FIXME: Change this not to receive default value as parameter
+func ParseHost(defaultTCPAddr, defaultUnixAddr, addr string) (string, error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		if runtime.GOOS != "windows" {
+			addr = fmt.Sprintf("unix://%s", defaultUnixAddr)
+		} else {
+			// Note - defaultTCPAddr already includes tcp:// prefix
+			addr = fmt.Sprintf("%s", defaultTCPAddr)
+		}
+	}
+	addrParts := strings.Split(addr, "://")
+	if len(addrParts) == 1 {
+		addrParts = []string{"tcp", addrParts[0]}
+	}
+
+	switch addrParts[0] {
+	case "tcp":
+		return ParseTCPAddr(addrParts[1], defaultTCPAddr)
+	case "unix":
+		return ParseUnixAddr(addrParts[1], defaultUnixAddr)
+	case "fd":
+		return addr, nil
+	default:
+		return "", fmt.Errorf("Invalid bind address format: %s", addr)
+	}
+}
+
+func ParseUnixAddr(addr string, defaultAddr string) (string, error) {
+	addr = strings.TrimPrefix(addr, "unix://")
+	if strings.Contains(addr, "://") {
+		return "", fmt.Errorf("Invalid proto, expected unix: %s", addr)
+	}
+	if addr == "" {
+		addr = defaultAddr
+	}
+	return fmt.Sprintf("unix://%s", addr), nil
+}
+
+func ParseTCPAddr(addr string, defaultAddr string) (string, error) {
+	addr = strings.TrimPrefix(addr, "tcp://")
+	if strings.Contains(addr, "://") || addr == "" {
+		return "", fmt.Errorf("Invalid proto, expected tcp: %s", addr)
+	}
+
+	hostParts := strings.Split(addr, ":")
+	if len(hostParts) != 2 {
+		return "", fmt.Errorf("Invalid bind address format: %s", addr)
+	}
+	host := hostParts[0]
+	if host == "" {
+		host = defaultAddr
+	}
+
+	p, err := strconv.Atoi(hostParts[1])
+	if err != nil && p == 0 {
+		return "", fmt.Errorf("Invalid bind address format: %s", addr)
+	}
+	return fmt.Sprintf("tcp://%s:%d", host, p), nil
+}
+
+// Get a repos name and returns the right reposName + tag|digest
+// The tag can be confusing because of a port in a repository name.
+//     Ex: localhost.localdomain:5000/samalba/hipache:latest
+//     Digest ex: localhost:5000/foo/bar@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb
+func ParseRepositoryTag(repos string) (string, string) {
+	n := strings.Index(repos, "@")
+	if n >= 0 {
+		parts := strings.Split(repos, "@")
+		return parts[0], parts[1]
+	}
+	n = strings.LastIndex(repos, ":")
+	if n < 0 {
+		return repos, ""
+	}
+	if tag := repos[n+1:]; !strings.Contains(tag, "/") {
+		return repos[:n], tag
+	}
+	return repos, ""
+}
+
+func PartParser(template, data string) (map[string]string, error) {
+	// ip:public:private
+	var (
+		templateParts = strings.Split(template, ":")
+		parts         = strings.Split(data, ":")
+		out           = make(map[string]string, len(templateParts))
+	)
+	if len(parts) != len(templateParts) {
+		return nil, fmt.Errorf("Invalid format to parse.  %s should match template %s", data, template)
+	}
+
+	for i, t := range templateParts {
+		value := ""
+		if len(parts) > i {
+			value = parts[i]
+		}
+		out[t] = value
+	}
+	return out, nil
+}
+
+func ParseKeyValueOpt(opt string) (string, string, error) {
+	parts := strings.SplitN(opt, "=", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Unable to parse key/value option: %s", opt)
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+}
+
+func ParsePortRange(ports string) (uint64, uint64, error) {
+	if ports == "" {
+		return 0, 0, fmt.Errorf("Empty string specified for ports.")
+	}
+	if !strings.Contains(ports, "-") {
+		start, err := strconv.ParseUint(ports, 10, 16)
+		end := start
+		return start, end, err
+	}
+
+	parts := strings.Split(ports, "-")
+	start, err := strconv.ParseUint(parts[0], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	end, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	if end < start {
+		return 0, 0, fmt.Errorf("Invalid range specified for the Port: %s", ports)
+	}
+	return start, end, nil
+}
+
+func ParseLink(val string) (string, string, error) {
+	if val == "" {
+		return "", "", fmt.Errorf("empty string specified for links")
+	}
+	arr := strings.Split(val, ":")
+	if len(arr) > 2 {
+		return "", "", fmt.Errorf("bad format for links: %s", val)
+	}
+	if len(arr) == 1 {
+		return val, val, nil
+	}
+	return arr[0], arr[1], nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/parsers_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/parsers/parsers_test.go
@@ -1,0 +1,157 @@
+package parsers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseHost(t *testing.T) {
+	var (
+		defaultHttpHost = "127.0.0.1"
+		defaultUnix     = "/var/run/docker.sock"
+	)
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "0.0.0.0"); err == nil {
+		t.Errorf("tcp 0.0.0.0 address expected error return, but err == nil, got %s", addr)
+	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "tcp://"); err == nil {
+		t.Errorf("default tcp:// address expected error return, but err == nil, got %s", addr)
+	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "0.0.0.1:5555"); err != nil || addr != "tcp://0.0.0.1:5555" {
+		t.Errorf("0.0.0.1:5555 -> expected tcp://0.0.0.1:5555, got %s", addr)
+	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, ":6666"); err != nil || addr != "tcp://127.0.0.1:6666" {
+		t.Errorf(":6666 -> expected tcp://127.0.0.1:6666, got %s", addr)
+	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "tcp://:7777"); err != nil || addr != "tcp://127.0.0.1:7777" {
+		t.Errorf("tcp://:7777 -> expected tcp://127.0.0.1:7777, got %s", addr)
+	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, ""); err != nil || addr != "unix:///var/run/docker.sock" {
+		t.Errorf("empty argument -> expected unix:///var/run/docker.sock, got %s", addr)
+	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "unix:///var/run/docker.sock"); err != nil || addr != "unix:///var/run/docker.sock" {
+		t.Errorf("unix:///var/run/docker.sock -> expected unix:///var/run/docker.sock, got %s", addr)
+	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "unix://"); err != nil || addr != "unix:///var/run/docker.sock" {
+		t.Errorf("unix:///var/run/docker.sock -> expected unix:///var/run/docker.sock, got %s", addr)
+	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "udp://127.0.0.1"); err == nil {
+		t.Errorf("udp protocol address expected error return, but err == nil. Got %s", addr)
+	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "udp://127.0.0.1:2375"); err == nil {
+		t.Errorf("udp protocol address expected error return, but err == nil. Got %s", addr)
+	}
+}
+
+func TestParseRepositoryTag(t *testing.T) {
+	if repo, tag := ParseRepositoryTag("root"); repo != "root" || tag != "" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "root", "", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("root:tag"); repo != "root" || tag != "tag" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "root", "tag", repo, tag)
+	}
+	if repo, digest := ParseRepositoryTag("root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"); repo != "root" || digest != "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		t.Errorf("Expected repo: '%s' and digest: '%s', got '%s' and '%s'", "root", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", repo, digest)
+	}
+	if repo, tag := ParseRepositoryTag("user/repo"); repo != "user/repo" || tag != "" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "user/repo", "", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("user/repo:tag"); repo != "user/repo" || tag != "tag" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "user/repo", "tag", repo, tag)
+	}
+	if repo, digest := ParseRepositoryTag("user/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"); repo != "user/repo" || digest != "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		t.Errorf("Expected repo: '%s' and digest: '%s', got '%s' and '%s'", "user/repo", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", repo, digest)
+	}
+	if repo, tag := ParseRepositoryTag("url:5000/repo"); repo != "url:5000/repo" || tag != "" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "url:5000/repo", "", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("url:5000/repo:tag"); repo != "url:5000/repo" || tag != "tag" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "url:5000/repo", "tag", repo, tag)
+	}
+	if repo, digest := ParseRepositoryTag("url:5000/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"); repo != "url:5000/repo" || digest != "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		t.Errorf("Expected repo: '%s' and digest: '%s', got '%s' and '%s'", "url:5000/repo", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", repo, digest)
+	}
+}
+
+func TestParsePortMapping(t *testing.T) {
+	data, err := PartParser("ip:public:private", "192.168.1.1:80:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(data) != 3 {
+		t.FailNow()
+	}
+	if data["ip"] != "192.168.1.1" {
+		t.Fail()
+	}
+	if data["public"] != "80" {
+		t.Fail()
+	}
+	if data["private"] != "8080" {
+		t.Fail()
+	}
+}
+
+func TestParsePortRange(t *testing.T) {
+	if start, end, err := ParsePortRange("8000-8080"); err != nil || start != 8000 || end != 8080 {
+		t.Fatalf("Error: %s or Expecting {start,end} values {8000,8080} but found {%d,%d}.", err, start, end)
+	}
+}
+
+func TestParsePortRangeIncorrectRange(t *testing.T) {
+	if _, _, err := ParsePortRange("9000-8080"); err == nil || !strings.Contains(err.Error(), "Invalid range specified for the Port") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParsePortRangeIncorrectEndRange(t *testing.T) {
+	if _, _, err := ParsePortRange("8000-a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+
+	if _, _, err := ParsePortRange("8000-30a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParsePortRangeIncorrectStartRange(t *testing.T) {
+	if _, _, err := ParsePortRange("a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+
+	if _, _, err := ParsePortRange("30a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParseLink(t *testing.T) {
+	name, alias, err := ParseLink("name:alias")
+	if err != nil {
+		t.Fatalf("Expected not to error out on a valid name:alias format but got: %v", err)
+	}
+	if name != "name" {
+		t.Fatalf("Link name should have been name, got %s instead", name)
+	}
+	if alias != "alias" {
+		t.Fatalf("Link alias should have been alias, got %s instead", alias)
+	}
+	// short format definition
+	name, alias, err = ParseLink("name")
+	if err != nil {
+		t.Fatalf("Expected not to error out on a valid name only format but got: %v", err)
+	}
+	if name != "name" {
+		t.Fatalf("Link name should have been name, got %s instead", name)
+	}
+	if alias != "name" {
+		t.Fatalf("Link alias should have been name, got %s instead", alias)
+	}
+	// empty string link definition is not allowed
+	if _, _, err := ParseLink(""); err == nil || !strings.Contains(err.Error(), "empty string specified for links") {
+		t.Fatalf("Expected error 'empty string specified for links' but got: %v", err)
+	}
+	// more than two colons are not allowed
+	if _, _, err := ParseLink("link:alias:wrong"); err == nil || !strings.Contains(err.Error(), "bad format for links: link:alias:wrong") {
+		t.Fatalf("Expected error 'bad format for links: link:alias:wrong' but got: %v", err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/tc_linux_cgo.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/tc_linux_cgo.go
@@ -1,0 +1,48 @@
+// +build linux,cgo
+
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// #include <termios.h>
+import "C"
+
+type Termios syscall.Termios
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd uintptr) (*State, error) {
+	var oldState State
+	if err := tcget(fd, &oldState.termios); err != 0 {
+		return nil, err
+	}
+
+	newState := oldState.termios
+
+	C.cfmakeraw((*C.struct_termios)(unsafe.Pointer(&newState)))
+	newState.Oflag = newState.Oflag | C.OPOST
+	if err := tcset(fd, &newState); err != 0 {
+		return nil, err
+	}
+	return &oldState, nil
+}
+
+func tcget(fd uintptr, p *Termios) syscall.Errno {
+	ret, err := C.tcgetattr(C.int(fd), (*C.struct_termios)(unsafe.Pointer(p)))
+	if ret != 0 {
+		return err.(syscall.Errno)
+	}
+	return 0
+}
+
+func tcset(fd uintptr, p *Termios) syscall.Errno {
+	ret, err := C.tcsetattr(C.int(fd), C.TCSANOW, (*C.struct_termios)(unsafe.Pointer(p)))
+	if ret != 0 {
+		return err.(syscall.Errno)
+	}
+	return 0
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/tc_other.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/tc_other.go
@@ -1,0 +1,19 @@
+// +build !windows
+// +build !linux !cgo
+
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func tcget(fd uintptr, p *Termios) syscall.Errno {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(getTermios), uintptr(unsafe.Pointer(p)))
+	return err
+}
+
+func tcset(fd uintptr, p *Termios) syscall.Errno {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, setTermios, uintptr(unsafe.Pointer(p)))
+	return err
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/term.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/term.go
@@ -1,0 +1,118 @@
+// +build !windows
+
+package term
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	ErrInvalidState = errors.New("Invalid terminal state")
+)
+
+type State struct {
+	termios Termios
+}
+
+type Winsize struct {
+	Height uint16
+	Width  uint16
+	x      uint16
+	y      uint16
+}
+
+func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
+	return os.Stdin, os.Stdout, os.Stderr
+}
+
+func GetFdInfo(in interface{}) (uintptr, bool) {
+	var inFd uintptr
+	var isTerminalIn bool
+	if file, ok := in.(*os.File); ok {
+		inFd = file.Fd()
+		isTerminalIn = IsTerminal(inFd)
+	}
+	return inFd, isTerminalIn
+}
+
+func GetWinsize(fd uintptr) (*Winsize, error) {
+	ws := &Winsize{}
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(ws)))
+	// Skipp errno = 0
+	if err == 0 {
+		return ws, nil
+	}
+	return ws, err
+}
+
+func SetWinsize(fd uintptr, ws *Winsize) error {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCSWINSZ), uintptr(unsafe.Pointer(ws)))
+	// Skipp errno = 0
+	if err == 0 {
+		return nil
+	}
+	return err
+}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios Termios
+	return tcget(fd, &termios) == 0
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func RestoreTerminal(fd uintptr, state *State) error {
+	if state == nil {
+		return ErrInvalidState
+	}
+	if err := tcset(fd, &state.termios); err != 0 {
+		return err
+	}
+	return nil
+}
+
+func SaveState(fd uintptr) (*State, error) {
+	var oldState State
+	if err := tcget(fd, &oldState.termios); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+func DisableEcho(fd uintptr, state *State) error {
+	newState := state.termios
+	newState.Lflag &^= syscall.ECHO
+
+	if err := tcset(fd, &newState); err != 0 {
+		return err
+	}
+	handleInterrupt(fd, state)
+	return nil
+}
+
+func SetRawTerminal(fd uintptr) (*State, error) {
+	oldState, err := MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+	handleInterrupt(fd, oldState)
+	return oldState, err
+}
+
+func handleInterrupt(fd uintptr, state *State) {
+	sigchan := make(chan os.Signal, 1)
+	signal.Notify(sigchan, os.Interrupt)
+
+	go func() {
+		_ = <-sigchan
+		RestoreTerminal(fd, state)
+		os.Exit(0)
+	}()
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/term_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/term_windows.go
@@ -1,0 +1,138 @@
+// +build windows
+package term
+
+import (
+	"io"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/term/winconsole"
+)
+
+// State holds the console mode for the terminal.
+type State struct {
+	mode uint32
+}
+
+// Winsize is used for window size.
+type Winsize struct {
+	Height uint16
+	Width  uint16
+	x      uint16
+	y      uint16
+}
+
+func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
+	switch {
+	case os.Getenv("ConEmuANSI") == "ON":
+		// The ConEmu shell emulates ANSI well by default.
+		return os.Stdin, os.Stdout, os.Stderr
+	case os.Getenv("MSYSTEM") != "":
+		// MSYS (mingw) does not emulate ANSI well.
+		return winconsole.WinConsoleStreams()
+	default:
+		return winconsole.WinConsoleStreams()
+	}
+}
+
+// GetFdInfo returns file descriptor and bool indicating whether the file is a terminal.
+func GetFdInfo(in interface{}) (uintptr, bool) {
+	return winconsole.GetHandleInfo(in)
+}
+
+// GetWinsize retrieves the window size of the terminal connected to the passed file descriptor.
+func GetWinsize(fd uintptr) (*Winsize, error) {
+	info, err := winconsole.GetConsoleScreenBufferInfo(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(azlinux): Set the pixel width / height of the console (currently unused by any caller)
+	return &Winsize{
+		Width:  uint16(info.Window.Right - info.Window.Left + 1),
+		Height: uint16(info.Window.Bottom - info.Window.Top + 1),
+		x:      0,
+		y:      0}, nil
+}
+
+// SetWinsize sets the size of the given terminal connected to the passed file descriptor.
+func SetWinsize(fd uintptr, ws *Winsize) error {
+	// TODO(azlinux): Implement SetWinsize
+	logrus.Debugf("[windows] SetWinsize: WARNING -- Unsupported method invoked")
+	return nil
+}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd uintptr) bool {
+	return winconsole.IsConsole(fd)
+}
+
+// RestoreTerminal restores the terminal connected to the given file descriptor to a
+// previous state.
+func RestoreTerminal(fd uintptr, state *State) error {
+	return winconsole.SetConsoleMode(fd, state.mode)
+}
+
+// SaveState saves the state of the terminal connected to the given file descriptor.
+func SaveState(fd uintptr) (*State, error) {
+	mode, e := winconsole.GetConsoleMode(fd)
+	if e != nil {
+		return nil, e
+	}
+	return &State{mode}, nil
+}
+
+// DisableEcho disables echo for the terminal connected to the given file descriptor.
+// -- See http://msdn.microsoft.com/en-us/library/windows/desktop/ms683462(v=vs.85).aspx
+func DisableEcho(fd uintptr, state *State) error {
+	mode := state.mode
+	mode &^= winconsole.ENABLE_ECHO_INPUT
+	mode |= winconsole.ENABLE_PROCESSED_INPUT | winconsole.ENABLE_LINE_INPUT
+	// TODO(azlinux): Core code registers a goroutine to catch os.Interrupt and reset the terminal state.
+	return winconsole.SetConsoleMode(fd, mode)
+}
+
+// SetRawTerminal puts the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func SetRawTerminal(fd uintptr) (*State, error) {
+	state, err := MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(azlinux): Core code registers a goroutine to catch os.Interrupt and reset the terminal state.
+	return state, err
+}
+
+// MakeRaw puts the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd uintptr) (*State, error) {
+	state, err := SaveState(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	// See
+	// -- https://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
+	// -- https://msdn.microsoft.com/en-us/library/windows/desktop/ms683462(v=vs.85).aspx
+	mode := state.mode
+
+	// Disable these modes
+	mode &^= winconsole.ENABLE_ECHO_INPUT
+	mode &^= winconsole.ENABLE_LINE_INPUT
+	mode &^= winconsole.ENABLE_MOUSE_INPUT
+	mode &^= winconsole.ENABLE_WINDOW_INPUT
+	mode &^= winconsole.ENABLE_PROCESSED_INPUT
+
+	// Enable these modes
+	mode |= winconsole.ENABLE_EXTENDED_FLAGS
+	mode |= winconsole.ENABLE_INSERT_MODE
+	mode |= winconsole.ENABLE_QUICK_EDIT_MODE
+
+	err = winconsole.SetConsoleMode(fd, mode)
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/termios_darwin.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/termios_darwin.go
@@ -1,0 +1,65 @@
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	getTermios = syscall.TIOCGETA
+	setTermios = syscall.TIOCSETA
+
+	IGNBRK = syscall.IGNBRK
+	PARMRK = syscall.PARMRK
+	INLCR  = syscall.INLCR
+	IGNCR  = syscall.IGNCR
+	ECHONL = syscall.ECHONL
+	CSIZE  = syscall.CSIZE
+	ICRNL  = syscall.ICRNL
+	ISTRIP = syscall.ISTRIP
+	PARENB = syscall.PARENB
+	ECHO   = syscall.ECHO
+	ICANON = syscall.ICANON
+	ISIG   = syscall.ISIG
+	IXON   = syscall.IXON
+	BRKINT = syscall.BRKINT
+	INPCK  = syscall.INPCK
+	OPOST  = syscall.OPOST
+	CS8    = syscall.CS8
+	IEXTEN = syscall.IEXTEN
+)
+
+type Termios struct {
+	Iflag  uint64
+	Oflag  uint64
+	Cflag  uint64
+	Lflag  uint64
+	Cc     [20]byte
+	Ispeed uint64
+	Ospeed uint64
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd uintptr) (*State, error) {
+	var oldState State
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(getTermios), uintptr(unsafe.Pointer(&oldState.termios))); err != 0 {
+		return nil, err
+	}
+
+	newState := oldState.termios
+	newState.Iflag &^= (IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON)
+	newState.Oflag &^= OPOST
+	newState.Lflag &^= (ECHO | ECHONL | ICANON | ISIG | IEXTEN)
+	newState.Cflag &^= (CSIZE | PARENB)
+	newState.Cflag |= CS8
+	newState.Cc[syscall.VMIN] = 1
+	newState.Cc[syscall.VTIME] = 0
+
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(setTermios), uintptr(unsafe.Pointer(&newState))); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/termios_freebsd.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/termios_freebsd.go
@@ -1,0 +1,65 @@
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	getTermios = syscall.TIOCGETA
+	setTermios = syscall.TIOCSETA
+
+	IGNBRK = syscall.IGNBRK
+	PARMRK = syscall.PARMRK
+	INLCR  = syscall.INLCR
+	IGNCR  = syscall.IGNCR
+	ECHONL = syscall.ECHONL
+	CSIZE  = syscall.CSIZE
+	ICRNL  = syscall.ICRNL
+	ISTRIP = syscall.ISTRIP
+	PARENB = syscall.PARENB
+	ECHO   = syscall.ECHO
+	ICANON = syscall.ICANON
+	ISIG   = syscall.ISIG
+	IXON   = syscall.IXON
+	BRKINT = syscall.BRKINT
+	INPCK  = syscall.INPCK
+	OPOST  = syscall.OPOST
+	CS8    = syscall.CS8
+	IEXTEN = syscall.IEXTEN
+)
+
+type Termios struct {
+	Iflag  uint32
+	Oflag  uint32
+	Cflag  uint32
+	Lflag  uint32
+	Cc     [20]byte
+	Ispeed uint32
+	Ospeed uint32
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd uintptr) (*State, error) {
+	var oldState State
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(getTermios), uintptr(unsafe.Pointer(&oldState.termios))); err != 0 {
+		return nil, err
+	}
+
+	newState := oldState.termios
+	newState.Iflag &^= (IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON)
+	newState.Oflag &^= OPOST
+	newState.Lflag &^= (ECHO | ECHONL | ICANON | ISIG | IEXTEN)
+	newState.Cflag &^= (CSIZE | PARENB)
+	newState.Cflag |= CS8
+	newState.Cc[syscall.VMIN] = 1
+	newState.Cc[syscall.VTIME] = 0
+
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(setTermios), uintptr(unsafe.Pointer(&newState))); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/termios_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/termios_linux.go
@@ -1,0 +1,46 @@
+// +build !cgo
+
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	getTermios = syscall.TCGETS
+	setTermios = syscall.TCSETS
+)
+
+type Termios struct {
+	Iflag  uint32
+	Oflag  uint32
+	Cflag  uint32
+	Lflag  uint32
+	Cc     [20]byte
+	Ispeed uint32
+	Ospeed uint32
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd uintptr) (*State, error) {
+	var oldState State
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, getTermios, uintptr(unsafe.Pointer(&oldState.termios))); err != 0 {
+		return nil, err
+	}
+
+	newState := oldState.termios
+
+	newState.Iflag &^= (syscall.IGNBRK | syscall.BRKINT | syscall.PARMRK | syscall.ISTRIP | syscall.INLCR | syscall.IGNCR | syscall.ICRNL | syscall.IXON)
+	newState.Oflag &^= syscall.OPOST
+	newState.Lflag &^= (syscall.ECHO | syscall.ECHONL | syscall.ICANON | syscall.ISIG | syscall.IEXTEN)
+	newState.Cflag &^= (syscall.CSIZE | syscall.PARENB)
+	newState.Cflag |= syscall.CS8
+
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, setTermios, uintptr(unsafe.Pointer(&newState))); err != 0 {
+		return nil, err
+	}
+	return &oldState, nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/winconsole/console_windows.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/winconsole/console_windows.go
@@ -1,0 +1,1053 @@
+// +build windows
+
+package winconsole
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"github.com/Sirupsen/logrus"
+)
+
+const (
+	// Consts for Get/SetConsoleMode function
+	// -- See https://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
+	ENABLE_PROCESSED_INPUT = 0x0001
+	ENABLE_LINE_INPUT      = 0x0002
+	ENABLE_ECHO_INPUT      = 0x0004
+	ENABLE_WINDOW_INPUT    = 0x0008
+	ENABLE_MOUSE_INPUT     = 0x0010
+	ENABLE_INSERT_MODE     = 0x0020
+	ENABLE_QUICK_EDIT_MODE = 0x0040
+	ENABLE_EXTENDED_FLAGS  = 0x0080
+
+	// If parameter is a screen buffer handle, additional values
+	ENABLE_PROCESSED_OUTPUT   = 0x0001
+	ENABLE_WRAP_AT_EOL_OUTPUT = 0x0002
+
+	//http://msdn.microsoft.com/en-us/library/windows/desktop/ms682088(v=vs.85).aspx#_win32_character_attributes
+	FOREGROUND_BLUE       = 1
+	FOREGROUND_GREEN      = 2
+	FOREGROUND_RED        = 4
+	FOREGROUND_INTENSITY  = 8
+	FOREGROUND_MASK_SET   = 0x000F
+	FOREGROUND_MASK_UNSET = 0xFFF0
+
+	BACKGROUND_BLUE       = 16
+	BACKGROUND_GREEN      = 32
+	BACKGROUND_RED        = 64
+	BACKGROUND_INTENSITY  = 128
+	BACKGROUND_MASK_SET   = 0x00F0
+	BACKGROUND_MASK_UNSET = 0xFF0F
+
+	COMMON_LVB_REVERSE_VIDEO = 0x4000
+	COMMON_LVB_UNDERSCORE    = 0x8000
+
+	// http://man7.org/linux/man-pages/man4/console_codes.4.html
+	// ECMA-48 Set Graphics Rendition
+	ANSI_ATTR_RESET     = 0
+	ANSI_ATTR_BOLD      = 1
+	ANSI_ATTR_DIM       = 2
+	ANSI_ATTR_UNDERLINE = 4
+	ANSI_ATTR_BLINK     = 5
+	ANSI_ATTR_REVERSE   = 7
+	ANSI_ATTR_INVISIBLE = 8
+
+	ANSI_ATTR_UNDERLINE_OFF = 24
+	ANSI_ATTR_BLINK_OFF     = 25
+	ANSI_ATTR_REVERSE_OFF   = 27
+	ANSI_ATTR_INVISIBLE_OFF = 8
+
+	ANSI_FOREGROUND_BLACK   = 30
+	ANSI_FOREGROUND_RED     = 31
+	ANSI_FOREGROUND_GREEN   = 32
+	ANSI_FOREGROUND_YELLOW  = 33
+	ANSI_FOREGROUND_BLUE    = 34
+	ANSI_FOREGROUND_MAGENTA = 35
+	ANSI_FOREGROUND_CYAN    = 36
+	ANSI_FOREGROUND_WHITE   = 37
+	ANSI_FOREGROUND_DEFAULT = 39
+
+	ANSI_BACKGROUND_BLACK   = 40
+	ANSI_BACKGROUND_RED     = 41
+	ANSI_BACKGROUND_GREEN   = 42
+	ANSI_BACKGROUND_YELLOW  = 43
+	ANSI_BACKGROUND_BLUE    = 44
+	ANSI_BACKGROUND_MAGENTA = 45
+	ANSI_BACKGROUND_CYAN    = 46
+	ANSI_BACKGROUND_WHITE   = 47
+	ANSI_BACKGROUND_DEFAULT = 49
+
+	ANSI_MAX_CMD_LENGTH = 256
+
+	MAX_INPUT_EVENTS = 128
+	MAX_INPUT_BUFFER = 1024
+	DEFAULT_WIDTH    = 80
+	DEFAULT_HEIGHT   = 24
+)
+
+// http://msdn.microsoft.com/en-us/library/windows/desktop/dd375731(v=vs.85).aspx
+const (
+	VK_PRIOR    = 0x21 // PAGE UP key
+	VK_NEXT     = 0x22 // PAGE DOWN key
+	VK_END      = 0x23 // END key
+	VK_HOME     = 0x24 // HOME key
+	VK_LEFT     = 0x25 // LEFT ARROW key
+	VK_UP       = 0x26 // UP ARROW key
+	VK_RIGHT    = 0x27 // RIGHT ARROW key
+	VK_DOWN     = 0x28 // DOWN ARROW key
+	VK_SELECT   = 0x29 // SELECT key
+	VK_PRINT    = 0x2A // PRINT key
+	VK_EXECUTE  = 0x2B // EXECUTE key
+	VK_SNAPSHOT = 0x2C // PRINT SCREEN key
+	VK_INSERT   = 0x2D // INS key
+	VK_DELETE   = 0x2E // DEL key
+	VK_HELP     = 0x2F // HELP key
+	VK_F1       = 0x70 // F1 key
+	VK_F2       = 0x71 // F2 key
+	VK_F3       = 0x72 // F3 key
+	VK_F4       = 0x73 // F4 key
+	VK_F5       = 0x74 // F5 key
+	VK_F6       = 0x75 // F6 key
+	VK_F7       = 0x76 // F7 key
+	VK_F8       = 0x77 // F8 key
+	VK_F9       = 0x78 // F9 key
+	VK_F10      = 0x79 // F10 key
+	VK_F11      = 0x7A // F11 key
+	VK_F12      = 0x7B // F12 key
+)
+
+var kernel32DLL = syscall.NewLazyDLL("kernel32.dll")
+
+var (
+	setConsoleModeProc                = kernel32DLL.NewProc("SetConsoleMode")
+	getConsoleScreenBufferInfoProc    = kernel32DLL.NewProc("GetConsoleScreenBufferInfo")
+	setConsoleCursorPositionProc      = kernel32DLL.NewProc("SetConsoleCursorPosition")
+	setConsoleTextAttributeProc       = kernel32DLL.NewProc("SetConsoleTextAttribute")
+	fillConsoleOutputCharacterProc    = kernel32DLL.NewProc("FillConsoleOutputCharacterW")
+	writeConsoleOutputProc            = kernel32DLL.NewProc("WriteConsoleOutputW")
+	readConsoleInputProc              = kernel32DLL.NewProc("ReadConsoleInputW")
+	getNumberOfConsoleInputEventsProc = kernel32DLL.NewProc("GetNumberOfConsoleInputEvents")
+	getConsoleCursorInfoProc          = kernel32DLL.NewProc("GetConsoleCursorInfo")
+	setConsoleCursorInfoProc          = kernel32DLL.NewProc("SetConsoleCursorInfo")
+	setConsoleWindowInfoProc          = kernel32DLL.NewProc("SetConsoleWindowInfo")
+	setConsoleScreenBufferSizeProc    = kernel32DLL.NewProc("SetConsoleScreenBufferSize")
+)
+
+// types for calling various windows API
+// see http://msdn.microsoft.com/en-us/library/windows/desktop/ms682093(v=vs.85).aspx
+type (
+	SHORT int16
+	BOOL  int32
+	WORD  uint16
+	WCHAR uint16
+	DWORD uint32
+
+	SMALL_RECT struct {
+		Left   SHORT
+		Top    SHORT
+		Right  SHORT
+		Bottom SHORT
+	}
+
+	COORD struct {
+		X SHORT
+		Y SHORT
+	}
+
+	CONSOLE_SCREEN_BUFFER_INFO struct {
+		Size              COORD
+		CursorPosition    COORD
+		Attributes        WORD
+		Window            SMALL_RECT
+		MaximumWindowSize COORD
+	}
+
+	CONSOLE_CURSOR_INFO struct {
+		Size    DWORD
+		Visible BOOL
+	}
+
+	// http://msdn.microsoft.com/en-us/library/windows/desktop/ms684166(v=vs.85).aspx
+	KEY_EVENT_RECORD struct {
+		KeyDown         BOOL
+		RepeatCount     WORD
+		VirtualKeyCode  WORD
+		VirtualScanCode WORD
+		UnicodeChar     WCHAR
+		ControlKeyState DWORD
+	}
+
+	INPUT_RECORD struct {
+		EventType WORD
+		KeyEvent  KEY_EVENT_RECORD
+	}
+
+	CHAR_INFO struct {
+		UnicodeChar WCHAR
+		Attributes  WORD
+	}
+)
+
+// TODO(azlinux): Basic type clean-up
+// -- Convert all uses of uintptr to syscall.Handle to be consistent with Windows syscall
+// -- Convert, as appropriate, types to use defined Windows types (e.g., DWORD instead of uint32)
+
+// Implements the TerminalEmulator interface
+type WindowsTerminal struct {
+	outMutex            sync.Mutex
+	inMutex             sync.Mutex
+	inputBuffer         []byte
+	inputSize           int
+	inputEvents         []INPUT_RECORD
+	screenBufferInfo    *CONSOLE_SCREEN_BUFFER_INFO
+	inputEscapeSequence []byte
+}
+
+func getStdHandle(stdhandle int) uintptr {
+	handle, err := syscall.GetStdHandle(stdhandle)
+	if err != nil {
+		panic(fmt.Errorf("could not get standard io handle %d", stdhandle))
+	}
+	return uintptr(handle)
+}
+
+func WinConsoleStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
+	handler := &WindowsTerminal{
+		inputBuffer:         make([]byte, MAX_INPUT_BUFFER),
+		inputEscapeSequence: []byte(KEY_ESC_CSI),
+		inputEvents:         make([]INPUT_RECORD, MAX_INPUT_EVENTS),
+	}
+
+	if IsConsole(os.Stdin.Fd()) {
+		stdIn = &terminalReader{
+			wrappedReader: os.Stdin,
+			emulator:      handler,
+			command:       make([]byte, 0, ANSI_MAX_CMD_LENGTH),
+			fd:            getStdHandle(syscall.STD_INPUT_HANDLE),
+		}
+	} else {
+		stdIn = os.Stdin
+	}
+
+	if IsConsole(os.Stdout.Fd()) {
+		stdoutHandle := getStdHandle(syscall.STD_OUTPUT_HANDLE)
+
+		// Save current screen buffer info
+		screenBufferInfo, err := GetConsoleScreenBufferInfo(stdoutHandle)
+		if err != nil {
+			// If GetConsoleScreenBufferInfo returns a nil error, it usually means that stdout is not a TTY.
+			// However, this is in the branch where stdout is a TTY, hence the panic.
+			panic("could not get console screen buffer info")
+		}
+		handler.screenBufferInfo = screenBufferInfo
+
+		buffer = make([]CHAR_INFO, screenBufferInfo.MaximumWindowSize.X*screenBufferInfo.MaximumWindowSize.Y)
+
+		stdOut = &terminalWriter{
+			wrappedWriter: os.Stdout,
+			emulator:      handler,
+			command:       make([]byte, 0, ANSI_MAX_CMD_LENGTH),
+			fd:            stdoutHandle,
+		}
+	} else {
+		stdOut = os.Stdout
+	}
+
+	if IsConsole(os.Stderr.Fd()) {
+		stdErr = &terminalWriter{
+			wrappedWriter: os.Stderr,
+			emulator:      handler,
+			command:       make([]byte, 0, ANSI_MAX_CMD_LENGTH),
+			fd:            getStdHandle(syscall.STD_ERROR_HANDLE),
+		}
+	} else {
+		stdErr = os.Stderr
+	}
+
+	return stdIn, stdOut, stdErr
+}
+
+// GetHandleInfo returns file descriptor and bool indicating whether the file is a console.
+func GetHandleInfo(in interface{}) (uintptr, bool) {
+	var inFd uintptr
+	var isTerminalIn bool
+
+	switch t := in.(type) {
+	case *terminalReader:
+		in = t.wrappedReader
+	case *terminalWriter:
+		in = t.wrappedWriter
+	}
+
+	if file, ok := in.(*os.File); ok {
+		inFd = file.Fd()
+		isTerminalIn = IsConsole(inFd)
+	}
+	return inFd, isTerminalIn
+}
+
+func getError(r1, r2 uintptr, lastErr error) error {
+	// If the function fails, the return value is zero.
+	if r1 == 0 {
+		if lastErr != nil {
+			return lastErr
+		}
+		return syscall.EINVAL
+	}
+	return nil
+}
+
+// GetConsoleMode gets the console mode for given file descriptor
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms683167(v=vs.85).aspx
+func GetConsoleMode(handle uintptr) (uint32, error) {
+	var mode uint32
+	err := syscall.GetConsoleMode(syscall.Handle(handle), &mode)
+	return mode, err
+}
+
+// SetConsoleMode sets the console mode for given file descriptor
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
+func SetConsoleMode(handle uintptr, mode uint32) error {
+	return getError(setConsoleModeProc.Call(handle, uintptr(mode), 0))
+}
+
+// SetCursorVisible sets the cursor visbility
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms686019(v=vs.85).aspx
+func SetCursorVisible(handle uintptr, isVisible BOOL) (bool, error) {
+	var cursorInfo *CONSOLE_CURSOR_INFO = &CONSOLE_CURSOR_INFO{}
+	if err := getError(getConsoleCursorInfoProc.Call(handle, uintptr(unsafe.Pointer(cursorInfo)), 0)); err != nil {
+		return false, err
+	}
+	cursorInfo.Visible = isVisible
+	if err := getError(setConsoleCursorInfoProc.Call(handle, uintptr(unsafe.Pointer(cursorInfo)), 0)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// SetWindowSize sets the size of the console window.
+func SetWindowSize(handle uintptr, width, height, max SHORT) (bool, error) {
+	window := SMALL_RECT{Left: 0, Top: 0, Right: width - 1, Bottom: height - 1}
+	coord := COORD{X: width - 1, Y: max}
+	if err := getError(setConsoleWindowInfoProc.Call(handle, uintptr(1), uintptr(unsafe.Pointer(&window)))); err != nil {
+		return false, err
+	}
+	if err := getError(setConsoleScreenBufferSizeProc.Call(handle, marshal(coord))); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// GetConsoleScreenBufferInfo retrieves information about the specified console screen buffer.
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms683171(v=vs.85).aspx
+func GetConsoleScreenBufferInfo(handle uintptr) (*CONSOLE_SCREEN_BUFFER_INFO, error) {
+	var info CONSOLE_SCREEN_BUFFER_INFO
+	if err := getError(getConsoleScreenBufferInfoProc.Call(handle, uintptr(unsafe.Pointer(&info)), 0)); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// setConsoleTextAttribute sets the attributes of characters written to the
+// console screen buffer by the WriteFile or WriteConsole function,
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms686047(v=vs.85).aspx
+func setConsoleTextAttribute(handle uintptr, attribute WORD) error {
+	return getError(setConsoleTextAttributeProc.Call(handle, uintptr(attribute), 0))
+}
+
+func writeConsoleOutput(handle uintptr, buffer []CHAR_INFO, bufferSize COORD, bufferCoord COORD, writeRegion *SMALL_RECT) (bool, error) {
+	if err := getError(writeConsoleOutputProc.Call(handle, uintptr(unsafe.Pointer(&buffer[0])), marshal(bufferSize), marshal(bufferCoord), uintptr(unsafe.Pointer(writeRegion)))); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms682663(v=vs.85).aspx
+func fillConsoleOutputCharacter(handle uintptr, fillChar byte, length uint32, writeCord COORD) (bool, error) {
+	out := int64(0)
+	if err := getError(fillConsoleOutputCharacterProc.Call(handle, uintptr(fillChar), uintptr(length), marshal(writeCord), uintptr(unsafe.Pointer(&out)))); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Gets the number of space characters to write for "clearing" the section of terminal
+func getNumberOfChars(fromCoord COORD, toCoord COORD, screenSize COORD) uint32 {
+	// must be valid cursor position
+	if fromCoord.X < 0 || fromCoord.Y < 0 || toCoord.X < 0 || toCoord.Y < 0 {
+		return 0
+	}
+	if fromCoord.X >= screenSize.X || fromCoord.Y >= screenSize.Y || toCoord.X >= screenSize.X || toCoord.Y >= screenSize.Y {
+		return 0
+	}
+	// can't be backwards
+	if fromCoord.Y > toCoord.Y {
+		return 0
+	}
+	// same line
+	if fromCoord.Y == toCoord.Y {
+		return uint32(toCoord.X-fromCoord.X) + 1
+	}
+	// spans more than one line
+	if fromCoord.Y < toCoord.Y {
+		// from start till end of line for first line +  from start of line till end
+		retValue := uint32(screenSize.X-fromCoord.X) + uint32(toCoord.X) + 1
+		// don't count first and last line
+		linesBetween := toCoord.Y - fromCoord.Y - 1
+		if linesBetween > 0 {
+			retValue = retValue + uint32(linesBetween*screenSize.X)
+		}
+		return retValue
+	}
+	return 0
+}
+
+var buffer []CHAR_INFO
+
+func clearDisplayRect(handle uintptr, attributes WORD, fromCoord COORD, toCoord COORD) (uint32, error) {
+	var writeRegion SMALL_RECT
+	writeRegion.Left = fromCoord.X
+	writeRegion.Top = fromCoord.Y
+	writeRegion.Right = toCoord.X
+	writeRegion.Bottom = toCoord.Y
+
+	// allocate and initialize buffer
+	width := toCoord.X - fromCoord.X + 1
+	height := toCoord.Y - fromCoord.Y + 1
+	size := uint32(width) * uint32(height)
+	if size > 0 {
+		buffer := make([]CHAR_INFO, size)
+		for i := range buffer {
+			buffer[i] = CHAR_INFO{WCHAR(' '), attributes}
+		}
+
+		// Write to buffer
+		r, err := writeConsoleOutput(handle, buffer, COORD{X: width, Y: height}, COORD{X: 0, Y: 0}, &writeRegion)
+		if !r {
+			if err != nil {
+				return 0, err
+			}
+			return 0, syscall.EINVAL
+		}
+	}
+	return uint32(size), nil
+}
+
+func clearDisplayRange(handle uintptr, attributes WORD, fromCoord COORD, toCoord COORD) (uint32, error) {
+	nw := uint32(0)
+	// start and end on same line
+	if fromCoord.Y == toCoord.Y {
+		return clearDisplayRect(handle, attributes, fromCoord, toCoord)
+	}
+	// TODO(azlinux): if full screen, optimize
+
+	// spans more than one line
+	if fromCoord.Y < toCoord.Y {
+		// from start position till end of line for first line
+		n, err := clearDisplayRect(handle, attributes, fromCoord, COORD{X: toCoord.X, Y: fromCoord.Y})
+		if err != nil {
+			return nw, err
+		}
+		nw += n
+		// lines between
+		linesBetween := toCoord.Y - fromCoord.Y - 1
+		if linesBetween > 0 {
+			n, err = clearDisplayRect(handle, attributes, COORD{X: 0, Y: fromCoord.Y + 1}, COORD{X: toCoord.X, Y: toCoord.Y - 1})
+			if err != nil {
+				return nw, err
+			}
+			nw += n
+		}
+		// lines at end
+		n, err = clearDisplayRect(handle, attributes, COORD{X: 0, Y: toCoord.Y}, toCoord)
+		if err != nil {
+			return nw, err
+		}
+		nw += n
+	}
+	return nw, nil
+}
+
+// setConsoleCursorPosition sets the console cursor position
+// Note The X and Y are zero based
+// If relative is true then the new position is relative to current one
+func setConsoleCursorPosition(handle uintptr, isRelative bool, column int16, line int16) error {
+	screenBufferInfo, err := GetConsoleScreenBufferInfo(handle)
+	if err != nil {
+		return err
+	}
+	var position COORD
+	if isRelative {
+		position.X = screenBufferInfo.CursorPosition.X + SHORT(column)
+		position.Y = screenBufferInfo.CursorPosition.Y + SHORT(line)
+	} else {
+		position.X = SHORT(column)
+		position.Y = SHORT(line)
+	}
+	return getError(setConsoleCursorPositionProc.Call(handle, marshal(position), 0))
+}
+
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms683207(v=vs.85).aspx
+func getNumberOfConsoleInputEvents(handle uintptr) (uint16, error) {
+	var n DWORD
+	if err := getError(getNumberOfConsoleInputEventsProc.Call(handle, uintptr(unsafe.Pointer(&n)))); err != nil {
+		return 0, err
+	}
+	return uint16(n), nil
+}
+
+//http://msdn.microsoft.com/en-us/library/windows/desktop/ms684961(v=vs.85).aspx
+func readConsoleInputKey(handle uintptr, inputBuffer []INPUT_RECORD) (int, error) {
+	var nr DWORD
+	if err := getError(readConsoleInputProc.Call(handle, uintptr(unsafe.Pointer(&inputBuffer[0])), uintptr(len(inputBuffer)), uintptr(unsafe.Pointer(&nr)))); err != nil {
+		return 0, err
+	}
+	return int(nr), nil
+}
+
+func getWindowsTextAttributeForAnsiValue(originalFlag WORD, defaultValue WORD, ansiValue int16) (WORD, error) {
+	flag := WORD(originalFlag)
+	if flag == 0 {
+		flag = defaultValue
+	}
+	switch ansiValue {
+	case ANSI_ATTR_RESET:
+		flag &^= COMMON_LVB_UNDERSCORE
+		flag &^= BACKGROUND_INTENSITY
+		flag = flag | FOREGROUND_INTENSITY
+	case ANSI_ATTR_INVISIBLE:
+		// TODO: how do you reset reverse?
+	case ANSI_ATTR_UNDERLINE:
+		flag = flag | COMMON_LVB_UNDERSCORE
+	case ANSI_ATTR_BLINK:
+		// seems like background intenisty is blink
+		flag = flag | BACKGROUND_INTENSITY
+	case ANSI_ATTR_UNDERLINE_OFF:
+		flag &^= COMMON_LVB_UNDERSCORE
+	case ANSI_ATTR_BLINK_OFF:
+		// seems like background intenisty is blink
+		flag &^= BACKGROUND_INTENSITY
+	case ANSI_ATTR_BOLD:
+		flag = flag | FOREGROUND_INTENSITY
+	case ANSI_ATTR_DIM:
+		flag &^= FOREGROUND_INTENSITY
+	case ANSI_ATTR_REVERSE, ANSI_ATTR_REVERSE_OFF:
+		// swap forground and background bits
+		foreground := flag & FOREGROUND_MASK_SET
+		background := flag & BACKGROUND_MASK_SET
+		flag = (flag & BACKGROUND_MASK_UNSET & FOREGROUND_MASK_UNSET) | (foreground << 4) | (background >> 4)
+
+	// FOREGROUND
+	case ANSI_FOREGROUND_DEFAULT:
+		flag = (flag & FOREGROUND_MASK_UNSET) | (defaultValue & FOREGROUND_MASK_SET)
+	case ANSI_FOREGROUND_BLACK:
+		flag = flag ^ (FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE)
+	case ANSI_FOREGROUND_RED:
+		flag = (flag & FOREGROUND_MASK_UNSET) | FOREGROUND_RED
+	case ANSI_FOREGROUND_GREEN:
+		flag = (flag & FOREGROUND_MASK_UNSET) | FOREGROUND_GREEN
+	case ANSI_FOREGROUND_YELLOW:
+		flag = (flag & FOREGROUND_MASK_UNSET) | FOREGROUND_RED | FOREGROUND_GREEN
+	case ANSI_FOREGROUND_BLUE:
+		flag = (flag & FOREGROUND_MASK_UNSET) | FOREGROUND_BLUE
+	case ANSI_FOREGROUND_MAGENTA:
+		flag = (flag & FOREGROUND_MASK_UNSET) | FOREGROUND_RED | FOREGROUND_BLUE
+	case ANSI_FOREGROUND_CYAN:
+		flag = (flag & FOREGROUND_MASK_UNSET) | FOREGROUND_GREEN | FOREGROUND_BLUE
+	case ANSI_FOREGROUND_WHITE:
+		flag = (flag & FOREGROUND_MASK_UNSET) | FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE
+
+	// Background
+	case ANSI_BACKGROUND_DEFAULT:
+		// Black with no intensity
+		flag = (flag & BACKGROUND_MASK_UNSET) | (defaultValue & BACKGROUND_MASK_SET)
+	case ANSI_BACKGROUND_BLACK:
+		flag = (flag & BACKGROUND_MASK_UNSET)
+	case ANSI_BACKGROUND_RED:
+		flag = (flag & BACKGROUND_MASK_UNSET) | BACKGROUND_RED
+	case ANSI_BACKGROUND_GREEN:
+		flag = (flag & BACKGROUND_MASK_UNSET) | BACKGROUND_GREEN
+	case ANSI_BACKGROUND_YELLOW:
+		flag = (flag & BACKGROUND_MASK_UNSET) | BACKGROUND_RED | BACKGROUND_GREEN
+	case ANSI_BACKGROUND_BLUE:
+		flag = (flag & BACKGROUND_MASK_UNSET) | BACKGROUND_BLUE
+	case ANSI_BACKGROUND_MAGENTA:
+		flag = (flag & BACKGROUND_MASK_UNSET) | BACKGROUND_RED | BACKGROUND_BLUE
+	case ANSI_BACKGROUND_CYAN:
+		flag = (flag & BACKGROUND_MASK_UNSET) | BACKGROUND_GREEN | BACKGROUND_BLUE
+	case ANSI_BACKGROUND_WHITE:
+		flag = (flag & BACKGROUND_MASK_UNSET) | BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE
+	}
+	return flag, nil
+}
+
+// HandleOutputCommand interpretes the Ansi commands and then makes appropriate Win32 calls
+func (term *WindowsTerminal) HandleOutputCommand(handle uintptr, command []byte) (n int, err error) {
+	// always consider all the bytes in command, processed
+	n = len(command)
+
+	parsedCommand := parseAnsiCommand(command)
+	logrus.Debugf("[windows] HandleOutputCommand: %v", parsedCommand)
+
+	// console settings changes need to happen in atomic way
+	term.outMutex.Lock()
+	defer term.outMutex.Unlock()
+
+	switch parsedCommand.Command {
+	case "m":
+		// [Value;...;Valuem
+		// Set Graphics Mode:
+		// Calls the graphics functions specified by the following values.
+		// These specified functions remain active until the next occurrence of this escape sequence.
+		// Graphics mode changes the colors and attributes of text (such as bold and underline) displayed on the screen.
+		screenBufferInfo, err := GetConsoleScreenBufferInfo(handle)
+		if err != nil {
+			return n, err
+		}
+		flag := screenBufferInfo.Attributes
+		for _, e := range parsedCommand.Parameters {
+			value, _ := strconv.ParseInt(e, 10, 16) // base 10, 16 bit
+			if value == ANSI_ATTR_RESET {
+				flag = term.screenBufferInfo.Attributes // reset
+			} else {
+				flag, err = getWindowsTextAttributeForAnsiValue(flag, term.screenBufferInfo.Attributes, int16(value))
+				if err != nil {
+					return n, err
+				}
+			}
+		}
+		if err := setConsoleTextAttribute(handle, flag); err != nil {
+			return n, err
+		}
+	case "H", "f":
+		// [line;columnH
+		// [line;columnf
+		// Moves the cursor to the specified position (coordinates).
+		// If you do not specify a position, the cursor moves to the home position at the upper-left corner of the screen (line 0, column 0).
+		screenBufferInfo, err := GetConsoleScreenBufferInfo(handle)
+		if err != nil {
+			return n, err
+		}
+		line, err := parseInt16OrDefault(parsedCommand.getParam(0), 1)
+		if err != nil {
+			return n, err
+		}
+		if line > int16(screenBufferInfo.Window.Bottom) {
+			line = int16(screenBufferInfo.Window.Bottom) + 1
+		}
+		column, err := parseInt16OrDefault(parsedCommand.getParam(1), 1)
+		if err != nil {
+			return n, err
+		}
+		if column > int16(screenBufferInfo.Window.Right) {
+			column = int16(screenBufferInfo.Window.Right) + 1
+		}
+		// The numbers are not 0 based, but 1 based
+		logrus.Debugf("[windows] HandleOutputCommmand: Moving cursor to (%v,%v)", column-1, line-1)
+		if err := setConsoleCursorPosition(handle, false, column-1, line-1); err != nil {
+			return n, err
+		}
+
+	case "A":
+		// [valueA
+		// Moves the cursor up by the specified number of lines without changing columns.
+		// If the cursor is already on the top line, ignores this sequence.
+		value, err := parseInt16OrDefault(parsedCommand.getParam(0), 1)
+		if err != nil {
+			return len(command), err
+		}
+		if err := setConsoleCursorPosition(handle, true, 0, -value); err != nil {
+			return n, err
+		}
+	case "B":
+		// [valueB
+		// Moves the cursor down by the specified number of lines without changing columns.
+		// If the cursor is already on the bottom line, ignores this sequence.
+		value, err := parseInt16OrDefault(parsedCommand.getParam(0), 1)
+		if err != nil {
+			return n, err
+		}
+		if err := setConsoleCursorPosition(handle, true, 0, value); err != nil {
+			return n, err
+		}
+	case "C":
+		// [valueC
+		// Moves the cursor forward by the specified number of columns without changing lines.
+		// If the cursor is already in the rightmost column, ignores this sequence.
+		value, err := parseInt16OrDefault(parsedCommand.getParam(0), 1)
+		if err != nil {
+			return n, err
+		}
+		if err := setConsoleCursorPosition(handle, true, value, 0); err != nil {
+			return n, err
+		}
+	case "D":
+		// [valueD
+		// Moves the cursor back by the specified number of columns without changing lines.
+		// If the cursor is already in the leftmost column, ignores this sequence.
+		value, err := parseInt16OrDefault(parsedCommand.getParam(0), 1)
+		if err != nil {
+			return n, err
+		}
+		if err := setConsoleCursorPosition(handle, true, -value, 0); err != nil {
+			return n, err
+		}
+	case "J":
+		// [J   Erases from the cursor to the end of the screen, including the cursor position.
+		// [1J  Erases from the beginning of the screen to the cursor, including the cursor position.
+		// [2J  Erases the complete display. The cursor does not move.
+		// Clears the screen and moves the cursor to the home position (line 0, column 0).
+		value, err := parseInt16OrDefault(parsedCommand.getParam(0), 0)
+		if err != nil {
+			return n, err
+		}
+		var start COORD
+		var cursor COORD
+		var end COORD
+		screenBufferInfo, err := GetConsoleScreenBufferInfo(handle)
+		if err != nil {
+			return n, err
+		}
+		switch value {
+		case 0:
+			start = screenBufferInfo.CursorPosition
+			// end of the buffer
+			end.X = screenBufferInfo.Size.X - 1
+			end.Y = screenBufferInfo.Size.Y - 1
+			// cursor
+			cursor = screenBufferInfo.CursorPosition
+		case 1:
+
+			// start of the screen
+			start.X = 0
+			start.Y = 0
+			// end of the screen
+			end = screenBufferInfo.CursorPosition
+			// cursor
+			cursor = screenBufferInfo.CursorPosition
+		case 2:
+			// start of the screen
+			start.X = 0
+			start.Y = 0
+			// end of the buffer
+			end.X = screenBufferInfo.Size.X - 1
+			end.Y = screenBufferInfo.Size.Y - 1
+			// cursor
+			cursor.X = 0
+			cursor.Y = 0
+		}
+		if _, err := clearDisplayRange(uintptr(handle), term.screenBufferInfo.Attributes, start, end); err != nil {
+			return n, err
+		}
+		// remember the the cursor position is 1 based
+		if err := setConsoleCursorPosition(handle, false, int16(cursor.X), int16(cursor.Y)); err != nil {
+			return n, err
+		}
+
+	case "K":
+		// [K
+		// Clears all characters from the cursor position to the end of the line (including the character at the cursor position).
+		// [K  Erases from the cursor to the end of the line, including the cursor position.
+		// [1K  Erases from the beginning of the line to the cursor, including the cursor position.
+		// [2K  Erases the complete line.
+		value, err := parseInt16OrDefault(parsedCommand.getParam(0), 0)
+		var start COORD
+		var cursor COORD
+		var end COORD
+		screenBufferInfo, err := GetConsoleScreenBufferInfo(uintptr(handle))
+		if err != nil {
+			return n, err
+		}
+		switch value {
+		case 0:
+			// start is where cursor is
+			start = screenBufferInfo.CursorPosition
+			// end of line
+			end.X = screenBufferInfo.Size.X - 1
+			end.Y = screenBufferInfo.CursorPosition.Y
+			// cursor remains the same
+			cursor = screenBufferInfo.CursorPosition
+
+		case 1:
+			// beginning of line
+			start.X = 0
+			start.Y = screenBufferInfo.CursorPosition.Y
+			// until cursor
+			end = screenBufferInfo.CursorPosition
+			// cursor remains the same
+			cursor = screenBufferInfo.CursorPosition
+		case 2:
+			// start of the line
+			start.X = 0
+			start.Y = screenBufferInfo.CursorPosition.Y - 1
+			// end of the line
+			end.X = screenBufferInfo.Size.X - 1
+			end.Y = screenBufferInfo.CursorPosition.Y - 1
+			// cursor
+			cursor.X = 0
+			cursor.Y = screenBufferInfo.CursorPosition.Y - 1
+		}
+		if _, err := clearDisplayRange(uintptr(handle), term.screenBufferInfo.Attributes, start, end); err != nil {
+			return n, err
+		}
+		// remember the the cursor position is 1 based
+		if err := setConsoleCursorPosition(uintptr(handle), false, int16(cursor.X), int16(cursor.Y)); err != nil {
+			return n, err
+		}
+
+	case "l":
+		for _, value := range parsedCommand.Parameters {
+			switch value {
+			case "?25", "25":
+				SetCursorVisible(uintptr(handle), BOOL(0))
+			case "?1049", "1049":
+				// TODO (azlinux):  Restore terminal
+			case "?1", "1":
+				// If the DECCKM function is reset, then the arrow keys send ANSI cursor sequences to the host.
+				term.inputEscapeSequence = []byte(KEY_ESC_CSI)
+			}
+		}
+	case "h":
+		for _, value := range parsedCommand.Parameters {
+			switch value {
+			case "?25", "25":
+				SetCursorVisible(uintptr(handle), BOOL(1))
+			case "?1049", "1049":
+				// TODO (azlinux): Save terminal
+			case "?1", "1":
+				// If the DECCKM function is set, then the arrow keys send application sequences to the host.
+				// DECCKM (default off): When set, the cursor keys send an ESC O prefix, rather than ESC [.
+				term.inputEscapeSequence = []byte(KEY_ESC_O)
+			}
+		}
+
+	case "]":
+		/*
+			TODO (azlinux):
+				Linux Console Private CSI Sequences
+
+			       The following sequences are neither ECMA-48 nor native VT102.  They are
+			       native  to the Linux console driver.  Colors are in SGR parameters: 0 =
+			       black, 1 = red, 2 = green, 3 = brown, 4 = blue, 5 = magenta, 6 =  cyan,
+			       7 = white.
+
+			       ESC [ 1 ; n ]       Set color n as the underline color
+			       ESC [ 2 ; n ]       Set color n as the dim color
+			       ESC [ 8 ]           Make the current color pair the default attributes.
+			       ESC [ 9 ; n ]       Set screen blank timeout to n minutes.
+			       ESC [ 10 ; n ]      Set bell frequency in Hz.
+			       ESC [ 11 ; n ]      Set bell duration in msec.
+			       ESC [ 12 ; n ]      Bring specified console to the front.
+			       ESC [ 13 ]          Unblank the screen.
+			       ESC [ 14 ; n ]      Set the VESA powerdown interval in minutes.
+
+		*/
+	}
+	return n, nil
+}
+
+// WriteChars writes the bytes to given writer.
+func (term *WindowsTerminal) WriteChars(fd uintptr, w io.Writer, p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return w.Write(p)
+}
+
+const (
+	CAPSLOCK_ON        = 0x0080 //The CAPS LOCK light is on.
+	ENHANCED_KEY       = 0x0100 //The key is enhanced.
+	LEFT_ALT_PRESSED   = 0x0002 //The left ALT key is pressed.
+	LEFT_CTRL_PRESSED  = 0x0008 //The left CTRL key is pressed.
+	NUMLOCK_ON         = 0x0020 //The NUM LOCK light is on.
+	RIGHT_ALT_PRESSED  = 0x0001 //The right ALT key is pressed.
+	RIGHT_CTRL_PRESSED = 0x0004 //The right CTRL key is pressed.
+	SCROLLLOCK_ON      = 0x0040 //The SCROLL LOCK light is on.
+	SHIFT_PRESSED      = 0x0010 // The SHIFT key is pressed.
+)
+
+const (
+	KEY_CONTROL_PARAM_2 = ";2"
+	KEY_CONTROL_PARAM_3 = ";3"
+	KEY_CONTROL_PARAM_4 = ";4"
+	KEY_CONTROL_PARAM_5 = ";5"
+	KEY_CONTROL_PARAM_6 = ";6"
+	KEY_CONTROL_PARAM_7 = ";7"
+	KEY_CONTROL_PARAM_8 = ";8"
+	KEY_ESC_CSI         = "\x1B["
+	KEY_ESC_N           = "\x1BN"
+	KEY_ESC_O           = "\x1BO"
+)
+
+var keyMapPrefix = map[WORD]string{
+	VK_UP:     "\x1B[%sA",
+	VK_DOWN:   "\x1B[%sB",
+	VK_RIGHT:  "\x1B[%sC",
+	VK_LEFT:   "\x1B[%sD",
+	VK_HOME:   "\x1B[1%s~", // showkey shows ^[[1
+	VK_END:    "\x1B[4%s~", // showkey shows ^[[4
+	VK_INSERT: "\x1B[2%s~",
+	VK_DELETE: "\x1B[3%s~",
+	VK_PRIOR:  "\x1B[5%s~",
+	VK_NEXT:   "\x1B[6%s~",
+	VK_F1:     "",
+	VK_F2:     "",
+	VK_F3:     "\x1B[13%s~",
+	VK_F4:     "\x1B[14%s~",
+	VK_F5:     "\x1B[15%s~",
+	VK_F6:     "\x1B[17%s~",
+	VK_F7:     "\x1B[18%s~",
+	VK_F8:     "\x1B[19%s~",
+	VK_F9:     "\x1B[20%s~",
+	VK_F10:    "\x1B[21%s~",
+	VK_F11:    "\x1B[23%s~",
+	VK_F12:    "\x1B[24%s~",
+}
+
+var arrowKeyMapPrefix = map[WORD]string{
+	VK_UP:    "%s%sA",
+	VK_DOWN:  "%s%sB",
+	VK_RIGHT: "%s%sC",
+	VK_LEFT:  "%s%sD",
+}
+
+func getControlStateParameter(shift, alt, control, meta bool) string {
+	if shift && alt && control {
+		return KEY_CONTROL_PARAM_8
+	}
+	if alt && control {
+		return KEY_CONTROL_PARAM_7
+	}
+	if shift && control {
+		return KEY_CONTROL_PARAM_6
+	}
+	if control {
+		return KEY_CONTROL_PARAM_5
+	}
+	if shift && alt {
+		return KEY_CONTROL_PARAM_4
+	}
+	if alt {
+		return KEY_CONTROL_PARAM_3
+	}
+	if shift {
+		return KEY_CONTROL_PARAM_2
+	}
+	return ""
+}
+
+func getControlKeys(controlState DWORD) (shift, alt, control bool) {
+	shift = 0 != (controlState & SHIFT_PRESSED)
+	alt = 0 != (controlState & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))
+	control = 0 != (controlState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED))
+	return shift, alt, control
+}
+
+func charSequenceForKeys(key WORD, controlState DWORD, escapeSequence []byte) string {
+	i, ok := arrowKeyMapPrefix[key]
+	if ok {
+		shift, alt, control := getControlKeys(controlState)
+		modifier := getControlStateParameter(shift, alt, control, false)
+		return fmt.Sprintf(i, escapeSequence, modifier)
+	}
+
+	i, ok = keyMapPrefix[key]
+	if ok {
+		shift, alt, control := getControlKeys(controlState)
+		modifier := getControlStateParameter(shift, alt, control, false)
+		return fmt.Sprintf(i, modifier)
+	}
+
+	return ""
+}
+
+// mapKeystokeToTerminalString maps the given input event record to string
+func mapKeystokeToTerminalString(keyEvent *KEY_EVENT_RECORD, escapeSequence []byte) string {
+	_, alt, control := getControlKeys(keyEvent.ControlKeyState)
+	if keyEvent.UnicodeChar == 0 {
+		return charSequenceForKeys(keyEvent.VirtualKeyCode, keyEvent.ControlKeyState, escapeSequence)
+	}
+	if control {
+		// TODO(azlinux): Implement following control sequences
+		// <Ctrl>-D  Signals the end of input from the keyboard; also exits current shell.
+		// <Ctrl>-H  Deletes the first character to the left of the cursor. Also called the ERASE key.
+		// <Ctrl>-Q  Restarts printing after it has been stopped with <Ctrl>-s.
+		// <Ctrl>-S  Suspends printing on the screen (does not stop the program).
+		// <Ctrl>-U  Deletes all characters on the current line. Also called the KILL key.
+		// <Ctrl>-E  Quits current command and creates a core
+
+	}
+	// <Alt>+Key generates ESC N Key
+	if !control && alt {
+		return KEY_ESC_N + strings.ToLower(string(keyEvent.UnicodeChar))
+	}
+	return string(keyEvent.UnicodeChar)
+}
+
+// getAvailableInputEvents polls the console for availble events
+// The function does not return until at least one input record has been read.
+func getAvailableInputEvents(handle uintptr, inputEvents []INPUT_RECORD) (n int, err error) {
+	// TODO(azlinux): Why is there a for loop? Seems to me, that `n` cannot be negative. - tibor
+	for {
+		// Read number of console events available
+		n, err = readConsoleInputKey(handle, inputEvents)
+		if err != nil || n >= 0 {
+			return n, err
+		}
+	}
+}
+
+// getTranslatedKeyCodes converts the input events into the string of characters
+// The ansi escape sequence are used to map key strokes to the strings
+func getTranslatedKeyCodes(inputEvents []INPUT_RECORD, escapeSequence []byte) string {
+	var buf bytes.Buffer
+	for i := 0; i < len(inputEvents); i++ {
+		input := inputEvents[i]
+		if input.EventType == KEY_EVENT && input.KeyEvent.KeyDown != 0 {
+			keyString := mapKeystokeToTerminalString(&input.KeyEvent, escapeSequence)
+			buf.WriteString(keyString)
+		}
+	}
+	return buf.String()
+}
+
+// ReadChars reads the characters from the given reader
+func (term *WindowsTerminal) ReadChars(fd uintptr, r io.Reader, p []byte) (n int, err error) {
+	for term.inputSize == 0 {
+		nr, err := getAvailableInputEvents(fd, term.inputEvents)
+		if nr == 0 && nil != err {
+			return n, err
+		}
+		if nr > 0 {
+			keyCodes := getTranslatedKeyCodes(term.inputEvents[:nr], term.inputEscapeSequence)
+			term.inputSize = copy(term.inputBuffer, keyCodes)
+		}
+	}
+	n = copy(p, term.inputBuffer[:term.inputSize])
+	term.inputSize -= n
+	return n, nil
+}
+
+// HandleInputSequence interprets the input sequence command
+func (term *WindowsTerminal) HandleInputSequence(fd uintptr, command []byte) (n int, err error) {
+	return 0, nil
+}
+
+func marshal(c COORD) uintptr {
+	return uintptr(*((*DWORD)(unsafe.Pointer(&c))))
+}
+
+// IsConsole returns true if the given file descriptor is a terminal.
+// -- The code assumes that GetConsoleMode will return an error for file descriptors that are not a console.
+func IsConsole(fd uintptr) bool {
+	_, e := GetConsoleMode(fd)
+	return e == nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/winconsole/console_windows_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/winconsole/console_windows_test.go
@@ -1,0 +1,232 @@
+// +build windows
+
+package winconsole
+
+import (
+	"fmt"
+	"testing"
+)
+
+func helpsTestParseInt16OrDefault(t *testing.T, expectedValue int16, shouldFail bool, input string, defaultValue int16, format string, args ...string) {
+	value, err := parseInt16OrDefault(input, defaultValue)
+	if nil != err && !shouldFail {
+		t.Errorf("Unexpected error returned %v", err)
+		t.Errorf(format, args)
+	}
+	if nil == err && shouldFail {
+		t.Errorf("Should have failed as expected\n\tReturned value = %d", value)
+		t.Errorf(format, args)
+	}
+	if expectedValue != value {
+		t.Errorf("The value returned does not match expected\n\tExpected:%v\n\t:Actual%v", expectedValue, value)
+		t.Errorf(format, args)
+	}
+}
+
+func TestParseInt16OrDefault(t *testing.T) {
+	// empty string
+	helpsTestParseInt16OrDefault(t, 0, false, "", 0, "Empty string returns default")
+	helpsTestParseInt16OrDefault(t, 2, false, "", 2, "Empty string returns default")
+
+	// normal case
+	helpsTestParseInt16OrDefault(t, 0, false, "0", 0, "0 handled correctly")
+	helpsTestParseInt16OrDefault(t, 111, false, "111", 2, "Normal")
+	helpsTestParseInt16OrDefault(t, 111, false, "+111", 2, "+N")
+	helpsTestParseInt16OrDefault(t, -111, false, "-111", 2, "-N")
+	helpsTestParseInt16OrDefault(t, 0, false, "+0", 11, "+0")
+	helpsTestParseInt16OrDefault(t, 0, false, "-0", 12, "-0")
+
+	// ill formed strings
+	helpsTestParseInt16OrDefault(t, 0, true, "abc", 0, "Invalid string")
+	helpsTestParseInt16OrDefault(t, 42, true, "+= 23", 42, "Invalid string")
+	helpsTestParseInt16OrDefault(t, 42, true, "123.45", 42, "float like")
+
+}
+
+func helpsTestGetNumberOfChars(t *testing.T, expected uint32, fromCoord COORD, toCoord COORD, screenSize COORD, format string, args ...interface{}) {
+	actual := getNumberOfChars(fromCoord, toCoord, screenSize)
+	mesg := fmt.Sprintf(format, args)
+	assertTrue(t, expected == actual, fmt.Sprintf("%s Expected=%d, Actual=%d, Parameters = { fromCoord=%+v, toCoord=%+v, screenSize=%+v", mesg, expected, actual, fromCoord, toCoord, screenSize))
+}
+
+func TestGetNumberOfChars(t *testing.T) {
+	// Note: The columns and lines are 0 based
+	// Also that interval is "inclusive" means will have both start and end chars
+	// This test only tests the number opf characters being written
+
+	// all four corners
+	maxWindow := COORD{X: 80, Y: 50}
+	leftTop := COORD{X: 0, Y: 0}
+	rightTop := COORD{X: 79, Y: 0}
+	leftBottom := COORD{X: 0, Y: 49}
+	rightBottom := COORD{X: 79, Y: 49}
+
+	// same position
+	helpsTestGetNumberOfChars(t, 1, COORD{X: 1, Y: 14}, COORD{X: 1, Y: 14}, COORD{X: 80, Y: 50}, "Same position random line")
+
+	// four corners
+	helpsTestGetNumberOfChars(t, 1, leftTop, leftTop, maxWindow, "Same position- leftTop")
+	helpsTestGetNumberOfChars(t, 1, rightTop, rightTop, maxWindow, "Same position- rightTop")
+	helpsTestGetNumberOfChars(t, 1, leftBottom, leftBottom, maxWindow, "Same position- leftBottom")
+	helpsTestGetNumberOfChars(t, 1, rightBottom, rightBottom, maxWindow, "Same position- rightBottom")
+
+	// from this char to next char on same line
+	helpsTestGetNumberOfChars(t, 2, COORD{X: 0, Y: 0}, COORD{X: 1, Y: 0}, maxWindow, "Next position on same line")
+	helpsTestGetNumberOfChars(t, 2, COORD{X: 1, Y: 14}, COORD{X: 2, Y: 14}, maxWindow, "Next position on same line")
+
+	// from this char to next 10 chars on same line
+	helpsTestGetNumberOfChars(t, 11, COORD{X: 0, Y: 0}, COORD{X: 10, Y: 0}, maxWindow, "Next position on same line")
+	helpsTestGetNumberOfChars(t, 11, COORD{X: 1, Y: 14}, COORD{X: 11, Y: 14}, maxWindow, "Next position on same line")
+
+	helpsTestGetNumberOfChars(t, 5, COORD{X: 3, Y: 11}, COORD{X: 7, Y: 11}, maxWindow, "To and from on same line")
+
+	helpsTestGetNumberOfChars(t, 8, COORD{X: 0, Y: 34}, COORD{X: 7, Y: 34}, maxWindow, "Start of line to middle")
+	helpsTestGetNumberOfChars(t, 4, COORD{X: 76, Y: 34}, COORD{X: 79, Y: 34}, maxWindow, "Middle to end of line")
+
+	// multiple lines - 1
+	helpsTestGetNumberOfChars(t, 81, COORD{X: 0, Y: 0}, COORD{X: 0, Y: 1}, maxWindow, "one line below same X")
+	helpsTestGetNumberOfChars(t, 81, COORD{X: 10, Y: 10}, COORD{X: 10, Y: 11}, maxWindow, "one line below same X")
+
+	// multiple lines - 2
+	helpsTestGetNumberOfChars(t, 161, COORD{X: 0, Y: 0}, COORD{X: 0, Y: 2}, maxWindow, "one line below same X")
+	helpsTestGetNumberOfChars(t, 161, COORD{X: 10, Y: 10}, COORD{X: 10, Y: 12}, maxWindow, "one line below same X")
+
+	// multiple lines - 3
+	helpsTestGetNumberOfChars(t, 241, COORD{X: 0, Y: 0}, COORD{X: 0, Y: 3}, maxWindow, "one line below same X")
+	helpsTestGetNumberOfChars(t, 241, COORD{X: 10, Y: 10}, COORD{X: 10, Y: 13}, maxWindow, "one line below same X")
+
+	// full line
+	helpsTestGetNumberOfChars(t, 80, COORD{X: 0, Y: 0}, COORD{X: 79, Y: 0}, maxWindow, "Full line - first")
+	helpsTestGetNumberOfChars(t, 80, COORD{X: 0, Y: 23}, COORD{X: 79, Y: 23}, maxWindow, "Full line - random")
+	helpsTestGetNumberOfChars(t, 80, COORD{X: 0, Y: 49}, COORD{X: 79, Y: 49}, maxWindow, "Full line - last")
+
+	// full screen
+	helpsTestGetNumberOfChars(t, 80*50, leftTop, rightBottom, maxWindow, "full screen")
+
+	helpsTestGetNumberOfChars(t, 80*50-1, COORD{X: 1, Y: 0}, rightBottom, maxWindow, "dropping first char to, end of screen")
+	helpsTestGetNumberOfChars(t, 80*50-2, COORD{X: 2, Y: 0}, rightBottom, maxWindow, "dropping first two char to, end of screen")
+
+	helpsTestGetNumberOfChars(t, 80*50-1, leftTop, COORD{X: 78, Y: 49}, maxWindow, "from start of screen, till last char-1")
+	helpsTestGetNumberOfChars(t, 80*50-2, leftTop, COORD{X: 77, Y: 49}, maxWindow, "from start of screen, till last char-2")
+
+	helpsTestGetNumberOfChars(t, 80*50-5, COORD{X: 4, Y: 0}, COORD{X: 78, Y: 49}, COORD{X: 80, Y: 50}, "from start of screen+4, till last char-1")
+	helpsTestGetNumberOfChars(t, 80*50-6, COORD{X: 4, Y: 0}, COORD{X: 77, Y: 49}, COORD{X: 80, Y: 50}, "from start of screen+4, till last char-2")
+}
+
+var allForeground = []int16{
+	ANSI_FOREGROUND_BLACK,
+	ANSI_FOREGROUND_RED,
+	ANSI_FOREGROUND_GREEN,
+	ANSI_FOREGROUND_YELLOW,
+	ANSI_FOREGROUND_BLUE,
+	ANSI_FOREGROUND_MAGENTA,
+	ANSI_FOREGROUND_CYAN,
+	ANSI_FOREGROUND_WHITE,
+	ANSI_FOREGROUND_DEFAULT,
+}
+var allBackground = []int16{
+	ANSI_BACKGROUND_BLACK,
+	ANSI_BACKGROUND_RED,
+	ANSI_BACKGROUND_GREEN,
+	ANSI_BACKGROUND_YELLOW,
+	ANSI_BACKGROUND_BLUE,
+	ANSI_BACKGROUND_MAGENTA,
+	ANSI_BACKGROUND_CYAN,
+	ANSI_BACKGROUND_WHITE,
+	ANSI_BACKGROUND_DEFAULT,
+}
+
+func maskForeground(flag WORD) WORD {
+	return flag & FOREGROUND_MASK_UNSET
+}
+
+func onlyForeground(flag WORD) WORD {
+	return flag & FOREGROUND_MASK_SET
+}
+
+func maskBackground(flag WORD) WORD {
+	return flag & BACKGROUND_MASK_UNSET
+}
+
+func onlyBackground(flag WORD) WORD {
+	return flag & BACKGROUND_MASK_SET
+}
+
+func helpsTestGetWindowsTextAttributeForAnsiValue(t *testing.T, oldValue WORD /*, expected WORD*/, ansi int16, onlyMask WORD, restMask WORD) WORD {
+	actual, err := getWindowsTextAttributeForAnsiValue(oldValue, FOREGROUND_MASK_SET, ansi)
+	assertTrue(t, nil == err, "Should be no error")
+	// assert that other bits are not affected
+	if 0 != oldValue {
+		assertTrue(t, (actual&restMask) == (oldValue&restMask), "The operation should not have affected other bits actual=%X oldValue=%X ansi=%d", actual, oldValue, ansi)
+	}
+	return actual
+}
+
+func TestBackgroundForAnsiValue(t *testing.T) {
+	// Check that nothing else changes
+	// background changes
+	for _, state1 := range allBackground {
+		for _, state2 := range allBackground {
+			flag := WORD(0)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state1, BACKGROUND_MASK_SET, BACKGROUND_MASK_UNSET)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state2, BACKGROUND_MASK_SET, BACKGROUND_MASK_UNSET)
+		}
+	}
+	// cummulative bcakground changes
+	for _, state1 := range allBackground {
+		flag := WORD(0)
+		for _, state2 := range allBackground {
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state1, BACKGROUND_MASK_SET, BACKGROUND_MASK_UNSET)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state2, BACKGROUND_MASK_SET, BACKGROUND_MASK_UNSET)
+		}
+	}
+	// change background after foreground
+	for _, state1 := range allForeground {
+		for _, state2 := range allBackground {
+			flag := WORD(0)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state1, FOREGROUND_MASK_SET, FOREGROUND_MASK_UNSET)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state2, BACKGROUND_MASK_SET, BACKGROUND_MASK_UNSET)
+		}
+	}
+	// change background after change cumulative
+	for _, state1 := range allForeground {
+		flag := WORD(0)
+		for _, state2 := range allBackground {
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state1, FOREGROUND_MASK_SET, FOREGROUND_MASK_UNSET)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state2, BACKGROUND_MASK_SET, BACKGROUND_MASK_UNSET)
+		}
+	}
+}
+
+func TestForegroundForAnsiValue(t *testing.T) {
+	// Check that nothing else changes
+	for _, state1 := range allForeground {
+		for _, state2 := range allForeground {
+			flag := WORD(0)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state1, FOREGROUND_MASK_SET, FOREGROUND_MASK_UNSET)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state2, FOREGROUND_MASK_SET, FOREGROUND_MASK_UNSET)
+		}
+	}
+
+	for _, state1 := range allForeground {
+		flag := WORD(0)
+		for _, state2 := range allForeground {
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state1, FOREGROUND_MASK_SET, FOREGROUND_MASK_UNSET)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state2, FOREGROUND_MASK_SET, FOREGROUND_MASK_UNSET)
+		}
+	}
+	for _, state1 := range allBackground {
+		for _, state2 := range allForeground {
+			flag := WORD(0)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state1, BACKGROUND_MASK_SET, BACKGROUND_MASK_UNSET)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state2, FOREGROUND_MASK_SET, FOREGROUND_MASK_UNSET)
+		}
+	}
+	for _, state1 := range allBackground {
+		flag := WORD(0)
+		for _, state2 := range allForeground {
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state1, BACKGROUND_MASK_SET, BACKGROUND_MASK_UNSET)
+			flag = helpsTestGetWindowsTextAttributeForAnsiValue(t, flag, state2, FOREGROUND_MASK_SET, FOREGROUND_MASK_UNSET)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/winconsole/term_emulator.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/winconsole/term_emulator.go
@@ -1,0 +1,234 @@
+package winconsole
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// http://manpages.ubuntu.com/manpages/intrepid/man4/console_codes.4.html
+const (
+	ANSI_ESCAPE_PRIMARY   = 0x1B
+	ANSI_ESCAPE_SECONDARY = 0x5B
+	ANSI_COMMAND_FIRST    = 0x40
+	ANSI_COMMAND_LAST     = 0x7E
+	ANSI_PARAMETER_SEP    = ";"
+	ANSI_CMD_G0           = '('
+	ANSI_CMD_G1           = ')'
+	ANSI_CMD_G2           = '*'
+	ANSI_CMD_G3           = '+'
+	ANSI_CMD_DECPNM       = '>'
+	ANSI_CMD_DECPAM       = '='
+	ANSI_CMD_OSC          = ']'
+	ANSI_CMD_STR_TERM     = '\\'
+	ANSI_BEL              = 0x07
+	KEY_EVENT             = 1
+)
+
+// Interface that implements terminal handling
+type terminalEmulator interface {
+	HandleOutputCommand(fd uintptr, command []byte) (n int, err error)
+	HandleInputSequence(fd uintptr, command []byte) (n int, err error)
+	WriteChars(fd uintptr, w io.Writer, p []byte) (n int, err error)
+	ReadChars(fd uintptr, w io.Reader, p []byte) (n int, err error)
+}
+
+type terminalWriter struct {
+	wrappedWriter io.Writer
+	emulator      terminalEmulator
+	command       []byte
+	inSequence    bool
+	fd            uintptr
+}
+
+type terminalReader struct {
+	wrappedReader io.ReadCloser
+	emulator      terminalEmulator
+	command       []byte
+	inSequence    bool
+	fd            uintptr
+}
+
+// http://manpages.ubuntu.com/manpages/intrepid/man4/console_codes.4.html
+func isAnsiCommandChar(b byte) bool {
+	switch {
+	case ANSI_COMMAND_FIRST <= b && b <= ANSI_COMMAND_LAST && b != ANSI_ESCAPE_SECONDARY:
+		return true
+	case b == ANSI_CMD_G1 || b == ANSI_CMD_OSC || b == ANSI_CMD_DECPAM || b == ANSI_CMD_DECPNM:
+		// non-CSI escape sequence terminator
+		return true
+	case b == ANSI_CMD_STR_TERM || b == ANSI_BEL:
+		// String escape sequence terminator
+		return true
+	}
+	return false
+}
+
+func isCharacterSelectionCmdChar(b byte) bool {
+	return (b == ANSI_CMD_G0 || b == ANSI_CMD_G1 || b == ANSI_CMD_G2 || b == ANSI_CMD_G3)
+}
+
+func isXtermOscSequence(command []byte, current byte) bool {
+	return (len(command) >= 2 && command[0] == ANSI_ESCAPE_PRIMARY && command[1] == ANSI_CMD_OSC && current != ANSI_BEL)
+}
+
+// Write writes len(p) bytes from p to the underlying data stream.
+// http://golang.org/pkg/io/#Writer
+func (tw *terminalWriter) Write(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if tw.emulator == nil {
+		return tw.wrappedWriter.Write(p)
+	}
+	// Emulate terminal by extracting commands and executing them
+	totalWritten := 0
+	start := 0 // indicates start of the next chunk
+	end := len(p)
+	for current := 0; current < end; current++ {
+		if tw.inSequence {
+			// inside escape sequence
+			tw.command = append(tw.command, p[current])
+			if isAnsiCommandChar(p[current]) {
+				if !isXtermOscSequence(tw.command, p[current]) {
+					// found the last command character.
+					// Now we have a complete command.
+					nchar, err := tw.emulator.HandleOutputCommand(tw.fd, tw.command)
+					totalWritten += nchar
+					if err != nil {
+						return totalWritten, err
+					}
+
+					// clear the command
+					// don't include current character again
+					tw.command = tw.command[:0]
+					start = current + 1
+					tw.inSequence = false
+				}
+			}
+		} else {
+			if p[current] == ANSI_ESCAPE_PRIMARY {
+				// entering escape sequnce
+				tw.inSequence = true
+				// indicates end of "normal sequence", write whatever you have so far
+				if len(p[start:current]) > 0 {
+					nw, err := tw.emulator.WriteChars(tw.fd, tw.wrappedWriter, p[start:current])
+					totalWritten += nw
+					if err != nil {
+						return totalWritten, err
+					}
+				}
+				// include the current character as part of the next sequence
+				tw.command = append(tw.command, p[current])
+			}
+		}
+	}
+	// note that so far, start of the escape sequence triggers writing out of bytes to console.
+	// For the part _after_ the end of last escape sequence, it is not written out yet. So write it out
+	if !tw.inSequence {
+		// assumption is that we can't be inside sequence and therefore command should be empty
+		if len(p[start:]) > 0 {
+			nw, err := tw.emulator.WriteChars(tw.fd, tw.wrappedWriter, p[start:])
+			totalWritten += nw
+			if err != nil {
+				return totalWritten, err
+			}
+		}
+	}
+	return totalWritten, nil
+
+}
+
+// Read reads up to len(p) bytes into p.
+// http://golang.org/pkg/io/#Reader
+func (tr *terminalReader) Read(p []byte) (n int, err error) {
+	//Implementations of Read are discouraged from returning a zero byte count
+	// with a nil error, except when len(p) == 0.
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if nil == tr.emulator {
+		return tr.readFromWrappedReader(p)
+	}
+	return tr.emulator.ReadChars(tr.fd, tr.wrappedReader, p)
+}
+
+// Close the underlying stream
+func (tr *terminalReader) Close() (err error) {
+	return tr.wrappedReader.Close()
+}
+
+func (tr *terminalReader) readFromWrappedReader(p []byte) (n int, err error) {
+	return tr.wrappedReader.Read(p)
+}
+
+type ansiCommand struct {
+	CommandBytes []byte
+	Command      string
+	Parameters   []string
+	IsSpecial    bool
+}
+
+func parseAnsiCommand(command []byte) *ansiCommand {
+	if isCharacterSelectionCmdChar(command[1]) {
+		// Is Character Set Selection commands
+		return &ansiCommand{
+			CommandBytes: command,
+			Command:      string(command),
+			IsSpecial:    true,
+		}
+	}
+	// last char is command character
+	lastCharIndex := len(command) - 1
+
+	retValue := &ansiCommand{
+		CommandBytes: command,
+		Command:      string(command[lastCharIndex]),
+		IsSpecial:    false,
+	}
+	// more than a single escape
+	if lastCharIndex != 0 {
+		start := 1
+		// skip if double char escape sequence
+		if command[0] == ANSI_ESCAPE_PRIMARY && command[1] == ANSI_ESCAPE_SECONDARY {
+			start++
+		}
+		// convert this to GetNextParam method
+		retValue.Parameters = strings.Split(string(command[start:lastCharIndex]), ANSI_PARAMETER_SEP)
+	}
+	return retValue
+}
+
+func (c *ansiCommand) getParam(index int) string {
+	if len(c.Parameters) > index {
+		return c.Parameters[index]
+	}
+	return ""
+}
+
+func (ac *ansiCommand) String() string {
+	return fmt.Sprintf("0x%v \"%v\" (\"%v\")",
+		bytesToHex(ac.CommandBytes),
+		ac.Command,
+		strings.Join(ac.Parameters, "\",\""))
+}
+
+func bytesToHex(b []byte) string {
+	hex := make([]string, len(b))
+	for i, ch := range b {
+		hex[i] = fmt.Sprintf("%X", ch)
+	}
+	return strings.Join(hex, "")
+}
+
+func parseInt16OrDefault(s string, defaultValue int16) (n int16, err error) {
+	if s == "" {
+		return defaultValue, nil
+	}
+	parsedValue, err := strconv.ParseInt(s, 10, 16)
+	if err != nil {
+		return defaultValue, err
+	}
+	return int16(parsedValue), nil
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/term/winconsole/term_emulator_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/term/winconsole/term_emulator_test.go
@@ -1,0 +1,388 @@
+package winconsole
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+)
+
+const (
+	WRITE_OPERATION   = iota
+	COMMAND_OPERATION = iota
+)
+
+var languages = []string{
+	"Български",
+	"Català",
+	"Čeština",
+	"Ελληνικά",
+	"Español",
+	"Esperanto",
+	"Euskara",
+	"Français",
+	"Galego",
+	"한국어",
+	"ქართული",
+	"Latviešu",
+	"Lietuvių",
+	"Magyar",
+	"Nederlands",
+	"日本語",
+	"Norsk bokmål",
+	"Norsk nynorsk",
+	"Polski",
+	"Português",
+	"Română",
+	"Русский",
+	"Slovenčina",
+	"Slovenščina",
+	"Српски",
+	"српскохрватски",
+	"Suomi",
+	"Svenska",
+	"ไทย",
+	"Tiếng Việt",
+	"Türkçe",
+	"Українська",
+	"中文",
+}
+
+// Mock terminal handler object
+type mockTerminal struct {
+	OutputCommandSequence []terminalOperation
+}
+
+// Used for recording the callback data
+type terminalOperation struct {
+	Operation int
+	Data      []byte
+	Str       string
+}
+
+func (mt *mockTerminal) record(operation int, data []byte) {
+	op := terminalOperation{
+		Operation: operation,
+		Data:      make([]byte, len(data)),
+	}
+	copy(op.Data, data)
+	op.Str = string(op.Data)
+	mt.OutputCommandSequence = append(mt.OutputCommandSequence, op)
+}
+
+func (mt *mockTerminal) HandleOutputCommand(fd uintptr, command []byte) (n int, err error) {
+	mt.record(COMMAND_OPERATION, command)
+	return len(command), nil
+}
+
+func (mt *mockTerminal) HandleInputSequence(fd uintptr, command []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (mt *mockTerminal) WriteChars(fd uintptr, w io.Writer, p []byte) (n int, err error) {
+	mt.record(WRITE_OPERATION, p)
+	return len(p), nil
+}
+
+func (mt *mockTerminal) ReadChars(fd uintptr, w io.Reader, p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func assertTrue(t *testing.T, cond bool, format string, args ...interface{}) {
+	if !cond {
+		t.Errorf(format, args...)
+	}
+}
+
+// reflect.DeepEqual does not provide detailed information as to what excatly failed.
+func assertBytesEqual(t *testing.T, expected, actual []byte, format string, args ...interface{}) {
+	match := true
+	mismatchIndex := 0
+	if len(expected) == len(actual) {
+		for i := 0; i < len(expected); i++ {
+			if expected[i] != actual[i] {
+				match = false
+				mismatchIndex = i
+				break
+			}
+		}
+	} else {
+		match = false
+		t.Errorf("Lengths don't match Expected=%d Actual=%d", len(expected), len(actual))
+	}
+	if !match {
+		t.Errorf("Mismatch at index %d ", mismatchIndex)
+		t.Errorf("\tActual String   = %s", string(actual))
+		t.Errorf("\tExpected String = %s", string(expected))
+		t.Errorf("\tActual          = %v", actual)
+		t.Errorf("\tExpected        = %v", expected)
+		t.Errorf(format, args)
+	}
+}
+
+// Just to make sure :)
+func TestAssertEqualBytes(t *testing.T) {
+	data := []byte{9, 9, 1, 1, 1, 9, 9}
+	assertBytesEqual(t, data, data, "Self")
+	assertBytesEqual(t, data[1:4], data[1:4], "Self")
+	assertBytesEqual(t, []byte{1, 1}, []byte{1, 1}, "Simple match")
+	assertBytesEqual(t, []byte{1, 2, 3}, []byte{1, 2, 3}, "content mismatch")
+	assertBytesEqual(t, []byte{1, 1, 1}, data[2:5], "slice match")
+}
+
+/*
+func TestAssertEqualBytesNegative(t *testing.T) {
+	AssertBytesEqual(t, []byte{1, 1}, []byte{1}, "Length mismatch")
+	AssertBytesEqual(t, []byte{1, 1}, []byte{1}, "Length mismatch")
+	AssertBytesEqual(t, []byte{1, 2, 3}, []byte{1, 1, 1}, "content mismatch")
+}*/
+
+// Checks that the calls received
+func assertHandlerOutput(t *testing.T, mock *mockTerminal, plainText string, commands ...string) {
+	text := make([]byte, 0, 3*len(plainText))
+	cmdIndex := 0
+	for opIndex := 0; opIndex < len(mock.OutputCommandSequence); opIndex++ {
+		op := mock.OutputCommandSequence[opIndex]
+		if op.Operation == WRITE_OPERATION {
+			t.Logf("\nThe data is[%d] == %s", opIndex, string(op.Data))
+			text = append(text[:], op.Data...)
+		} else {
+			assertTrue(t, mock.OutputCommandSequence[opIndex].Operation == COMMAND_OPERATION, "Operation should be command : %s", fmt.Sprintf("%+v", mock))
+			assertBytesEqual(t, StringToBytes(commands[cmdIndex]), mock.OutputCommandSequence[opIndex].Data, "Command data should match")
+			cmdIndex++
+		}
+	}
+	assertBytesEqual(t, StringToBytes(plainText), text, "Command data should match %#v", mock)
+}
+
+func StringToBytes(str string) []byte {
+	bytes := make([]byte, len(str))
+	copy(bytes[:], str)
+	return bytes
+}
+
+func TestParseAnsiCommand(t *testing.T) {
+	// Note: if the parameter does not exist then the empty value is returned
+
+	c := parseAnsiCommand(StringToBytes("\x1Bm"))
+	assertTrue(t, c.Command == "m", "Command should be m")
+	assertTrue(t, "" == c.getParam(0), "should return empty string")
+	assertTrue(t, "" == c.getParam(1), "should return empty string")
+
+	// Escape sequence - ESC[
+	c = parseAnsiCommand(StringToBytes("\x1B[m"))
+	assertTrue(t, c.Command == "m", "Command should be m")
+	assertTrue(t, "" == c.getParam(0), "should return empty string")
+	assertTrue(t, "" == c.getParam(1), "should return empty string")
+
+	// Escape sequence With empty parameters- ESC[
+	c = parseAnsiCommand(StringToBytes("\x1B[;m"))
+	assertTrue(t, c.Command == "m", "Command should be m")
+	assertTrue(t, "" == c.getParam(0), "should return empty string")
+	assertTrue(t, "" == c.getParam(1), "should return empty string")
+	assertTrue(t, "" == c.getParam(2), "should return empty string")
+
+	// Escape sequence With empty muliple parameters- ESC[
+	c = parseAnsiCommand(StringToBytes("\x1B[;;m"))
+	assertTrue(t, c.Command == "m", "Command should be m")
+	assertTrue(t, "" == c.getParam(0), "")
+	assertTrue(t, "" == c.getParam(1), "")
+	assertTrue(t, "" == c.getParam(2), "")
+
+	// Escape sequence With muliple parameters- ESC[
+	c = parseAnsiCommand(StringToBytes("\x1B[1;2;3m"))
+	assertTrue(t, c.Command == "m", "Command should be m")
+	assertTrue(t, "1" == c.getParam(0), "")
+	assertTrue(t, "2" == c.getParam(1), "")
+	assertTrue(t, "3" == c.getParam(2), "")
+
+	// Escape sequence With muliple parameters- some missing
+	c = parseAnsiCommand(StringToBytes("\x1B[1;;3;;;6m"))
+	assertTrue(t, c.Command == "m", "Command should be m")
+	assertTrue(t, "1" == c.getParam(0), "")
+	assertTrue(t, "" == c.getParam(1), "")
+	assertTrue(t, "3" == c.getParam(2), "")
+	assertTrue(t, "" == c.getParam(3), "")
+	assertTrue(t, "" == c.getParam(4), "")
+	assertTrue(t, "6" == c.getParam(5), "")
+}
+
+func newBufferedMockTerm() (stdOut io.Writer, stdErr io.Writer, stdIn io.ReadCloser, mock *mockTerminal) {
+	var input bytes.Buffer
+	var output bytes.Buffer
+	var err bytes.Buffer
+
+	mock = &mockTerminal{
+		OutputCommandSequence: make([]terminalOperation, 0, 256),
+	}
+
+	stdOut = &terminalWriter{
+		wrappedWriter: &output,
+		emulator:      mock,
+		command:       make([]byte, 0, 256),
+	}
+	stdErr = &terminalWriter{
+		wrappedWriter: &err,
+		emulator:      mock,
+		command:       make([]byte, 0, 256),
+	}
+	stdIn = &terminalReader{
+		wrappedReader: ioutil.NopCloser(&input),
+		emulator:      mock,
+		command:       make([]byte, 0, 256),
+	}
+
+	return
+}
+
+func TestOutputSimple(t *testing.T) {
+	stdOut, _, _, mock := newBufferedMockTerm()
+
+	stdOut.Write(StringToBytes("Hello world"))
+	stdOut.Write(StringToBytes("\x1BmHello again"))
+
+	assertTrue(t, mock.OutputCommandSequence[0].Operation == WRITE_OPERATION, "Operation should be Write : %#v", mock)
+	assertBytesEqual(t, StringToBytes("Hello world"), mock.OutputCommandSequence[0].Data, "Write data should match")
+
+	assertTrue(t, mock.OutputCommandSequence[1].Operation == COMMAND_OPERATION, "Operation should be command : %+v", mock)
+	assertBytesEqual(t, StringToBytes("\x1Bm"), mock.OutputCommandSequence[1].Data, "Command data should match")
+
+	assertTrue(t, mock.OutputCommandSequence[2].Operation == WRITE_OPERATION, "Operation should be Write : %#v", mock)
+	assertBytesEqual(t, StringToBytes("Hello again"), mock.OutputCommandSequence[2].Data, "Write data should match")
+}
+
+func TestOutputSplitCommand(t *testing.T) {
+	stdOut, _, _, mock := newBufferedMockTerm()
+
+	stdOut.Write(StringToBytes("Hello world\x1B[1;2;3"))
+	stdOut.Write(StringToBytes("mHello again"))
+
+	assertTrue(t, mock.OutputCommandSequence[0].Operation == WRITE_OPERATION, "Operation should be Write : %#v", mock)
+	assertBytesEqual(t, StringToBytes("Hello world"), mock.OutputCommandSequence[0].Data, "Write data should match")
+
+	assertTrue(t, mock.OutputCommandSequence[1].Operation == COMMAND_OPERATION, "Operation should be command : %+v", mock)
+	assertBytesEqual(t, StringToBytes("\x1B[1;2;3m"), mock.OutputCommandSequence[1].Data, "Command data should match")
+
+	assertTrue(t, mock.OutputCommandSequence[2].Operation == WRITE_OPERATION, "Operation should be Write : %#v", mock)
+	assertBytesEqual(t, StringToBytes("Hello again"), mock.OutputCommandSequence[2].Data, "Write data should match")
+}
+
+func TestOutputMultipleCommands(t *testing.T) {
+	stdOut, _, _, mock := newBufferedMockTerm()
+
+	stdOut.Write(StringToBytes("Hello world"))
+	stdOut.Write(StringToBytes("\x1B[1;2;3m"))
+	stdOut.Write(StringToBytes("\x1B[J"))
+	stdOut.Write(StringToBytes("Hello again"))
+
+	assertTrue(t, mock.OutputCommandSequence[0].Operation == WRITE_OPERATION, "Operation should be Write : %#v", mock)
+	assertBytesEqual(t, StringToBytes("Hello world"), mock.OutputCommandSequence[0].Data, "Write data should match")
+
+	assertTrue(t, mock.OutputCommandSequence[1].Operation == COMMAND_OPERATION, "Operation should be command : %+v", mock)
+	assertBytesEqual(t, StringToBytes("\x1B[1;2;3m"), mock.OutputCommandSequence[1].Data, "Command data should match")
+
+	assertTrue(t, mock.OutputCommandSequence[2].Operation == COMMAND_OPERATION, "Operation should be command : %+v", mock)
+	assertBytesEqual(t, StringToBytes("\x1B[J"), mock.OutputCommandSequence[2].Data, "Command data should match")
+
+	assertTrue(t, mock.OutputCommandSequence[3].Operation == WRITE_OPERATION, "Operation should be Write : %#v", mock)
+	assertBytesEqual(t, StringToBytes("Hello again"), mock.OutputCommandSequence[3].Data, "Write data should match")
+}
+
+// Splits the given data in two chunks , makes two writes and checks the split data is parsed correctly
+// checks output write/command is passed to handler correctly
+func helpsTestOutputSplitChunksAtIndex(t *testing.T, i int, data []byte) {
+	t.Logf("\ni=%d", i)
+	stdOut, _, _, mock := newBufferedMockTerm()
+
+	t.Logf("\nWriting chunk[0] == %s", string(data[:i]))
+	t.Logf("\nWriting chunk[1] == %s", string(data[i:]))
+	stdOut.Write(data[:i])
+	stdOut.Write(data[i:])
+
+	assertTrue(t, mock.OutputCommandSequence[0].Operation == WRITE_OPERATION, "Operation should be Write : %#v", mock)
+	assertBytesEqual(t, data[:i], mock.OutputCommandSequence[0].Data, "Write data should match")
+
+	assertTrue(t, mock.OutputCommandSequence[1].Operation == WRITE_OPERATION, "Operation should be Write : %#v", mock)
+	assertBytesEqual(t, data[i:], mock.OutputCommandSequence[1].Data, "Write data should match")
+}
+
+// Splits the given data in three chunks , makes three writes and checks the split data is parsed correctly
+// checks output write/command is passed to handler correctly
+func helpsTestOutputSplitThreeChunksAtIndex(t *testing.T, data []byte, i int, j int) {
+	stdOut, _, _, mock := newBufferedMockTerm()
+
+	t.Logf("\nWriting chunk[0] == %s", string(data[:i]))
+	t.Logf("\nWriting chunk[1] == %s", string(data[i:j]))
+	t.Logf("\nWriting chunk[2] == %s", string(data[j:]))
+	stdOut.Write(data[:i])
+	stdOut.Write(data[i:j])
+	stdOut.Write(data[j:])
+
+	assertTrue(t, mock.OutputCommandSequence[0].Operation == WRITE_OPERATION, "Operation should be Write : %#v", mock)
+	assertBytesEqual(t, data[:i], mock.OutputCommandSequence[0].Data, "Write data should match")
+
+	assertTrue(t, mock.OutputCommandSequence[1].Operation == WRITE_OPERATION, "Operation should be Write : %#v", mock)
+	assertBytesEqual(t, data[i:j], mock.OutputCommandSequence[1].Data, "Write data should match")
+
+	assertTrue(t, mock.OutputCommandSequence[2].Operation == WRITE_OPERATION, "Operation should be Write : %#v", mock)
+	assertBytesEqual(t, data[j:], mock.OutputCommandSequence[2].Data, "Write data should match")
+}
+
+// Splits the output into two parts and tests all such possible pairs
+func helpsTestOutputSplitChunks(t *testing.T, data []byte) {
+	for i := 1; i < len(data)-1; i++ {
+		helpsTestOutputSplitChunksAtIndex(t, i, data)
+	}
+}
+
+// Splits the output in three parts and tests all such possible triples
+func helpsTestOutputSplitThreeChunks(t *testing.T, data []byte) {
+	for i := 1; i < len(data)-2; i++ {
+		for j := i + 1; j < len(data)-1; j++ {
+			helpsTestOutputSplitThreeChunksAtIndex(t, data, i, j)
+		}
+	}
+}
+
+func helpsTestOutputSplitCommandsAtIndex(t *testing.T, data []byte, i int, plainText string, commands ...string) {
+	t.Logf("\ni=%d", i)
+	stdOut, _, _, mock := newBufferedMockTerm()
+
+	stdOut.Write(data[:i])
+	stdOut.Write(data[i:])
+	assertHandlerOutput(t, mock, plainText, commands...)
+}
+
+func helpsTestOutputSplitCommands(t *testing.T, data []byte, plainText string, commands ...string) {
+	for i := 1; i < len(data)-1; i++ {
+		helpsTestOutputSplitCommandsAtIndex(t, data, i, plainText, commands...)
+	}
+}
+
+func injectCommandAt(data string, i int, command string) string {
+	retValue := make([]byte, len(data)+len(command)+4)
+	retValue = append(retValue, data[:i]...)
+	retValue = append(retValue, data[i:]...)
+	return string(retValue)
+}
+
+func TestOutputSplitChunks(t *testing.T) {
+	data := StringToBytes("qwertyuiopasdfghjklzxcvbnm")
+	helpsTestOutputSplitChunks(t, data)
+	helpsTestOutputSplitChunks(t, StringToBytes("BBBBB"))
+	helpsTestOutputSplitThreeChunks(t, StringToBytes("ABCDE"))
+}
+
+func TestOutputSplitChunksIncludingCommands(t *testing.T) {
+	helpsTestOutputSplitCommands(t, StringToBytes("Hello world.\x1B[mHello again."), "Hello world.Hello again.", "\x1B[m")
+	helpsTestOutputSplitCommandsAtIndex(t, StringToBytes("Hello world.\x1B[mHello again."), 2, "Hello world.Hello again.", "\x1B[m")
+}
+
+func TestSplitChunkUnicode(t *testing.T) {
+	for _, l := range languages {
+		data := StringToBytes(l)
+		helpsTestOutputSplitChunks(t, data)
+		helpsTestOutputSplitThreeChunks(t, data)
+	}
+}

--- a/api/api.go
+++ b/api/api.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/docker/libnetwork"
-	"github.com/docker/libnetwork/netutils"
 	"github.com/gorilla/mux"
 )
 
@@ -125,24 +124,9 @@ func makeHandler(ctrl libnetwork.NetworkController, fct processor) http.HandlerF
 	}
 }
 
-/***********
- Resources
-************/
-
-// networkResource is the body of the "get network" http response message
-type networkResource struct {
-	Name      string
-	ID        string
-	Type      string
-	Endpoints []*endpointResource
-}
-
-// endpointResource is the body of the "get endpoint" http response message
-type endpointResource struct {
-	Name    string
-	ID      string
-	Network string
-}
+/*****************
+ Resource Builders
+******************/
 
 func buildNetworkResource(nw libnetwork.Network) *networkResource {
 	r := &networkResource{}
@@ -170,51 +154,9 @@ func buildEndpointResource(ep libnetwork.Endpoint) *endpointResource {
 	return r
 }
 
-/***********
- Body types
-************/
-
-// networkCreate is the expected body of the "create network" http request message
-type networkCreate struct {
-	Name        string
-	NetworkType string
-	Options     map[string]interface{}
-}
-
-// endpointCreate represents the body of the "create endpoint" http request message
-type endpointCreate struct {
-	Name         string
-	NetworkID    string
-	ExposedPorts []netutils.TransportPort
-	PortMapping  []netutils.PortBinding
-}
-
-// endpointJoin represents the expected body of the "join endpoint" or "leave endpoint" http request messages
-type endpointJoin struct {
-	ContainerID       string
-	HostName          string
-	DomainName        string
-	HostsPath         string
-	ResolvConfPath    string
-	DNS               []string
-	ExtraHosts        []endpointExtraHost
-	ParentUpdates     []endpointParentUpdate
-	UseDefaultSandbox bool
-}
-
-// EndpointExtraHost represents the extra host object
-type endpointExtraHost struct {
-	Name    string
-	Address string
-}
-
-// EndpointParentUpdate is the object carrying the information about the
-// endpoint parent that needs to be updated
-type endpointParentUpdate struct {
-	EndpointID string
-	Name       string
-	Address    string
-}
+/**************
+ Options Parser
+***************/
 
 func (ej *endpointJoin) parseOptions() []libnetwork.EndpointOption {
 	var setFctList []libnetwork.EndpointOption

--- a/api/types.go
+++ b/api/types.go
@@ -1,0 +1,68 @@
+package api
+
+import "github.com/docker/libnetwork/netutils"
+
+/***********
+ Resources
+************/
+
+// networkResource is the body of the "get network" http response message
+type networkResource struct {
+	Name      string
+	ID        string
+	Type      string
+	Endpoints []*endpointResource
+}
+
+// endpointResource is the body of the "get endpoint" http response message
+type endpointResource struct {
+	Name    string
+	ID      string
+	Network string
+}
+
+/***********
+  Body types
+  ************/
+
+// networkCreate is the expected body of the "create network" http request message
+type networkCreate struct {
+	Name        string
+	NetworkType string
+	Options     map[string]interface{}
+}
+
+// endpointCreate represents the body of the "create endpoint" http request message
+type endpointCreate struct {
+	Name         string
+	NetworkID    string
+	ExposedPorts []netutils.TransportPort
+	PortMapping  []netutils.PortBinding
+}
+
+// endpointJoin represents the expected body of the "join endpoint" or "leave endpoint" http request messages
+type endpointJoin struct {
+	ContainerID       string
+	HostName          string
+	DomainName        string
+	HostsPath         string
+	ResolvConfPath    string
+	DNS               []string
+	ExtraHosts        []endpointExtraHost
+	ParentUpdates     []endpointParentUpdate
+	UseDefaultSandbox bool
+}
+
+// EndpointExtraHost represents the extra host object
+type endpointExtraHost struct {
+	Name    string
+	Address string
+}
+
+// EndpointParentUpdate is the object carrying the information about the
+// endpoint parent that needs to be updated
+type endpointParentUpdate struct {
+	EndpointID string
+	Name       string
+	Address    string
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -28,16 +28,16 @@ func TestClientDummyCommand(t *testing.T) {
 	}
 }
 
-func TestClientNoCommand(t *testing.T) {
+func TestClientNetworkInvalidCommand(t *testing.T) {
 	var out, errOut bytes.Buffer
 	cFunc := func(method, path string, data interface{}, headers map[string][]string) (io.ReadCloser, int, error) {
 		return nopCloser{bytes.NewBufferString("")}, 200, nil
 	}
 	cli := NewNetworkCli(&out, &errOut, cFunc)
 
-	err := cli.Cmd("docker")
+	err := cli.Cmd("docker", "network", "invalid")
 	if err == nil {
-		t.Fatalf("Incorrect Command must fail")
+		t.Fatalf("Passing invalid commands must fail")
 	}
 }
 
@@ -119,33 +119,7 @@ func TestClientNetworkInfo(t *testing.T) {
 	}
 }
 
-func TestClientNetworkJoin(t *testing.T) {
-	var out, errOut bytes.Buffer
-	cFunc := func(method, path string, data interface{}, headers map[string][]string) (io.ReadCloser, int, error) {
-		return nopCloser{bytes.NewBufferString("")}, 200, nil
-	}
-	cli := NewNetworkCli(&out, &errOut, cFunc)
-
-	err := cli.Cmd("docker", "network", "join", "db1", "dbnet", "db1-ep")
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-}
-
-func TestClientNetworkLeave(t *testing.T) {
-	var out, errOut bytes.Buffer
-	cFunc := func(method, path string, data interface{}, headers map[string][]string) (io.ReadCloser, int, error) {
-		return nopCloser{bytes.NewBufferString("")}, 200, nil
-	}
-	cli := NewNetworkCli(&out, &errOut, cFunc)
-
-	err := cli.Cmd("docker", "network", "leave", "db1", "dbnet")
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-}
-
-// Docker Flag processing in flag.go uses os.Exit(0) for --help
+// Docker Flag processing in flag.go uses os.Exit() frequently, even for --help
 // TODO : Handle the --help test-case in the IT when CLI is available
 /*
 func TestClientNetworkCreateHelp(t *testing.T) {

--- a/client/network.go
+++ b/client/network.go
@@ -26,6 +26,7 @@ var (
 	}
 )
 
+// CmdNetwork handles the root Network UI
 func (cli *NetworkCli) CmdNetwork(chain string, args ...string) error {
 	cmd := cli.Subcmd(chain, "network", "COMMAND [OPTIONS] [arg...]", networkUsage(chain), false)
 	cmd.Require(flag.Min, 1)
@@ -35,17 +36,6 @@ func (cli *NetworkCli) CmdNetwork(chain string, args ...string) error {
 		return fmt.Errorf("Invalid command : %v", args)
 	}
 	return err
-}
-
-func networkUsage(chain string) string {
-	help := "Commands:\n"
-
-	for _, cmd := range networkCommands {
-		help += fmt.Sprintf("    %-10.10s%s\n", cmd.name, cmd.description)
-	}
-
-	help += fmt.Sprintf("\nRun '%s network COMMAND --help' for more information on a command.", chain)
-	return help
 }
 
 // CmdNetworkCreate handles Network Create UI
@@ -60,8 +50,10 @@ func (cli *NetworkCli) CmdNetworkCreate(chain string, args ...string) error {
 	if *flDriver == "" {
 		*flDriver = nullNetType
 	}
-	// TODO : Proper Backend handling
-	obj, _, err := readBody(cli.call("POST", "/networks/"+args[0], nil, nil))
+
+	nc := networkCreate{Name: cmd.Arg(0), NetworkType: *flDriver}
+
+	obj, _, err := readBody(cli.call("POST", "/networks/name/"+cmd.Arg(0), nc, nil))
 	if err != nil {
 		fmt.Fprintf(cli.err, "%s", err.Error())
 		return err
@@ -80,8 +72,7 @@ func (cli *NetworkCli) CmdNetworkRm(chain string, args ...string) error {
 	if err != nil {
 		return err
 	}
-	// TODO : Proper Backend handling
-	obj, _, err := readBody(cli.call("DELETE", "/networks/"+args[0], nil, nil))
+	obj, _, err := readBody(cli.call("DELETE", "/networks/name/"+cmd.Arg(0), nil, nil))
 	if err != nil {
 		fmt.Fprintf(cli.err, "%s", err.Error())
 		return err
@@ -99,7 +90,6 @@ func (cli *NetworkCli) CmdNetworkLs(chain string, args ...string) error {
 	if err != nil {
 		return err
 	}
-	// TODO : Proper Backend handling
 	obj, _, err := readBody(cli.call("GET", "/networks", nil, nil))
 	if err != nil {
 		fmt.Fprintf(cli.err, "%s", err.Error())
@@ -119,8 +109,7 @@ func (cli *NetworkCli) CmdNetworkInfo(chain string, args ...string) error {
 	if err != nil {
 		return err
 	}
-	// TODO : Proper Backend handling
-	obj, _, err := readBody(cli.call("GET", "/networks/"+args[0], nil, nil))
+	obj, _, err := readBody(cli.call("GET", "/networks/name/"+cmd.Arg(0), nil, nil))
 	if err != nil {
 		fmt.Fprintf(cli.err, "%s", err.Error())
 		return err
@@ -131,46 +120,13 @@ func (cli *NetworkCli) CmdNetworkInfo(chain string, args ...string) error {
 	return nil
 }
 
-// CmdNetworkJoin handles the UI to let a Container join a Network via an endpoint
-// Sample UI : <chain> network join <container-name/id> <network-name/id> [<endpoint-name>]
-func (cli *NetworkCli) CmdNetworkJoin(chain string, args ...string) error {
-	cmd := cli.Subcmd(chain, "join", "CONTAINER-NAME/ID NETWORK-NAME/ID [ENDPOINT-NAME]",
-		chain+" join", false)
-	cmd.Require(flag.Min, 2)
-	err := cmd.ParseFlags(args, true)
-	if err != nil {
-		return err
-	}
-	// TODO : Proper Backend handling
-	obj, _, err := readBody(cli.call("POST", "/endpoints/", nil, nil))
-	if err != nil {
-		fmt.Fprintf(cli.err, "%s", err.Error())
-		return err
-	}
-	if _, err := io.Copy(cli.out, bytes.NewReader(obj)); err != nil {
-		return err
-	}
-	return nil
-}
+func networkUsage(chain string) string {
+	help := "Commands:\n"
 
-// CmdNetworkLeave handles the UI to let a Container disconnect from a Network
-// Sample UI : <chain> network leave <container-name/id> <network-name/id>
-func (cli *NetworkCli) CmdNetworkLeave(chain string, args ...string) error {
-	cmd := cli.Subcmd(chain, "leave", "CONTAINER-NAME/ID NETWORK-NAME/ID",
-		chain+" leave", false)
-	cmd.Require(flag.Min, 2)
-	err := cmd.ParseFlags(args, true)
-	if err != nil {
-		return err
+	for _, cmd := range networkCommands {
+		help += fmt.Sprintf("    %-10.10s%s\n", cmd.name, cmd.description)
 	}
-	// TODO : Proper Backend handling
-	obj, _, err := readBody(cli.call("PUT", "/endpoints/", nil, nil))
-	if err != nil {
-		fmt.Fprintf(cli.err, "%s", err.Error())
-		return err
-	}
-	if _, err := io.Copy(cli.out, bytes.NewReader(obj)); err != nil {
-		return err
-	}
-	return nil
+
+	help += fmt.Sprintf("\nRun '%s network COMMAND --help' for more information on a command.", chain)
+	return help
 }

--- a/client/types.go
+++ b/client/types.go
@@ -1,0 +1,34 @@
+package client
+
+import "github.com/docker/libnetwork/sandbox"
+
+/***********
+ Resources
+************/
+
+// networkResource is the body of the "get network" http response message
+type networkResource struct {
+	Name      string
+	ID        string
+	Type      string
+	Endpoints []*endpointResource
+}
+
+// endpointResource is the body of the "get endpoint" http response message
+type endpointResource struct {
+	Name    string
+	ID      string
+	Network string
+	Info    sandbox.Info
+}
+
+/***********
+  Body types
+  ************/
+
+// networkCreate is the expected body of the "create network" http request message
+type networkCreate struct {
+	Name        string
+	NetworkType string
+	Options     map[string]interface{}
+}

--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+
+	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/parsers"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/term"
+	"github.com/docker/libnetwork"
+	"github.com/docker/libnetwork/api"
+	"github.com/docker/libnetwork/client"
+	"github.com/gorilla/mux"
+)
+
+var (
+	// DefaultHTTPHost is used if only port is provided to -H flag e.g. docker -d -H tcp://:8080
+	DefaultHTTPHost = "127.0.0.1"
+	// DefaultHTTPPort is the default http port used by dnet
+	DefaultHTTPPort = 2385
+	// DefaultUnixSocket exported
+	DefaultUnixSocket = "/var/run/dnet.sock"
+)
+
+func main() {
+	_, stdout, stderr := term.StdStreams()
+	logrus.SetOutput(stderr)
+
+	err := dnetCommand(stdout, stderr)
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func dnetCommand(stdout, stderr io.Writer) error {
+	flag.Parse()
+
+	if *flHelp {
+		flag.Usage()
+		return nil
+	}
+
+	if *flLogLevel != "" {
+		lvl, err := logrus.ParseLevel(*flLogLevel)
+		if err != nil {
+			fmt.Fprintf(stderr, "Unable to parse logging level: %s\n", *flLogLevel)
+			return err
+		}
+		logrus.SetLevel(lvl)
+	} else {
+		logrus.SetLevel(logrus.InfoLevel)
+	}
+
+	if *flDebug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
+	if *flHost == "" {
+		defaultHost := os.Getenv("DNET_HOST")
+		if defaultHost == "" {
+			// TODO : Add UDS support
+			defaultHost = fmt.Sprintf("tcp://%s:%d", DefaultHTTPHost, DefaultHTTPPort)
+		}
+		*flHost = defaultHost
+	}
+
+	dc, err := newDnetConnection(*flHost)
+	if err != nil {
+		if *flDaemon {
+			logrus.Error(err)
+		} else {
+			fmt.Fprint(stderr, err)
+		}
+		return err
+	}
+
+	if *flDaemon {
+		err := dc.dnetDaemon()
+		if err != nil {
+			logrus.Errorf("dnet Daemon exited with an error : %v", err)
+		}
+		return err
+	}
+
+	cli := client.NewNetworkCli(stdout, stderr, dc.httpCall)
+	if err := cli.Cmd("dnet", flag.Args()...); err != nil {
+		fmt.Fprintln(stderr, err)
+		return err
+	}
+	return nil
+}
+
+type dnetConnection struct {
+	// proto holds the client protocol i.e. unix.
+	proto string
+	// addr holds the client address.
+	addr string
+}
+
+func (d *dnetConnection) dnetDaemon() error {
+	controller, err := libnetwork.New()
+	if err != nil {
+		fmt.Println("Error starting dnetDaemon :", err)
+		return err
+	}
+	httpHandler := api.NewHTTPHandler(controller)
+	r := mux.NewRouter().StrictSlash(false)
+	post := r.PathPrefix("/networks").Subrouter()
+	post.Methods("GET").HandlerFunc(httpHandler)
+	post.Methods("PUT", "POST").HandlerFunc(httpHandler)
+	post.Methods("DELETE").HandlerFunc(httpHandler)
+	return http.ListenAndServe(d.addr, r)
+}
+
+func newDnetConnection(val string) (*dnetConnection, error) {
+	url, err := parsers.ParseHost(DefaultHTTPHost, DefaultUnixSocket, val)
+	if err != nil {
+		return nil, err
+	}
+	protoAddrParts := strings.SplitN(url, "://", 2)
+	if len(protoAddrParts) != 2 {
+		return nil, fmt.Errorf("bad format, expected tcp://ADDR")
+	}
+	if strings.ToLower(protoAddrParts[0]) != "tcp" {
+		return nil, fmt.Errorf("dnet currently only supports tcp transport")
+	}
+
+	return &dnetConnection{protoAddrParts[0], protoAddrParts[1]}, nil
+}
+
+func (d *dnetConnection) httpCall(method, path string, data interface{}, headers map[string][]string) (io.ReadCloser, int, error) {
+	var in io.Reader
+	in, err := encodeData(data)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	req, err := http.NewRequest(method, fmt.Sprintf("%s", path), in)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	setupRequestHeaders(method, data, req, headers)
+
+	req.URL.Host = d.addr
+	req.URL.Scheme = "http"
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	statusCode := -1
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	if err != nil {
+		return nil, statusCode, fmt.Errorf("An error occurred trying to connect: %v", err)
+	}
+
+	if statusCode < 200 || statusCode >= 400 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, statusCode, err
+		}
+		return nil, statusCode, fmt.Errorf("Error response from daemon: %s", bytes.TrimSpace(body))
+	}
+
+	return resp.Body, statusCode, nil
+}
+
+func setupRequestHeaders(method string, data interface{}, req *http.Request, headers map[string][]string) {
+	if data != nil {
+		if headers == nil {
+			headers = make(map[string][]string)
+		}
+		headers["Content-Type"] = []string{"application/json"}
+	}
+
+	expectedPayload := (method == "POST" || method == "PUT")
+
+	if expectedPayload && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "text/plain")
+	}
+
+	if headers != nil {
+		for k, v := range headers {
+			req.Header[k] = v
+		}
+	}
+}
+
+func encodeData(data interface{}) (*bytes.Buffer, error) {
+	params := bytes.NewBuffer(nil)
+	if data != nil {
+		if err := json.NewEncoder(params).Encode(data); err != nil {
+			return nil, err
+		}
+	}
+	return params, nil
+}

--- a/cmd/dnet/dnet_test.go
+++ b/cmd/dnet/dnet_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/docker/libnetwork/netutils"
+)
+
+const dnetCommandName = "dnet"
+
+var origStdOut = os.Stdout
+
+func TestDnetDaemonCustom(t *testing.T) {
+	if !netutils.IsRunningInContainer() {
+		t.Skip("This test must run inside a container ")
+	}
+	customPort := 4567
+	doneChan := make(chan bool)
+	go func() {
+		args := []string{dnetCommandName, "-d", fmt.Sprintf("-H=:%d", customPort)}
+		executeDnetCommand(t, args, true)
+		doneChan <- true
+	}()
+
+	select {
+	case <-doneChan:
+		t.Fatal("dnet Daemon is not supposed to exit")
+	case <-time.After(3 * time.Second):
+		args := []string{dnetCommandName, "-d=false", fmt.Sprintf("-H=:%d", customPort), "-D", "network", "ls"}
+		executeDnetCommand(t, args, true)
+	}
+}
+
+func TestDnetDaemonInvalidCustom(t *testing.T) {
+	if !netutils.IsRunningInContainer() {
+		t.Skip("This test must run inside a container ")
+	}
+	customPort := 4668
+	doneChan := make(chan bool)
+	go func() {
+		args := []string{dnetCommandName, "-d=true", fmt.Sprintf("-H=:%d", customPort)}
+		executeDnetCommand(t, args, true)
+		doneChan <- true
+	}()
+
+	select {
+	case <-doneChan:
+		t.Fatal("dnet Daemon is not supposed to exit")
+	case <-time.After(3 * time.Second):
+		args := []string{dnetCommandName, "-d=false", "-H=:6669", "-D", "network", "ls"}
+		executeDnetCommand(t, args, false)
+	}
+}
+
+func TestDnetDaemonInvalidParams(t *testing.T) {
+	if !netutils.IsRunningInContainer() {
+		t.Skip("This test must run inside a container ")
+	}
+	args := []string{dnetCommandName, "-d=false", "-H=tcp:/127.0.0.1:8080"}
+	executeDnetCommand(t, args, false)
+
+	args = []string{dnetCommandName, "-d=false", "-H=unix://var/run/dnet.sock"}
+	executeDnetCommand(t, args, false)
+
+	args = []string{dnetCommandName, "-d=false", "-H=", "-l=invalid"}
+	executeDnetCommand(t, args, false)
+
+	args = []string{dnetCommandName, "-d=false", "-H=", "-l=error", "invalid"}
+	executeDnetCommand(t, args, false)
+}
+
+func TestDnetDefaultsWithFlags(t *testing.T) {
+	if !netutils.IsRunningInContainer() {
+		t.Skip("This test must run inside a container ")
+	}
+	doneChan := make(chan bool)
+	go func() {
+		args := []string{dnetCommandName, "-d=true", "-H=", "-l=error"}
+		executeDnetCommand(t, args, true)
+		doneChan <- true
+	}()
+
+	select {
+	case <-doneChan:
+		t.Fatal("dnet Daemon is not supposed to exit")
+	case <-time.After(3 * time.Second):
+		args := []string{dnetCommandName, "-d=false", "network", "create", "-d=null", "test"}
+		executeDnetCommand(t, args, true)
+
+		args = []string{dnetCommandName, "-d=false", "-D", "network", "ls"}
+		executeDnetCommand(t, args, true)
+	}
+}
+
+func TestDnetMain(t *testing.T) {
+	if !netutils.IsRunningInContainer() {
+		t.Skip("This test must run inside a container ")
+	}
+	customPort := 4568
+	doneChan := make(chan bool)
+	go func() {
+		args := []string{dnetCommandName, "-d=true", "-h=false", fmt.Sprintf("-H=:%d", customPort)}
+		os.Args = args
+		main()
+		doneChan <- true
+	}()
+	select {
+	case <-doneChan:
+		t.Fatal("dnet Daemon is not supposed to exit")
+	case <-time.After(2 * time.Second):
+	}
+}
+
+func executeDnetCommand(t *testing.T, args []string, shouldSucced bool) {
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	os.Args = args
+	err := dnetCommand(ioutil.Discard, ioutil.Discard)
+	if shouldSucced && err != nil {
+		os.Stdout = origStdOut
+		t.Fatalf("cli [%v] must succeed, but failed with an error :  %v", args, err)
+	} else if !shouldSucced && err == nil {
+		os.Stdout = origStdOut
+		t.Fatalf("cli [%v] must fail, but succeeded with an error :  %v", args, err)
+	}
+	os.Stdout = origStdOut
+}

--- a/cmd/dnet/flags.go
+++ b/cmd/dnet/flags.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	flag "github.com/docker/docker/pkg/mflag"
+)
+
+type command struct {
+	name        string
+	description string
+}
+
+type byName []command
+
+var (
+	flDaemon   = flag.Bool([]string{"d", "-daemon"}, false, "Enable daemon mode")
+	flHost     = flag.String([]string{"H", "-Host"}, "", "Daemon socket to connect to")
+	flLogLevel = flag.String([]string{"l", "-log-level"}, "info", "Set the logging level")
+	flDebug    = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
+	flHelp     = flag.Bool([]string{"h", "-help"}, false, "Print usage")
+
+	dnetCommands = []command{
+		{"network", "Network management commands"},
+	}
+)
+
+func init() {
+	flag.Usage = func() {
+		fmt.Fprint(os.Stdout, "Usage: dnet [OPTIONS] COMMAND [arg...]\n\nA self-sufficient runtime for container networking.\n\nOptions:\n")
+
+		flag.CommandLine.SetOutput(os.Stdout)
+		flag.PrintDefaults()
+
+		help := "\nCommands:\n"
+
+		for _, cmd := range dnetCommands {
+			help += fmt.Sprintf("    %-10.10s%s\n", cmd.name, cmd.description)
+		}
+
+		help += "\nRun 'dnet COMMAND --help' for more information on a command."
+		fmt.Fprintf(os.Stdout, "%s\n", help)
+	}
+}
+
+func printUsage() {
+	fmt.Println("Usage: dnet network <subcommand> <OPTIONS>")
+}


### PR DESCRIPTION
- Fixed a few bugs in the client package
- Integrated client with API package (also separated types.go from api.go for readability)
- Added a new dnet tool to test and manage libnetwork & drivers end-to-end.
    1. Start the dnet daemon `dnet -d`
    2. Execute dnet commands `dnet network [create | rm | ls | info] -d <driver-name> <network-name>`
    3. Use `dnet --help` for usage documentation
    * More UI additions coming up in subsequent PRs.
