### PR TITLE
Restore anonymus import in iptables_test.go

### DIFF
--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	_ "github.com/docker/libnetwork/netutils"
 )
 
 const chainName = "DOCKER-TEST"


### PR DESCRIPTION

- Which is needed when running make (test in container)

Signed-off-by: Alessandro Boch <aboch@docker.com>