### PR TITLE
Change default namespace path

### DIFF
--- a/sandbox/namespace_linux.go
+++ b/sandbox/namespace_linux.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vishvananda/netns"
 )
 
-const prefix = "/var/run/netns"
+const prefix = "/var/run/docker/netns"
 
 var once sync.Once
 


### PR DESCRIPTION
Change namespace path to be /var/run/docker/netns since
/var/run/netns is being used by iproute2 and it is mounted
as MS_SHARED which causes some complications during integration.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>