### PR TITLE
Fix /etc/resolv.conf permission issue

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -548,6 +548,11 @@ func (ep *endpoint) updateDNS(resolvConf []byte) error {
 		return err
 	}
 
+	// Change the perms to 0644 since ioutil.TempFile creates it by default as 0600
+	if err := os.Chmod(tmpResolvFile.Name(), 0644); err != nil {
+		return err
+	}
+
 	// write the updates to the temp files
 	if err = ioutil.WriteFile(tmpHashFile.Name(), []byte(newHash), 0644); err != nil {
 		return err

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -1137,6 +1137,16 @@ func TestResolvConf(t *testing.T) {
 		}
 	}()
 
+	finfo, err := os.Stat(resolvConfPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmode := (os.FileMode)(0644)
+	if finfo.Mode() != fmode {
+		t.Fatalf("Expected file mode %s, got %s", fmode.String(), finfo.Mode().String())
+	}
+
 	content, err := ioutil.ReadFile(resolvConfPath)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The container's /etc/resolv.conf permission was getting setup
as 0600 while it should be 0644 for every user inside the
container to be able to read it. The tempfile that we create
initially to populate the resolvconf content is getting created
with 0600 mode. Changed it to 0644 once it is created since there
is noway to pass mode option to ioutil.Tempfile

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>