### PR TITLE
Cleanup namespace files

### DIFF
--- a/sandbox/namespace_linux.go
+++ b/sandbox/namespace_linux.go
@@ -91,10 +91,19 @@ func createNetworkNamespace(path string, osCreate bool) (*Info, error) {
 	return info, nil
 }
 
+func cleanupNamespaceFile(path string) {
+	if _, err := os.Stat(path); err == nil {
+		n := &networkNamespace{path: path}
+		n.Destroy()
+	}
+}
+
 func createNamespaceFile(path string) (err error) {
 	var f *os.File
 
 	once.Do(createBasePath)
+	// cleanup namespace file if it already exists because of a previous ungraceful exit.
+	cleanupNamespaceFile(path)
 	if f, err = os.Create(path); err == nil {
 		f.Close()
 	}

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -46,6 +46,26 @@ func TestSandboxCreate(t *testing.T) {
 	s.Destroy()
 }
 
+func TestSandboxCreateTwice(t *testing.T) {
+	key, err := newKey(t)
+	if err != nil {
+		t.Fatalf("Failed to obtain a key: %v", err)
+	}
+
+	_, err = NewSandbox(key, true)
+	if err != nil {
+		t.Fatalf("Failed to create a new sandbox: %v", err)
+	}
+
+	// Create another sandbox with the same key to see if we handle it
+	// gracefully.
+	s, err := NewSandbox(key, true)
+	if err != nil {
+		t.Fatalf("Failed to create a new sandbox: %v", err)
+	}
+	s.Destroy()
+}
+
 func TestInterfaceEqual(t *testing.T) {
 	list := getInterfaceList()
 


### PR DESCRIPTION
It may happen that the application (docker) may exit ungracefully
exit without calling leaves on endpoint and may result in stale
namespace files. So if a sandbox is created with the same key
attempt to cleanup the file if it exists before creating the
sandbox.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>