### PR TITLE
Added API support for both /vx.x/networks & /networks

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -100,7 +100,7 @@ func (h *httpHandler) initRouter() {
 		"DELETE": {
 			{"/networks/" + nwID, nil, procDeleteNetwork},
 			{"/networks/" + nwID + "/endpoints/" + epID, nil, procDeleteEndpoint},
-			{"/networks/id/" + nwID + "/endpoints/" + epID + "/containers/" + cnID, nil, procLeaveEndpoint},
+			{"/networks/" + nwID + "/endpoints/" + epID + "/containers/" + cnID, nil, procLeaveEndpoint},
 		},
 	}
 
@@ -108,6 +108,11 @@ func (h *httpHandler) initRouter() {
 	for method, routes := range m {
 		for _, route := range routes {
 			r := h.r.Path("/{.*}" + route.url).Methods(method).HandlerFunc(makeHandler(h.c, route.fct))
+			if route.qrs != nil {
+				r.Queries(route.qrs...)
+			}
+
+			r = h.r.Path(route.url).Methods(method).HandlerFunc(makeHandler(h.c, route.fct))
 			if route.qrs != nil {
 				r.Queries(route.qrs...)
 			}

--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -115,6 +115,8 @@ func (d *dnetConnection) dnetDaemon() error {
 	r := mux.NewRouter().StrictSlash(false)
 	post := r.PathPrefix("/{.*}/networks").Subrouter()
 	post.Methods("GET", "PUT", "POST", "DELETE").HandlerFunc(httpHandler)
+	post = r.PathPrefix("/networks").Subrouter()
+	post.Methods("GET", "PUT", "POST", "DELETE").HandlerFunc(httpHandler)
 	return http.ListenAndServe(d.addr, r)
 }
 
@@ -141,7 +143,7 @@ func (d *dnetConnection) httpCall(method, path string, data interface{}, headers
 		return nil, -1, err
 	}
 
-	req, err := http.NewRequest(method, fmt.Sprintf("/dnet%s", path), in)
+	req, err := http.NewRequest(method, fmt.Sprintf("%s", path), in)
 	if err != nil {
 		return nil, -1, err
 	}


### PR DESCRIPTION
In one of the previous commit, we went to the extreme of supporting just
the /{version}/networks. Though that satisfied the requirements for UI
integration, it is not fully consistent with Docker APIs.
Docker API supports both /{version}/resource and /resource and hence we
must add the same support for networks resource.

Signed-off-by: Madhu Venugopal <madhu@docker.com>