### PR TITLE
Separates the driver-specific and network-specific iptable operations

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1680,6 +1680,11 @@ func TestHttpHandlerUninit(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	err = c.ConfigureNetworkDriver(bridgeNetType, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	h := &httpHandler{c: c}
 	h.initRouter()
 	if h.r == nil {
@@ -1777,6 +1782,11 @@ func TestEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = c.ConfigureNetworkDriver(bridgeNetType, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	handleRequest := NewHTTPHandler(c)
 
 	ops := options.Generic{

--- a/drivers/bridge/link.go
+++ b/drivers/bridge/link.go
@@ -74,9 +74,9 @@ func linkContainers(action, parentIP, childIP string, ports []types.TransportPor
 		return InvalidLinkIPAddrError(childIP)
 	}
 
-	chain := iptables.Chain{Name: DockerChain, Bridge: bridge}
+	chain := iptables.ChainInfo{Name: DockerChain}
 	for _, port := range ports {
-		err := chain.Link(nfAction, ip1, ip2, int(port.Port), port.Proto.String())
+		err := chain.Link(nfAction, ip1, ip2, int(port.Port), port.Proto.String(), bridge)
 		if !ignoreErrors && err != nil {
 			return err
 		}

--- a/drivers/bridge/network_test.go
+++ b/drivers/bridge/network_test.go
@@ -14,6 +14,10 @@ func TestLinkCreate(t *testing.T) {
 	d := newDriver()
 	dr := d.(*driver)
 
+	if err := d.Config(nil); err != nil {
+		t.Fatalf("Failed to setup driver config: %v", err)
+	}
+
 	mtu := 1490
 	config := &networkConfiguration{
 		BridgeName: DefaultBridgeName,
@@ -108,6 +112,10 @@ func TestLinkCreateTwo(t *testing.T) {
 	defer netutils.SetupTestNetNS(t)()
 	d := newDriver()
 
+	if err := d.Config(nil); err != nil {
+		t.Fatalf("Failed to setup driver config: %v", err)
+	}
+
 	config := &networkConfiguration{
 		BridgeName: DefaultBridgeName,
 		EnableIPv6: true}
@@ -140,6 +148,10 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 	defer netutils.SetupTestNetNS(t)()
 	d := newDriver()
 
+	if err := d.Config(nil); err != nil {
+		t.Fatalf("Failed to setup driver config: %v", err)
+	}
+
 	config := &networkConfiguration{
 		BridgeName: DefaultBridgeName}
 	genericOption := make(map[string]interface{})
@@ -169,6 +181,10 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 func TestLinkDelete(t *testing.T) {
 	defer netutils.SetupTestNetNS(t)()
 	d := newDriver()
+
+	if err := d.Config(nil); err != nil {
+		t.Fatalf("Failed to setup driver config: %v", err)
+	}
 
 	config := &networkConfiguration{
 		BridgeName: DefaultBridgeName,

--- a/drivers/bridge/port_mapping_test.go
+++ b/drivers/bridge/port_mapping_test.go
@@ -21,6 +21,16 @@ func TestPortMappingConfig(t *testing.T) {
 	defer netutils.SetupTestNetNS(t)()
 	d := newDriver()
 
+	config := &configuration{
+		EnableIPTables: true,
+	}
+	genericOption := make(map[string]interface{})
+	genericOption[netlabel.GenericData] = config
+
+	if err := d.Config(genericOption); err != nil {
+		t.Fatalf("Failed to setup driver config: %v", err)
+	}
+
 	binding1 := types.PortBinding{Proto: types.UDP, Port: uint16(400), HostPort: uint16(54000)}
 	binding2 := types.PortBinding{Proto: types.TCP, Port: uint16(500), HostPort: uint16(65000)}
 	portBindings := []types.PortBinding{binding1, binding2}
@@ -29,8 +39,7 @@ func TestPortMappingConfig(t *testing.T) {
 	epOptions[netlabel.PortMap] = portBindings
 
 	netConfig := &networkConfiguration{
-		BridgeName:     DefaultBridgeName,
-		EnableIPTables: true,
+		BridgeName: DefaultBridgeName,
 	}
 	netOptions := make(map[string]interface{})
 	netOptions[netlabel.GenericData] = netConfig

--- a/drivers/bridge/setup_firewalld.go
+++ b/drivers/bridge/setup_firewalld.go
@@ -3,8 +3,13 @@ package bridge
 import "github.com/docker/libnetwork/iptables"
 
 func (n *bridgeNetwork) setupFirewalld(config *networkConfiguration, i *bridgeInterface) error {
+	d := n.driver
+	d.Lock()
+	driverConfig := d.config
+	d.Unlock()
+
 	// Sanity check.
-	if config.EnableIPTables == false {
+	if driverConfig.EnableIPTables == false {
 		return IPTableCfgError(config.BridgeName)
 	}
 

--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/netutils"
 )
@@ -13,13 +14,47 @@ const (
 	DockerChain = "DOCKER"
 )
 
-func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInterface) error {
+func setupIPChains(config *configuration) (*iptables.ChainInfo, *iptables.ChainInfo, error) {
 	// Sanity check.
 	if config.EnableIPTables == false {
-		return IPTableCfgError(config.BridgeName)
+		return nil, nil, fmt.Errorf("Cannot create new chains, EnableIPTable is disabled")
 	}
 
 	hairpinMode := !config.EnableUserlandProxy
+
+	natChain, err := iptables.NewChain(DockerChain, iptables.Nat, hairpinMode)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create NAT chain: %s", err.Error())
+	}
+	defer func() {
+		if err != nil {
+			if err := iptables.RemoveExistingChain(DockerChain, iptables.Nat); err != nil {
+				logrus.Warnf("Failed on removing iptables NAT chain on cleanup: %v", err)
+			}
+		}
+	}()
+
+	filterChain, err := iptables.NewChain(DockerChain, iptables.Filter, hairpinMode)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create FILTER chain: %s", err.Error())
+	}
+
+	return natChain, filterChain, nil
+}
+
+func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInterface) error {
+	d := n.driver
+	d.Lock()
+	driverConfig := d.config
+	d.Unlock()
+
+	// Sanity check.
+	if driverConfig.EnableIPTables == false {
+		return fmt.Errorf("Cannot program chains, EnableIPTable is disabled")
+	}
+
+	// Pickup this configuraton option from driver
+	hairpinMode := !driverConfig.EnableUserlandProxy
 
 	addrv4, _, err := netutils.GetIfaceAddr(config.BridgeName)
 	if err != nil {
@@ -34,17 +69,22 @@ func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInt
 		return fmt.Errorf("Failed to Setup IP tables: %s", err.Error())
 	}
 
-	_, err = iptables.NewChain(DockerChain, config.BridgeName, iptables.Nat, hairpinMode)
+	natChain, filterChain, err := n.getDriverChains()
 	if err != nil {
-		return fmt.Errorf("Failed to create NAT chain: %s", err.Error())
+		return fmt.Errorf("Failed to setup IP tables, cannot acquire chain info %s", err.Error())
 	}
 
-	chain, err := iptables.NewChain(DockerChain, config.BridgeName, iptables.Filter, hairpinMode)
+	err = iptables.ProgramChain(natChain, config.BridgeName, hairpinMode)
 	if err != nil {
-		return fmt.Errorf("Failed to create FILTER chain: %s", err.Error())
+		return fmt.Errorf("Failed to program NAT chain: %s", err.Error())
 	}
 
-	n.portMapper.SetIptablesChain(chain)
+	err = iptables.ProgramChain(filterChain, config.BridgeName, hairpinMode)
+	if err != nil {
+		return fmt.Errorf("Failed to program FILTER chain: %s", err.Error())
+	}
+
+	n.portMapper.SetIptablesChain(filterChain, n.getNetworkBridgeName())
 
 	return nil
 }

--- a/iptables/firewalld_test.go
+++ b/iptables/firewalld_test.go
@@ -17,9 +17,12 @@ func TestFirewalldInit(t *testing.T) {
 
 func TestReloaded(t *testing.T) {
 	var err error
-	var fwdChain *Chain
+	var fwdChain *ChainInfo
 
-	fwdChain, err = NewChain("FWD", "lo", Filter, false)
+	fwdChain, err = NewChain("FWD", Filter, false)
+	bridgeName := "lo"
+
+	err = ProgramChain(fwdChain, bridgeName, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,17 +34,17 @@ func TestReloaded(t *testing.T) {
 	port := 1234
 	proto := "tcp"
 
-	err = fwdChain.Link(Append, ip1, ip2, port, proto)
+	err = fwdChain.Link(Append, ip1, ip2, port, proto, bridgeName)
 	if err != nil {
 		t.Fatal(err)
 	} else {
 		// to be re-called again later
-		OnReloaded(func() { fwdChain.Link(Append, ip1, ip2, port, proto) })
+		OnReloaded(func() { fwdChain.Link(Append, ip1, ip2, port, proto, bridgeName) })
 	}
 
 	rule1 := []string{
-		"-i", fwdChain.Bridge,
-		"-o", fwdChain.Bridge,
+		"-i", bridgeName,
+		"-o", bridgeName,
 		"-p", proto,
 		"-s", ip1.String(),
 		"-d", ip2.String(),

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -251,10 +251,9 @@ func TestBridge(t *testing.T) {
 			"FixedCIDR":             cidr,
 			"FixedCIDRv6":           cidrv6,
 			"EnableIPv6":            true,
-			"EnableIPTables":        true,
-			"EnableIPMasquerade":    true,
 			"EnableICC":             true,
 			"AllowNonDefaultBridge": true,
+			"EnableIPMasquerade":    true,
 		},
 	}
 

--- a/portmapper/mapper.go
+++ b/portmapper/mapper.go
@@ -31,7 +31,8 @@ var (
 
 // PortMapper manages the network address translation
 type PortMapper struct {
-	chain *iptables.Chain
+	chain      *iptables.ChainInfo
+	bridgeName string
 
 	// udp:ip:port
 	currentMappings map[string]*mapping
@@ -54,8 +55,9 @@ func NewWithPortAllocator(allocator *portallocator.PortAllocator) *PortMapper {
 }
 
 // SetIptablesChain sets the specified chain into portmapper
-func (pm *PortMapper) SetIptablesChain(c *iptables.Chain) {
+func (pm *PortMapper) SetIptablesChain(c *iptables.ChainInfo, bridgeName string) {
 	pm.chain = c
+	pm.bridgeName = bridgeName
 }
 
 // Map maps the specified container transport address to the host's network address and transport port
@@ -215,5 +217,5 @@ func (pm *PortMapper) forward(action iptables.Action, proto string, sourceIP net
 	if pm.chain == nil {
 		return nil
 	}
-	return pm.chain.Forward(action, sourceIP, sourcePort, proto, containerIP, containerPort)
+	return pm.chain.Forward(action, sourceIP, sourcePort, proto, containerIP, containerPort, pm.bridgeName)
 }

--- a/portmapper/mapper_test.go
+++ b/portmapper/mapper_test.go
@@ -17,16 +17,15 @@ func init() {
 func TestSetIptablesChain(t *testing.T) {
 	pm := New()
 
-	c := &iptables.Chain{
-		Name:   "TEST",
-		Bridge: "192.168.1.1",
+	c := &iptables.ChainInfo{
+		Name: "TEST",
 	}
 
 	if pm.chain != nil {
 		t.Fatal("chain should be nil at init")
 	}
 
-	pm.SetIptablesChain(c)
+	pm.SetIptablesChain(c, "lo")
 	if pm.chain == nil {
 		t.Fatal("chain should not be nil after set")
 	}


### PR DESCRIPTION
for the bridge driver. Moves two config options, namely EnableIPTables and EnableUserlandProxy
from networks to the driver. Fixes #242 

Signed-off-by: Mohammad Banikazemi <MBanikazemi@gmail.com>