### PR TITLE
Change in bridge EndpointOperInfo()

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -925,6 +925,15 @@ func (d *driver) EndpointOperInfo(nid, eid types.UUID) (map[string]interface{}, 
 
 	m := make(map[string]interface{})
 
+	if ep.config.ExposedPorts != nil {
+		// Return a copy of the config data
+		epc := make([]types.TransportPort, 0, len(ep.config.ExposedPorts))
+		for _, tp := range ep.config.ExposedPorts {
+			epc = append(epc, tp.GetCopy())
+		}
+		m[netlabel.ExposedPorts] = epc
+	}
+
 	if ep.portMapping != nil {
 		// Return a copy of the operational data
 		pmc := make([]types.PortBinding, 0, len(ep.portMapping))


### PR DESCRIPTION
- To also return the configured exposed ports, besides the
  port bindings; as now libnetwork/endpoint.go endpoint setters
  separate the exposed ports and port binding configs.
  Docker daemon will take care of aggregating the two sources
  for presentation.

Signed-off-by: Alessandro Boch <aboch@docker.com>