### PR TITLE
Fix issues when customizing docker bridge-v2

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -48,6 +48,7 @@ package libnetwork
 import (
 	"sync"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/libnetwork/driverapi"
@@ -64,6 +65,9 @@ type NetworkController interface {
 	// Create a new network. The options parameter carries network specific options.
 	// Labels support will be added in the near future.
 	NewNetwork(networkType, name string, options ...NetworkOption) (Network, error)
+
+	// Clean up all network setup created by each driver implementation.
+	DestroyNetworks()
 
 	// Networks returns the list of Network(s) managed by this controller.
 	Networks() []Network
@@ -197,6 +201,16 @@ func (c *controller) WalkNetworks(walker NetworkWalker) {
 	for _, n := range c.Networks() {
 		if walker(n) {
 			return
+		}
+	}
+}
+
+func (c *controller) DestroyNetworks() {
+	logrus.Debugf("Destroy all networks")
+	for _, n := range c.Networks() {
+		err := n.Delete()
+		if err != nil {
+			logrus.Errorf("Failed to destroy network %s: %v", n.Name(), err)
 		}
 	}
 }

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -274,6 +274,8 @@ func Exists(table Table, chain string, rule ...string) bool {
 	if _, err := Raw(append([]string{
 		"-t", string(table), "-C", chain}, rule...)...); err == nil {
 		return true
+	} else if strings.Contains(err.Error(), "iptables: No chain/target/match by that name") {
+		return false
 	}
 
 	// parse "iptables -S" for the rule (this checks rules in a specific chain


### PR DESCRIPTION
When customizing docker bridge with --bip, I found two issues here:
1. docker daemon failed when creating docker0 bridge
2. After manually delete original docker0 bridge, docker instance network cannot reach outside

This PR try to address above issues automatically for docker in libnetwork by:
a. Provide DestroyNetworks for docker daemon to cleanup networks from different drivers
b. Take advantage of negative case of iptable -C to check exist of nat rule

The test has been done based on https://github.com/mrjana/docker/tree/cnm_integ,
and once libnetwork got merged, I will update docker daemon Shutdown procedure. 

Change log:
v2:
* Apologize for creating a new PR re-basing with master, original one is #156 
* Squash the commit which solving build failure
