### PR TITLE
Moving hostdiscovery under build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build: ${build_image}.created
 	${docker} make build-local
 
 build-local:
-	$(shell which godep) go build -tags experimental ./...
+	$(shell which godep) go build -tags experimental,libnetwork_discovery ./...
 
 check: ${build_image}.created
 	${docker} make check-local

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -159,7 +159,7 @@ func (te *testEndpoint) SetResolvConfPath(path string) error {
 }
 
 func (te *testEndpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP, interfaceID int) error {
-	te.routes = append(te.routes, types.StaticRoute{destination, routeType, nextHop, interfaceID})
+	te.routes = append(te.routes, types.StaticRoute{Destination: destination, RouteType: routeType, NextHop: nextHop, InterfaceID: interfaceID})
 	return nil
 }
 

--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -155,7 +155,7 @@ func (ep *endpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHo
 	ep.Lock()
 	defer ep.Unlock()
 
-	r := types.StaticRoute{destination, routeType, nextHop, interfaceID}
+	r := types.StaticRoute{Destination: destination, RouteType: routeType, NextHop: nextHop, InterfaceID: interfaceID}
 
 	if routeType == types.NEXTHOP {
 		// If the route specifies a next-hop, then it's loosely routed (i.e. not bound to a particular interface).

--- a/hostdiscovery/hostdiscovery.go
+++ b/hostdiscovery/hostdiscovery.go
@@ -1,3 +1,5 @@
+// +build libnetwork_discovery
+
 package hostdiscovery
 
 import (
@@ -23,22 +25,6 @@ import (
 )
 
 const defaultHeartbeat = 10
-
-// JoinCallback provides a callback event for new node joining the cluster
-type JoinCallback func(entries []net.IP)
-
-// LeaveCallback provides a callback event for node leaving the cluster
-type LeaveCallback func(entries []net.IP)
-
-// HostDiscovery primary interface
-type HostDiscovery interface {
-	// StartDiscovery initiates the discovery process and provides appropriate callbacks
-	StartDiscovery(*config.ClusterCfg, JoinCallback, LeaveCallback) error
-	// StopDiscovery stops the discovery perocess
-	StopDiscovery() error
-	// Fetch returns a list of host IPs that are currently discovered
-	Fetch() ([]net.IP, error)
-}
 
 type hostDiscovery struct {
 	discovery discovery.Discovery

--- a/hostdiscovery/hostdiscovery_api.go
+++ b/hostdiscovery/hostdiscovery_api.go
@@ -1,0 +1,23 @@
+package hostdiscovery
+
+import (
+	"net"
+
+	"github.com/docker/libnetwork/config"
+)
+
+// JoinCallback provides a callback event for new node joining the cluster
+type JoinCallback func(entries []net.IP)
+
+// LeaveCallback provides a callback event for node leaving the cluster
+type LeaveCallback func(entries []net.IP)
+
+// HostDiscovery primary interface
+type HostDiscovery interface {
+	// StartDiscovery initiates the discovery process and provides appropriate callbacks
+	StartDiscovery(*config.ClusterCfg, JoinCallback, LeaveCallback) error
+	// StopDiscovery stops the discovery perocess
+	StopDiscovery() error
+	// Fetch returns a list of host IPs that are currently discovered
+	Fetch() ([]net.IP, error)
+}

--- a/hostdiscovery/hostdiscovery_disabled.go
+++ b/hostdiscovery/hostdiscovery_disabled.go
@@ -1,0 +1,28 @@
+// +build !libnetwork_discovery
+
+package hostdiscovery
+
+import (
+	"net"
+
+	"github.com/docker/libnetwork/config"
+)
+
+type hostDiscovery struct{}
+
+// NewHostDiscovery function creates a host discovery object
+func NewHostDiscovery() HostDiscovery {
+	return &hostDiscovery{}
+}
+
+func (h *hostDiscovery) StartDiscovery(cfg *config.ClusterCfg, joinCallback JoinCallback, leaveCallback LeaveCallback) error {
+	return nil
+}
+
+func (h *hostDiscovery) StopDiscovery() error {
+	return nil
+}
+
+func (h *hostDiscovery) Fetch() ([]net.IP, error) {
+	return []net.IP{}, nil
+}

--- a/hostdiscovery/hostdiscovery_test.go
+++ b/hostdiscovery/hostdiscovery_test.go
@@ -1,3 +1,5 @@
+// +build libnetwork_discovery
+
 package hostdiscovery
 
 import (


### PR DESCRIPTION
In order to vendor-in libnetwork to docker, we need to remove the swarm
dependency even though it is used as library. using this PR, a new build
flag libnetwork_discovery is introduced in order to avoid pulling in the
unused hostdiscovery functionality into docker.
We are working with the Swarm project to see if we can modularize the
discovery package to become independent so that we can include them as a
vendor-in package in docker.