### PR TITLE
Change scope to LINK when setting device routes

### DIFF
--- a/sandbox/configure_linux.go
+++ b/sandbox/configure_linux.go
@@ -156,7 +156,7 @@ func setInterfaceName(iface netlink.Link, settings *Interface) error {
 func setInterfaceRoutes(iface netlink.Link, settings *Interface) error {
 	for _, route := range settings.Routes {
 		err := netlink.RouteAdd(&netlink.Route{
-			Scope:     netlink.SCOPE_UNIVERSE,
+			Scope:     netlink.SCOPE_LINK,
 			LinkIndex: iface.Attrs().Index,
 			Dst:       route,
 		})


### PR DESCRIPTION
Without this they don't have the desired effect.
The default when creating these types of routes with `ip route add` is link - the old setting of universe was just wrong.