### PR TITLE
cleanup: remove unused variable

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -452,11 +452,6 @@ func (ep *endpoint) buildHostsFiles() error {
 		}
 	}
 
-	name := container.config.hostName
-	if container.config.domainName != "" {
-		name = name + "." + container.config.domainName
-	}
-
 	for _, extraHost := range container.config.extraHosts {
 		extraContent = append(extraContent,
 			etchosts.Record{Hosts: extraHost.name, IP: extraHost.IP})


### PR DESCRIPTION
Here I noticed that variable "name" declared but not used, so remove those lines.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>