### PR TITLE
Fix RemoveInterface in sandbox

### DIFF
--- a/sandbox/namespace_linux.go
+++ b/sandbox/namespace_linux.go
@@ -165,6 +165,15 @@ func (n *networkNamespace) RemoveInterface(i *Interface) error {
 		return err
 	}
 
+	n.Lock()
+	for index, intf := range n.sinfo.Interfaces {
+		if intf == i {
+			n.sinfo.Interfaces = append(n.sinfo.Interfaces[:index], n.sinfo.Interfaces[index+1:]...)
+			break
+		}
+	}
+	n.Unlock()
+
 	return nil
 }
 
@@ -255,6 +264,8 @@ func (n *networkNamespace) SetGatewayIPv6(gw net.IP) error {
 }
 
 func (n *networkNamespace) Interfaces() []*Interface {
+	n.Lock()
+	defer n.Unlock()
 	return n.sinfo.Interfaces
 }
 

--- a/sandbox/sandbox_linux_test.go
+++ b/sandbox/sandbox_linux_test.go
@@ -84,6 +84,7 @@ func newInfo(t *testing.T) (*Info, error) {
 
 	// ip6, addrv6, err := net.ParseCIDR("2001:DB8::ABCD/48")
 	ip6, addrv6, err = net.ParseCIDR("fe80::3/64")
+
 	if err != nil {
 		return nil, err
 	}
@@ -127,13 +128,13 @@ func verifySandbox(t *testing.T, s Sandbox) {
 
 	_, err = netlink.LinkByName(sboxIfaceName + "0")
 	if err != nil {
-		t.Fatalf("Could not find the interface %s inside the sandbox: %v", sboxIfaceName,
+		t.Fatalf("Could not find the interface %s inside the sandbox: %v", sboxIfaceName+"0",
 			err)
 	}
 
 	_, err = netlink.LinkByName(sboxIfaceName + "1")
 	if err != nil {
-		t.Fatalf("Could not find the interface %s inside the sandbox: %v", sboxIfaceName,
+		t.Fatalf("Could not find the interface %s inside the sandbox: %v", sboxIfaceName+"1",
 			err)
 	}
 }

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -66,6 +66,58 @@ func TestSandboxCreateTwice(t *testing.T) {
 	s.Destroy()
 }
 
+func TestAddRemoveInterface(t *testing.T) {
+	key, err := newKey(t)
+	if err != nil {
+		t.Fatalf("Failed to obtain a key: %v", err)
+	}
+
+	s, err := NewSandbox(key, true)
+	if err != nil {
+		t.Fatalf("Failed to create a new sandbox: %v", err)
+	}
+
+	if s.Key() != key {
+		t.Fatalf("s.Key() returned %s. Expected %s", s.Key(), key)
+	}
+
+	info, err := newInfo(t)
+	if err != nil {
+		t.Fatalf("Failed to generate new sandbox info: %v", err)
+	}
+
+	for _, i := range info.Interfaces {
+		err = s.AddInterface(i)
+		if err != nil {
+			t.Fatalf("Failed to add interfaces to sandbox: %v", err)
+		}
+	}
+
+	interfaces := s.Interfaces()
+	if !(interfaces[0].Equal(info.Interfaces[0]) && interfaces[1].Equal(info.Interfaces[1])) {
+		t.Fatalf("Failed to update Sandbox.sinfo.Interfaces in AddInterfaces")
+	}
+
+	if err := s.RemoveInterface(info.Interfaces[0]); err != nil {
+		t.Fatalf("Failed to remove interfaces from sandbox: %v", err)
+	}
+
+	if !s.Interfaces()[0].Equal(info.Interfaces[1]) {
+		t.Fatalf("Failed to update the sanbox.sinfo.Interfaces in RemoveInterferce")
+	}
+
+	if err := s.AddInterface(info.Interfaces[0]); err != nil {
+		t.Fatalf("Failed to add interfaces to sandbox: %v", err)
+	}
+
+	interfaces = s.Interfaces()
+	if !(interfaces[0].Equal(info.Interfaces[1]) && interfaces[1].Equal(info.Interfaces[0])) {
+		t.Fatalf("Failed to update Sandbox.sinfo.Interfaces in AddInterfaces")
+	}
+
+	s.Destroy()
+}
+
 func TestInterfaceEqual(t *testing.T) {
 	list := getInterfaceList()
 


### PR DESCRIPTION
The networkNamespace struct will record all interfaces joined into this sandbox.
While RemoveInterface method does't remove the leaved interfaces.

Signed-off-by: junxu <xujun@cmss.chinamobile.com>