### PR TITLE
make libnetwork compile on freebsd

### DIFF
--- a/drivers_freebsd.go
+++ b/drivers_freebsd.go
@@ -1,0 +1,21 @@
+package libnetwork
+
+import (
+	"github.com/docker/libnetwork/driverapi"
+	"github.com/docker/libnetwork/drivers/null"
+	"github.com/docker/libnetwork/drivers/remote"
+)
+
+type driverTable map[string]driverapi.Driver
+
+func initDrivers(dc driverapi.DriverCallback) error {
+	for _, fn := range [](func(driverapi.DriverCallback) error){
+		null.Init,
+		remote.Init,
+	} {
+		if err := fn(dc); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Cross-platform network drivers are introduced, making a stub to be able to compile libnetwork in FreeBSD.