### PR TITLE
Freebsd preliminary support

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/bridge_freebsd.go
+++ b/drivers/bridge/bridge_freebsd.go
@@ -1,0 +1,55 @@
+// +build freebsd
+
+package bridge
+
+import (
+	"github.com/docker/libnetwork/driverapi"
+	"github.com/docker/libnetwork/types"
+)
+
+const networkType = "bridge"
+
+type driver struct{}
+
+// Init registers a new instance of bridge driver
+func Init(dc driverapi.DriverCallback) error {
+	return dc.RegisterDriver(networkType, &driver{})
+}
+
+func (d *driver) Config(option map[string]interface{}) error {
+	return nil
+}
+
+func (d *driver) CreateNetwork(id types.UUID, option map[string]interface{}) error {
+	return nil
+}
+
+func (d *driver) DeleteNetwork(nid types.UUID) error {
+	return nil
+}
+
+func (d *driver) CreateEndpoint(nid, eid types.UUID, epInfo driverapi.EndpointInfo, epOptions map[string]interface{}) error {
+	return nil
+}
+
+func (d *driver) DeleteEndpoint(nid, eid types.UUID) error {
+	return nil
+}
+
+func (d *driver) EndpointOperInfo(nid, eid types.UUID) (map[string]interface{}, error) {
+	return make(map[string]interface{}, 0), nil
+}
+
+// Join method is invoked when a Sandbox is attached to an endpoint.
+func (d *driver) Join(nid, eid types.UUID, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+	return nil
+}
+
+// Leave method is invoked when a Sandbox detaches from an endpoint.
+func (d *driver) Leave(nid, eid types.UUID) error {
+	return nil
+}
+
+func (d *driver) Type() string {
+	return networkType
+}

--- a/drivers/bridge/interface.go
+++ b/drivers/bridge/interface.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/link.go
+++ b/drivers/bridge/link.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/port_mapping.go
+++ b/drivers/bridge/port_mapping.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/resolvconf.go
+++ b/drivers/bridge/resolvconf.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/setup.go
+++ b/drivers/bridge/setup.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 type setupStep func(*networkConfiguration, *bridgeInterface) error

--- a/drivers/bridge/setup_device.go
+++ b/drivers/bridge/setup_device.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/setup_fixedcidrv4.go
+++ b/drivers/bridge/setup_fixedcidrv4.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/setup_fixedcidrv6.go
+++ b/drivers/bridge/setup_fixedcidrv6.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/setup_ip_forwarding.go
+++ b/drivers/bridge/setup_ip_forwarding.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/setup_ipv4.go
+++ b/drivers/bridge/setup_ipv4.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/setup_ipv6.go
+++ b/drivers/bridge/setup_ipv6.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/drivers/bridge/setup_verify.go
+++ b/drivers/bridge/setup_verify.go
@@ -1,3 +1,5 @@
+// +build !freebsd
+
 package bridge
 
 import (

--- a/sandbox/sandbox_unsupported.go
+++ b/sandbox/sandbox_unsupported.go
@@ -10,6 +10,17 @@ var (
 
 // NewSandbox provides a new sandbox instance created in an os specific way
 // provided a key which uniquely identifies the sandbox
-func NewSandbox(key string) (Sandbox, error) {
+func NewSandbox(key string, osCreate bool) (Sandbox, error) {
 	return nil, ErrNotImplemented
+}
+
+// GenerateKey generates a sandbox key based on the passed
+// container id.
+func GenerateKey(containerID string) string {
+	maxLen := 12
+	if len(containerID) < maxLen {
+		maxLen = len(containerID)
+	}
+
+	return containerID[:maxLen]
 }


### PR DESCRIPTION
Added pieces of code required to build docker on FreeBSD, this will be later used to implement bsdshared and bsdbridge drivers.