### PR TITLE
Windows: Allow compilation (again)

### DIFF
--- a/sandbox/namespace_unsupported.go
+++ b/sandbox/namespace_unsupported.go
@@ -1,0 +1,8 @@
+// +build !linux
+
+package sandbox
+
+// GC triggers garbage collection of namespace path right away
+// and waits for it.
+func GC() {
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@swernli @mrjana 

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. Commit https://github.com/docker/libnetwork/commit/d4a567660796d8f0f8e850d386172654133bbc40 breaks compilation on Windows. This PR fixes that.
