### PR TITLE
Add the ability to request a specific IP address when creating a new endpoint

### DIFF
--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -244,6 +244,9 @@ func TestCreateLinkWithOptions(t *testing.T) {
 	epOptions := make(map[string]interface{})
 	epOptions[netlabel.MacAddress] = mac
 
+	ip := net.ParseIP("172.17.42.111")
+	epOptions[netlabel.IPAddress] = ip
+
 	te := &testEndpoint{ifaces: []*testInterface{}}
 	err = d.CreateEndpoint("net1", "ep", te, epOptions)
 	if err != nil {
@@ -262,7 +265,12 @@ func TestCreateLinkWithOptions(t *testing.T) {
 	}
 
 	if !bytes.Equal(mac, veth.Attrs().HardwareAddr) {
-		t.Fatalf("Failed to parse and program endpoint configuration")
+		t.Fatalf("Failed to parse and program endpoint MAC configuration")
+	}
+
+	teIP4 := te.ifaces[0].addr.IP.To4()
+	if !ip.Equal(teIP4) {
+		t.Fatalf("Failed to parse and program endpoint IP configuration")
 	}
 }
 

--- a/netlabel/labels.go
+++ b/netlabel/labels.go
@@ -10,6 +10,9 @@ const (
 	// MacAddress constant represents Mac Address config of a Container
 	MacAddress = "io.docker.network.endpoint.macaddress"
 
+	// IPAddress constant represents requesting a specific IP address for a Container
+	IPAddress = "io.docker.network.endpoint.ipaddress"
+
 	// ExposedPorts constant represents exposedports of a Container
 	ExposedPorts = "io.docker.network.endpoint.exposedports"
 


### PR DESCRIPTION
When restoring a container, we want to request the same IP address we had before. I'm not sure if this is really the best way to do that, so I'm open to changing this if there are any alternate proposals.