### PR TITLE
WIP : default configs for new network in bridge driver

### DIFF
--- a/client/network.go
+++ b/client/network.go
@@ -45,7 +45,7 @@ func (cli *NetworkCli) CmdNetwork(chain string, args ...string) error {
 // CmdNetworkCreate handles Network Create UI
 func (cli *NetworkCli) CmdNetworkCreate(chain string, args ...string) error {
 	cmd := cli.Subcmd(chain, "create", "NETWORK-NAME", "Creates a new network with a name specified by the user", false)
-	flDriver := cmd.String([]string{"d", "-driver"}, "null", "Driver to manage the Network")
+	flDriver := cmd.String([]string{"d", "-driver"}, "bridge", "Driver to manage the Network")
 	cmd.Require(flag.Min, 1)
 	err := cmd.ParseFlags(args, true)
 	if err != nil {

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -175,8 +175,8 @@ func (c *networkConfiguration) Conflict(o *networkConfiguration) bool {
 	return false
 }
 
-// FromMap retrieve the configuration data from the map form.
-func (c *networkConfiguration) FromMap(data map[string]interface{}) error {
+// fromMap retrieve the configuration data from the map form.
+func (c *networkConfiguration) fromMap(data map[string]interface{}) error {
 	var err error
 
 	if i, ok := data["BridgeName"]; ok && i != nil {
@@ -393,8 +393,12 @@ func parseNetworkGenericOptions(data interface{}) (*networkConfiguration, error)
 	case *networkConfiguration:
 		config = opt
 	case map[string]interface{}:
-		config = &networkConfiguration{}
-		err = config.FromMap(opt)
+		config = &networkConfiguration{
+			EnableICC:          true,
+			EnableIPTables:     true,
+			EnableIPMasquerade: true,
+		}
+		err = config.fromMap(opt)
 	case options.Generic:
 		var opaqueConfig interface{}
 		if opaqueConfig, err = options.GenerateFromModel(opt, config); err == nil {


### PR DESCRIPTION
This fix provides seamless connectivity for the newly created network using Bridge driver.
We should not be forcing the user to pass these default configuration for each bridge being created.

Also fixed a minor bug in client to choose bridge as the default driver

Signed-off-by: Madhu Venugopal <madhu@docker.com>