### PR TITLE
Update netns to include support for PowerPC LE (ppc64le) architecture

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -113,7 +113,7 @@
 		},
 		{
 			"ImportPath": "github.com/vishvananda/netns",
-			"Rev": "008d17ae001344769b031375bdb38a86219154c6"
+			"Rev": "5478c060110032f972e86a1f844fdb9a2f008f2c"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/vishvananda/netns/netns.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netns/netns.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"syscall"
 )
+
 // NsHandle is a handle to a network namespace. It can be cast directly
 // to an int and used as a file descriptor.
 type NsHandle int

--- a/Godeps/_workspace/src/github.com/vishvananda/netns/netns_linux.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netns/netns_linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netns
 
 import (

--- a/Godeps/_workspace/src/github.com/vishvananda/netns/netns_linux_386.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netns/netns_linux_386.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package netns
 
 const (

--- a/Godeps/_workspace/src/github.com/vishvananda/netns/netns_linux_amd64.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netns/netns_linux_amd64.go
@@ -1,3 +1,5 @@
+// +build linux,amd64
+
 package netns
 
 const (

--- a/Godeps/_workspace/src/github.com/vishvananda/netns/netns_linux_arm.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netns/netns_linux_arm.go
@@ -1,3 +1,5 @@
+// +build linux,arm
+
 package netns
 
 const (

--- a/Godeps/_workspace/src/github.com/vishvananda/netns/netns_linux_ppc64le.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netns/netns_linux_ppc64le.go
@@ -1,0 +1,7 @@
+// +build linux,ppc64le
+
+package netns
+
+const (
+	SYS_SETNS = 350
+)

--- a/Godeps/_workspace/src/github.com/vishvananda/netns/netns_unspecified.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netns/netns_unspecified.go
@@ -10,26 +10,26 @@ var (
 	ErrNotImplemented = errors.New("not implemented")
 )
 
-func Set(ns Namespace) (err error) {
+func Set(ns NsHandle) (err error) {
 	return ErrNotImplemented
 }
 
-func New() (ns Namespace, err error) {
+func New() (ns NsHandle, err error) {
 	return -1, ErrNotImplemented
 }
 
-func Get() (Namespace, error) {
+func Get() (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
-func GetFromName(name string) (Namespace, error) {
+func GetFromName(name string) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
-func GetFromPid(pid int) (Namespace, error) {
+func GetFromPid(pid int) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
-func GetFromDocker(id string) (Namespace, error) {
+func GetFromDocker(id string) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }


### PR DESCRIPTION
Current version of netns used in libnetwork do not have requisite syscall
entry for PowerPC (ppc64le) arch. Consequently docker which uses libnetwork fails
to create any network enabled containers on Power systems.

This patch updates netns to latest commit 5478c060110032f972e86a1f844fdb9a2f008f2c
to add ppc64le syscall entry.

Signed-off-by: Pradipta Kr. Banerjee <bpradip@in.ibm.com>