### PR TITLE
Add ability for drivers to set static routes

### DIFF
--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -104,6 +104,10 @@ type JoinInfo interface {
 	// SetGatewayIPv6 sets the default IPv6 gateway when a container joins the endpoint.
 	SetGatewayIPv6(net.IP) error
 
+	// AddStaticRoute adds a routes to the sandbox.
+	// It may be used in addtion to or instead of a default gateway (as above).
+	AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP, interfaceID int) error
+
 	// SetHostsPath sets the overriding /etc/hosts path to use for the container.
 	SetHostsPath(string) error
 

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -87,6 +87,7 @@ type testEndpoint struct {
 	gw6            net.IP
 	hostsPath      string
 	resolvConfPath string
+	routes         []types.StaticRoute
 }
 
 func (te *testEndpoint) Interfaces() []driverapi.InterfaceInfo {
@@ -154,6 +155,11 @@ func (te *testEndpoint) SetHostsPath(path string) error {
 
 func (te *testEndpoint) SetResolvConfPath(path string) error {
 	te.resolvConfPath = path
+	return nil
+}
+
+func (te *testEndpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP, interfaceID int) error {
+	te.routes = append(te.routes, types.StaticRoute{destination, routeType, nextHop, interfaceID})
 	return nil
 }
 

--- a/drivers/remote/driver_test.go
+++ b/drivers/remote/driver_test.go
@@ -149,6 +149,11 @@ func (test *testEndpoint) SetNames(src string, dst string) error {
 	return nil
 }
 
+func (test *testEndpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP, interfaceID int) error {
+	//TODO
+	return nil
+}
+
 func (test *testEndpoint) ID() int {
 	return test.id
 }

--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -46,6 +46,7 @@ type endpointInterface struct {
 	addrv6    net.IPNet
 	srcName   string
 	dstPrefix string
+	routes    []*net.IPNet
 }
 
 type endpointJoinInfo struct {
@@ -53,6 +54,7 @@ type endpointJoinInfo struct {
 	gw6            net.IP
 	hostsPath      string
 	resolvConfPath string
+	StaticRoutes   []*types.StaticRoute
 }
 
 func (ep *endpoint) Info() EndpointInfo {
@@ -147,6 +149,35 @@ func (ep *endpoint) InterfaceNames() []driverapi.InterfaceNameInfo {
 	}
 
 	return iList
+}
+
+func (ep *endpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP, interfaceID int) error {
+	ep.Lock()
+	defer ep.Unlock()
+
+	r := types.StaticRoute{destination, routeType, nextHop, interfaceID}
+
+	if routeType == types.NEXTHOP {
+		// If the route specifies a next-hop, then it's loosely routed (i.e. not bound to a particular interface).
+		ep.joinInfo.StaticRoutes = append(ep.joinInfo.StaticRoutes, &r)
+	} else {
+		// If the route doesn't specify a next-hop, it must be a connected route, bound to an interface.
+		if err := ep.addInterfaceRoute(&r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ep *endpoint) addInterfaceRoute(route *types.StaticRoute) error {
+	for _, iface := range ep.iFaces {
+		if iface.id == route.InterfaceID {
+			iface.routes = append(iface.routes, route.Destination)
+			return nil
+		}
+	}
+	return types.BadRequestErrorf("Interface with ID %d doesn't exist.",
+		route.InterfaceID)
 }
 
 func (ep *endpoint) SandboxKey() string {

--- a/sandbox/configure_linux.go
+++ b/sandbox/configure_linux.go
@@ -19,6 +19,7 @@ func configureInterface(iface netlink.Link, settings *Interface) error {
 		{setInterfaceName, fmt.Sprintf("error renaming interface %q to %q", ifaceName, settings.DstName)},
 		{setInterfaceIP, fmt.Sprintf("error setting interface %q IP to %q", ifaceName, settings.Address)},
 		{setInterfaceIPv6, fmt.Sprintf("error setting interface %q IPv6 to %q", ifaceName, settings.AddressIPv6)},
+		{setInterfaceRoutes, fmt.Sprintf("error setting interface %q routes to %q", ifaceName, settings.Routes)},
 	}
 
 	for _, config := range ifaceConfigurators {
@@ -63,6 +64,78 @@ func programGateway(path string, gw net.IP) error {
 	})
 }
 
+// Program a route in to the namespace routing table.
+func programRoute(path string, dest *net.IPNet, nh net.IP) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	origns, err := netns.Get()
+	if err != nil {
+		return err
+	}
+	defer origns.Close()
+
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed get network namespace %q: %v", path, err)
+	}
+	defer f.Close()
+
+	nsFD := f.Fd()
+	if err = netns.Set(netns.NsHandle(nsFD)); err != nil {
+		return err
+	}
+	defer netns.Set(origns)
+
+	gwRoutes, err := netlink.RouteGet(nh)
+	if err != nil {
+		return fmt.Errorf("route for the next hop could not be found: %v", err)
+	}
+
+	return netlink.RouteAdd(&netlink.Route{
+		Scope:     netlink.SCOPE_UNIVERSE,
+		LinkIndex: gwRoutes[0].LinkIndex,
+		Gw:        gwRoutes[0].Gw,
+		Dst:       dest,
+	})
+}
+
+// Delete a route from the namespace routing table.
+func removeRoute(path string, dest *net.IPNet, nh net.IP) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	origns, err := netns.Get()
+	if err != nil {
+		return err
+	}
+	defer origns.Close()
+
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed get network namespace %q: %v", path, err)
+	}
+	defer f.Close()
+
+	nsFD := f.Fd()
+	if err = netns.Set(netns.NsHandle(nsFD)); err != nil {
+		return err
+	}
+	defer netns.Set(origns)
+
+	gwRoutes, err := netlink.RouteGet(nh)
+	if err != nil {
+		return fmt.Errorf("route for the next hop could not be found: %v", err)
+	}
+
+	return netlink.RouteDel(&netlink.Route{
+		Scope:     netlink.SCOPE_UNIVERSE,
+		LinkIndex: gwRoutes[0].LinkIndex,
+		Gw:        gwRoutes[0].Gw,
+		Dst:       dest,
+	})
+}
+
 func setInterfaceIP(iface netlink.Link, settings *Interface) error {
 	ipAddr := &netlink.Addr{IPNet: settings.Address, Label: ""}
 	return netlink.AddrAdd(iface, ipAddr)
@@ -78,4 +151,18 @@ func setInterfaceIPv6(iface netlink.Link, settings *Interface) error {
 
 func setInterfaceName(iface netlink.Link, settings *Interface) error {
 	return netlink.LinkSetName(iface, settings.DstName)
+}
+
+func setInterfaceRoutes(iface netlink.Link, settings *Interface) error {
+	for _, route := range settings.Routes {
+		err := netlink.RouteAdd(&netlink.Route{
+			Scope:     netlink.SCOPE_UNIVERSE,
+			LinkIndex: iface.Attrs().Index,
+			Dst:       route,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/sandbox/sandbox_linux_test.go
+++ b/sandbox/sandbox_linux_test.go
@@ -63,6 +63,13 @@ func newInfo(t *testing.T) (*Info, error) {
 	intf1.AddressIPv6 = addrv6
 	intf1.AddressIPv6.IP = ip6
 
+	_, route, err := net.ParseCIDR("192.168.2.1/32")
+	if err != nil {
+		return nil, err
+	}
+
+	intf1.Routes = []*net.IPNet{route}
+
 	veth = &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{Name: vethName3, TxQLen: 0},
 		PeerName:  vethName4}
@@ -92,6 +99,7 @@ func newInfo(t *testing.T) (*Info, error) {
 	intf2.AddressIPv6.IP = ip6
 
 	sinfo := &Info{Interfaces: []*Interface{intf1, intf2}}
+
 	sinfo.Gateway = net.ParseIP("192.168.1.1")
 	// sinfo.GatewayIPv6 = net.ParseIP("2001:DB8::1")
 	sinfo.GatewayIPv6 = net.ParseIP("fe80::1")

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -190,12 +190,14 @@ func getInterfaceList() []*Interface {
 			DstName:     "eth0",
 			Address:     netv4a,
 			AddressIPv6: netv6a,
+			Routes:      []*net.IPNet{netv4a, netv6a},
 		},
 		&Interface{
 			SrcName:     "veth7654321",
 			DstName:     "eth1",
 			Address:     netv4b,
 			AddressIPv6: netv6b,
+			Routes:      []*net.IPNet{netv4b, netv6b},
 		},
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -184,6 +184,40 @@ func CompareIPNet(a, b *net.IPNet) bool {
 	return a.IP.Equal(b.IP) && bytes.Equal(a.Mask, b.Mask)
 }
 
+const (
+	// NEXTHOP indicates a StaticRoute with an IP next hop.
+	NEXTHOP = iota
+
+	// CONNECTED indicates a StaticRoute with a interface for directly connected peers.
+	CONNECTED
+)
+
+// StaticRoute is a statically-provisioned IP route.
+type StaticRoute struct {
+	Destination *net.IPNet
+
+	RouteType int // NEXT_HOP or CONNECTED
+
+	// NextHop will be resolved by the kernel (i.e. as a loose hop).
+	NextHop net.IP
+
+	// InterfaceID must refer to a defined interface on the
+	// Endpoint to which the routes are specified.  Routes specified this way
+	// are interpreted as directly connected to the specified interface (no
+	// next hop will be used).
+	InterfaceID int
+}
+
+// GetCopy returns a copy of this StaticRoute structure
+func (r *StaticRoute) GetCopy() *StaticRoute {
+	d := GetIPNetCopy(r.Destination)
+	nh := GetIPCopy(r.NextHop)
+	return &StaticRoute{Destination: d,
+		RouteType:   r.RouteType,
+		NextHop:     nh,
+		InterfaceID: r.InterfaceID}
+}
+
 /******************************
  * Well-known Error Interfaces
  ******************************/


### PR DESCRIPTION
As suggested by @mrjana  and @mavenugo here's a rough outline for the API changes required to allow drivers to set static routes in the sandbox. 

Can you comment on this approach? If you think you could accept this PR I'll write the implementation and UTs.

I also expect I'll need to change the remote driver once @squaremo 's changes go in.