### PR TITLE
Do not warn in packages

### DIFF
--- a/portallocator/portallocator.go
+++ b/portallocator/portallocator.go
@@ -7,8 +7,6 @@ import (
 	"net"
 	"os"
 	"sync"
-
-	"github.com/Sirupsen/logrus"
 )
 
 const (
@@ -94,7 +92,6 @@ func Get() *PortAllocator {
 func newInstance() *PortAllocator {
 	start, end, err := getDynamicPortRange()
 	if err != nil {
-		logrus.Warn(err)
 		start, end = DefaultPortRangeStart, DefaultPortRangeEnd
 	}
 	return &PortAllocator{


### PR DESCRIPTION
Do not have log output in packages that applications consume because the
output can mess with logs, stdout/stderr of applications and such and
there is nothing that the consumer can do about it other than change the
package that they are using.

Fixes https://github.com/docker/docker/issues/13373

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>