### PR TITLE
Cherry-picked : enable hairpin mode on the bridge port & fix iptables rule

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -876,6 +876,13 @@ func (d *driver) CreateEndpoint(nid, eid types.UUID, epInfo driverapi.EndpointIn
 		return err
 	}
 
+	if !config.EnableUserlandProxy {
+		err = netlink.LinkSetHairpin(host, true)
+		if err != nil {
+			return err
+		}
+	}
+
 	// v4 address for the sandbox side pipe interface
 	ip4, err := ipAllocator.RequestIP(n.bridge.bridgeIPv4, nil)
 	if err != nil {

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -44,9 +44,10 @@ var (
 
 // Chain defines the iptables chain.
 type Chain struct {
-	Name   string
-	Bridge string
-	Table  Table
+	Name        string
+	Bridge      string
+	Table       Table
+	HairpinMode bool
 }
 
 // ChainError is returned to represent errors during ip table operation.
@@ -75,9 +76,10 @@ func initCheck() error {
 // NewChain adds a new chain to ip table.
 func NewChain(name, bridge string, table Table, hairpinMode bool) (*Chain, error) {
 	c := &Chain{
-		Name:   name,
-		Bridge: bridge,
-		Table:  table,
+		Name:        name,
+		Bridge:      bridge,
+		Table:       table,
+		HairpinMode: hairpinMode,
 	}
 
 	if string(c.Table) == "" {
@@ -151,12 +153,16 @@ func (c *Chain) Forward(action Action, ip net.IP, port int, proto, destAddr stri
 		// value" by both iptables and ip6tables.
 		daddr = "0/0"
 	}
-	if output, err := Raw("-t", string(Nat), string(action), c.Name,
+	args := []string{"-t", string(Nat), string(action), c.Name,
 		"-p", proto,
 		"-d", daddr,
 		"--dport", strconv.Itoa(port),
 		"-j", "DNAT",
-		"--to-destination", net.JoinHostPort(destAddr, strconv.Itoa(destPort))); err != nil {
+		"--to-destination", net.JoinHostPort(destAddr, strconv.Itoa(destPort))}
+	if !c.HairpinMode {
+		args = append(args, "!", "-i", c.Bridge)
+	}
+	if output, err := Raw(args...); err != nil {
 		return err
 	} else if len(output) != 0 {
 		return ChainError{Chain: "FORWARD", Output: output}

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -48,6 +48,7 @@ func TestForward(t *testing.T) {
 		"--dport", strconv.Itoa(port),
 		"-j", "DNAT",
 		"--to-destination", dstAddr + ":" + strconv.Itoa(dstPort),
+		"!", "-i", natChain.Bridge,
 	}
 
 	if !Exists(natChain.Table, natChain.Name, dnatRule...) {


### PR DESCRIPTION
* When userland-proxy is disabled, enable hairpin mode on the host-side of the veth
* When userland-proxy is enabled, fix the iptable rules appropriately

Signed-off-by: Madhu Venugopal <madhu@docker.com>