### PR TITLE
Modify driver Join api to only allow dst prefix

### DIFF
--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -83,8 +83,8 @@ type InterfaceInfo interface {
 // InterfaceNameInfo provides a go interface for the drivers to assign names
 // to interfaces.
 type InterfaceNameInfo interface {
-	// SetNames method assigns the srcName and dstName for the interface.
-	SetNames(srcName, dstName string) error
+	// SetNames method assigns the srcName and dstPrefix for the interface.
+	SetNames(srcName, dstPrefix string) error
 
 	// ID returns the numerical id that was assigned to the interface by the driver
 	// CreateEndpoint.

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -21,7 +21,7 @@ const (
 	networkType             = "bridge"
 	vethPrefix              = "veth"
 	vethLen                 = 7
-	containerVeth           = "eth0"
+	containerVethPrefix     = "eth"
 	maxAllocatePortAttempts = 10
 	ifaceID                 = 1
 )
@@ -545,7 +545,7 @@ func (d *driver) CreateEndpoint(nid, eid types.UUID, epInfo driverapi.EndpointIn
 	// Create the sandbox side pipe interface
 	intf := &sandbox.Interface{}
 	intf.SrcName = name2
-	intf.DstName = containerVeth
+	intf.DstName = containerVethPrefix
 	intf.Address = ipv4Addr
 
 	if config.EnableIPv6 {

--- a/endpoint.go
+++ b/endpoint.go
@@ -291,7 +291,7 @@ func (ep *endpoint) Join(containerID string, options ...EndpointOption) (*Contai
 	for _, i := range ifaces {
 		iface := &sandbox.Interface{
 			SrcName: i.srcName,
-			DstName: i.dstName,
+			DstName: i.dstPrefix,
 			Address: &i.addr,
 		}
 		if i.addrv6.IP.To16() != nil {

--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -40,12 +40,12 @@ type InterfaceInfo interface {
 }
 
 type endpointInterface struct {
-	id      int
-	mac     net.HardwareAddr
-	addr    net.IPNet
-	addrv6  net.IPNet
-	srcName string
-	dstName string
+	id        int
+	mac       net.HardwareAddr
+	addr      net.IPNet
+	addrv6    net.IPNet
+	srcName   string
+	dstPrefix string
 }
 
 type endpointJoinInfo struct {
@@ -130,9 +130,9 @@ func (i *endpointInterface) AddressIPv6() net.IPNet {
 	return (*types.GetIPNetCopy(&i.addrv6))
 }
 
-func (i *endpointInterface) SetNames(srcName string, dstName string) error {
+func (i *endpointInterface) SetNames(srcName string, dstPrefix string) error {
 	i.srcName = srcName
-	i.dstName = dstName
+	i.dstPrefix = dstPrefix
 	return nil
 }
 

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -20,7 +20,9 @@ type Sandbox interface {
 
 	// Add an existing Interface to this sandbox. The operation will rename
 	// from the Interface SrcName to DstName as it moves, and reconfigure the
-	// interface according to the specified settings.
+	// interface according to the specified settings. The caller is expected
+	// to only provide a prefix for DstName. The AddInterface api will auto-generate
+	// an appropriate suffix for the DstName to disambiguate.
 	AddInterface(*Interface) error
 
 	// Remove an interface from the sandbox by renamin to original name
@@ -62,7 +64,9 @@ type Interface struct {
 	SrcName string
 
 	// The name that will be assigned to the interface once moves inside a
-	// network namespace.
+	// network namespace. When the caller passes in a DstName, it is only
+	// expected to pass a prefix. The name will modified with an appropriately
+	// auto-generated suffix.
 	DstName string
 
 	// IPv4 address for the interface.


### PR DESCRIPTION
Currently the driver api allows the driver to specify the
full interface name for the interface inside the container.
This is not appropriate since the driver does not have the full
view of the sandbox to correcly allocate an unambiguous interface
name. Instead with this PR the driver will be allowed to specify
a prefix for the name and libnetwork and sandbox layers will
disambiguate it with an appropriate suffix.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>