### PR TITLE
Windows: Fix compile after SB interface

### DIFF
--- a/sandbox/interface_windows.go
+++ b/sandbox/interface_windows.go
@@ -1,0 +1,4 @@
+package sandbox
+
+// IfaceOption is a function option type to set interface options
+type IfaceOption func()

--- a/sandbox/namespace_unsupported.go
+++ b/sandbox/namespace_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!windows
 
 package sandbox
 

--- a/sandbox/namespace_windows.go
+++ b/sandbox/namespace_windows.go
@@ -1,0 +1,23 @@
+package sandbox
+
+// GenerateKey generates a sandbox key based on the passed
+// container id.
+func GenerateKey(containerID string) string {
+	maxLen := 12
+	if len(containerID) < maxLen {
+		maxLen = len(containerID)
+	}
+
+	return containerID[:maxLen]
+}
+
+// NewSandbox provides a new sandbox instance created in an os specific way
+// provided a key which uniquely identifies the sandbox
+func NewSandbox(key string, osCreate bool) (Sandbox, error) {
+	return nil, nil
+}
+
+// GC triggers garbage collection of namespace path right away
+// and waits for it.
+func GC() {
+}

--- a/sandbox/sandbox_unsupported.go
+++ b/sandbox/sandbox_unsupported.go
@@ -1,10 +1,11 @@
-// +build !linux
+// +build !linux,!windows
 
 package sandbox
 
 import "errors"
 
 var (
+	// ErrNotImplemented is for platforms which don't implement sandbox
 	ErrNotImplemented = errors.New("not implemented")
 )
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@swernli. After Sandbox was refactored to an Interface, Windows compilation was broken again. This fixes it up.