### PR TITLE
Remove the init time cleanup of namespace files

### DIFF
--- a/sandbox/namespace_linux.go
+++ b/sandbox/namespace_linux.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"sync"
 	"syscall"
@@ -46,9 +45,6 @@ func createBasePath() {
 	if err != nil && !os.IsExist(err) {
 		panic("Could not create net namespace path directory")
 	}
-
-	// cleanup any stale namespace files if any
-	cleanupNamespaceFiles()
 
 	// Start the garbage collection go routine
 	go removeUnusedPaths()
@@ -152,24 +148,6 @@ func createNetworkNamespace(path string, osCreate bool) (*Info, error) {
 	interfaces := []*Interface{}
 	info := &Info{Interfaces: interfaces}
 	return info, nil
-}
-
-func cleanupNamespaceFiles() {
-	filepath.Walk(prefix, func(path string, info os.FileInfo, err error) error {
-		stat, err := os.Stat(path)
-		if err != nil {
-			return err
-		}
-
-		if stat.IsDir() {
-			return filepath.SkipDir
-		}
-
-		syscall.Unmount(path, syscall.MNT_DETACH)
-		os.Remove(path)
-
-		return nil
-	})
 }
 
 func unmountNamespaceFile(path string) {


### PR DESCRIPTION
Removing this as this may cause problems when
multiple instances are  running.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>