### PR TITLE
Add support to trigger immediate garbage collection

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -76,6 +76,9 @@ type NetworkController interface {
 
 	// NetworkByID returns the Network which has the passed id. If not found, the error ErrNoSuchNetwork is returned.
 	NetworkByID(id string) (Network, error)
+
+	// GC triggers immediate garbage collection of resources which are garbage collected.
+	GC()
 }
 
 // NetworkWalker is a client provided function which will be used to walk the Networks.
@@ -298,4 +301,8 @@ func (c *controller) loadDriver(networkType string) (driverapi.Driver, error) {
 		return nil, ErrInvalidNetworkDriver(networkType)
 	}
 	return d, nil
+}
+
+func (c *controller) GC() {
+	sandbox.GC()
 }

--- a/sandbox/sandbox_linux_test.go
+++ b/sandbox/sandbox_linux_test.go
@@ -144,9 +144,16 @@ func verifySandbox(t *testing.T, s Sandbox) {
 	}
 }
 
-func verifyCleanup(t *testing.T, s Sandbox) {
-	time.Sleep(time.Duration(gpmCleanupPeriod * 2))
+func verifyCleanup(t *testing.T, s Sandbox, wait bool) {
+	if wait {
+		time.Sleep(time.Duration(gpmCleanupPeriod * 2))
+	}
+
 	if _, err := os.Stat(s.Key()); err == nil {
-		t.Fatalf("The sandbox path %s is not getting cleanup event after twice the cleanup period", s.Key())
+		if wait {
+			t.Fatalf("The sandbox path %s is not getting cleaned up even after twice the cleanup period", s.Key())
+		} else {
+			t.Fatalf("The sandbox path %s is not cleaned up after running gc", s.Key())
+		}
 	}
 }

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -54,7 +54,7 @@ func TestSandboxCreate(t *testing.T) {
 
 	verifySandbox(t, s)
 	s.Destroy()
-	verifyCleanup(t, s)
+	verifyCleanup(t, s, true)
 }
 
 func TestSandboxCreateTwice(t *testing.T) {
@@ -75,6 +75,23 @@ func TestSandboxCreateTwice(t *testing.T) {
 		t.Fatalf("Failed to create a new sandbox: %v", err)
 	}
 	s.Destroy()
+}
+
+func TestSandboxGC(t *testing.T) {
+	key, err := newKey(t)
+	if err != nil {
+		t.Fatalf("Failed to obtain a key: %v", err)
+	}
+
+	s, err := NewSandbox(key, true)
+	if err != nil {
+		t.Fatalf("Failed to create a new sandbox: %v", err)
+	}
+
+	s.Destroy()
+
+	GC()
+	verifyCleanup(t, s, false)
 }
 
 func TestInterfaceEqual(t *testing.T) {


### PR DESCRIPTION
Right now the namespace paths are cleaned up every
garbage collection period. But if the daemon is restarted
before all the namespace paths of removed containers are
garbage collected they will remain there forever. The fix
is to provide a GC() api so that garbage collection can be
triggered immediately.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>