### PR TITLE
Check GC loop is active/necessary before triggering GC

### DIFF
--- a/sandbox/namespace_linux.go
+++ b/sandbox/namespace_linux.go
@@ -103,12 +103,20 @@ func removeFromGarbagePaths(path string) {
 // GC triggers garbage collection of namespace path right away
 // and waits for it.
 func GC() {
+	gpmLock.Lock()
+	if len(garbagePathMap) == 0 {
+		// No need for GC if map is empty
+		gpmLock.Unlock()
+		return
+	}
+	gpmLock.Unlock()
+
+	// if content exists in the garbage paths
+	// we can trigger GC to run, providing a
+	// channel to be notified on completion
 	waitGC := make(chan struct{})
-
-	// Trigger GC now
 	gpmChan <- waitGC
-
-	// wait for gc to complete
+	// wait for GC completion
 	<-waitGC
 }
 


### PR DESCRIPTION
Calling GC() without ever creating a network namespace (sandbox on
Linux) will hang as the GC loop is not running (and therefore the
channel is not being listened to).

Tested via Docker that this corrects a daemon shutdown error if the
daemon is started and stopped without any containers or networks being
created while the daemon is up.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>