### PR TITLE
Moved the TOML based Configuration to dnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are many networking solutions available to suit a broad range of use-cases
 
 ```go
         // Create a new controller instance
-        controller := libnetwork.New("/etc/default/libnetwork.toml")
+        controller := libnetwork.New()
 
         // Select and configure the network driver
         networkType := "bridge"

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -79,7 +79,7 @@ func i2cL(i interface{}) []*containerResource {
 }
 
 func createTestNetwork(t *testing.T, network string) (libnetwork.NetworkController, libnetwork.Network) {
-	c, err := libnetwork.New("")
+	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +174,7 @@ func TestJson(t *testing.T) {
 func TestCreateDeleteNetwork(t *testing.T) {
 	defer netutils.SetupTestNetNS(t)()
 
-	c, err := libnetwork.New("")
+	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ func TestCreateDeleteNetwork(t *testing.T) {
 func TestGetNetworksAndEndpoints(t *testing.T) {
 	defer netutils.SetupTestNetNS(t)()
 
-	c, err := libnetwork.New("")
+	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -525,7 +525,7 @@ func TestGetNetworksAndEndpoints(t *testing.T) {
 func TestProcGetServices(t *testing.T) {
 	defer netutils.SetupTestNetNS(t)()
 
-	c, err := libnetwork.New("")
+	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1001,7 +1001,7 @@ func TestAttachDetachBackend(t *testing.T) {
 }
 
 func TestDetectGetNetworksInvalidQueryComposition(t *testing.T) {
-	c, err := libnetwork.New("")
+	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1108,7 +1108,7 @@ func TestFindNetworkUtil(t *testing.T) {
 func TestCreateDeleteEndpoints(t *testing.T) {
 	defer netutils.SetupTestNetNS(t)()
 
-	c, err := libnetwork.New("")
+	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1234,7 +1234,7 @@ func TestCreateDeleteEndpoints(t *testing.T) {
 func TestJoinLeave(t *testing.T) {
 	defer netutils.SetupTestNetNS(t)()
 
-	c, err := libnetwork.New("")
+	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1674,7 +1674,7 @@ func TestwriteJSON(t *testing.T) {
 func TestHttpHandlerUninit(t *testing.T) {
 	defer netutils.SetupTestNetNS(t)()
 
-	c, err := libnetwork.New("")
+	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1740,7 +1740,7 @@ func TestHttpHandlerBadBody(t *testing.T) {
 
 	rsp := newWriter()
 
-	c, err := libnetwork.New("")
+	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1772,7 +1772,7 @@ func TestEndToEnd(t *testing.T) {
 
 	rsp := newWriter()
 
-	c, err := libnetwork.New("")
+	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/service.go
+++ b/client/service.go
@@ -15,8 +15,8 @@ var (
 	serviceCommands = []command{
 		{"publish", "Publish a service"},
 		{"unpublish", "Remove a service"},
-		{"attach", "Attach a provider (container) to the service"},
-		{"detach", "Detach the provider from the service"},
+		{"attach", "Attach a backend (container) to the service"},
+		{"detach", "Detach the backend from the service"},
 		{"ls", "Lists all services"},
 		{"info", "Display information about a service"},
 	}
@@ -189,7 +189,7 @@ func (cli *NetworkCli) CmdServiceLs(chain string, args ...string) error {
 	wr := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
 	// unless quiet (-q) is specified, print field titles
 	if !*quiet {
-		fmt.Fprintln(wr, "SERVICE ID\tNAME\tNETWORK\tPROVIDER")
+		fmt.Fprintln(wr, "SERVICE ID\tNAME\tNETWORK\tCONTAINER")
 	}
 
 	for _, sr := range serviceResources {
@@ -228,7 +228,7 @@ func getBackendID(cli *NetworkCli, servID string) (string, error) {
 			}
 		} else {
 			// Only print a message, don't make the caller cli fail for this
-			fmt.Fprintf(cli.out, "Failed to retrieve provider list for service %s (%v)", servID, err)
+			fmt.Fprintf(cli.out, "Failed to retrieve backend list for service %s (%v)", servID, err)
 		}
 	}
 

--- a/cmd/dnet/flags.go
+++ b/cmd/dnet/flags.go
@@ -19,6 +19,7 @@ var (
 	flHost     = flag.String([]string{"H", "-host"}, "", "Daemon socket to connect to")
 	flLogLevel = flag.String([]string{"l", "-log-level"}, "info", "Set the logging level")
 	flDebug    = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
+	flCfgFile  = flag.String([]string{"c", "-cfg-file"}, "/etc/default/libnetwork.toml", "Configuration file")
 	flHelp     = flag.Bool([]string{"h", "-help"}, false, "Print usage")
 
 	dnetCommands = []command{

--- a/cmd/readme_test/readme.go
+++ b/cmd/readme_test/readme.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	// Create a new controller instance
-	controller, err := libnetwork.New("/etc/default/libnetwork.toml")
+	controller, err := libnetwork.New()
 	if err != nil {
 		return
 	}

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net"
-	"os"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -14,8 +13,7 @@ import (
 
 func main() {
 	log.SetLevel(log.DebugLevel)
-	os.Setenv("LIBNETWORK_CFG", "libnetwork.toml")
-	controller, err := libnetwork.New("libnetwork.toml")
+	controller, err := libnetwork.New()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,10 @@
 package config
 
-import "github.com/BurntSushi/toml"
+import (
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
 
 // Config encapsulates configurations of various Libnetwork components
 type Config struct {
@@ -11,7 +15,9 @@ type Config struct {
 
 // DaemonCfg represents libnetwork core configuration
 type DaemonCfg struct {
-	Debug bool
+	Debug          bool
+	DefaultNetwork string
+	DefaultDriver  string
 }
 
 // ClusterCfg represents cluster configuration
@@ -40,4 +46,45 @@ func ParseConfig(tomlCfgFile string) (*Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+// Option is a option setter function type used to pass varios configurations
+// to the controller
+type Option func(c *Config)
+
+// OptionDefaultNetwork function returns an option setter for a default network
+func OptionDefaultNetwork(dn string) Option {
+	return func(c *Config) {
+		c.Daemon.DefaultNetwork = strings.TrimSpace(dn)
+	}
+}
+
+// OptionDefaultDriver function returns an option setter for default driver
+func OptionDefaultDriver(dd string) Option {
+	return func(c *Config) {
+		c.Daemon.DefaultDriver = strings.TrimSpace(dd)
+	}
+}
+
+// OptionKVProvider function returns an option setter for kvstore provider
+func OptionKVProvider(provider string) Option {
+	return func(c *Config) {
+		c.Datastore.Client.Provider = strings.TrimSpace(provider)
+	}
+}
+
+// OptionKVProviderURL function returns an option setter for kvstore url
+func OptionKVProviderURL(url string) Option {
+	return func(c *Config) {
+		c.Datastore.Client.Address = strings.TrimSpace(url)
+	}
+}
+
+// ProcessOptions processes options and stores it in config
+func (c *Config) ProcessOptions(options ...Option) {
+	for _, opt := range options {
+		if opt != nil {
+			opt(c)
+		}
+	}
 }

--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestDriverRegistration(t *testing.T) {
 	bridgeNetType := "bridge"
-	c, err := New("")
+	c, err := New()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -63,7 +63,7 @@ func TestMain(m *testing.M) {
 func createController() error {
 	var err error
 
-	controller, err = libnetwork.New("")
+	controller, err = libnetwork.New()
 	if err != nil {
 		return err
 	}
@@ -1665,7 +1665,7 @@ func TestInvalidRemoteDriver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	controller, err := libnetwork.New("")
+	controller, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/store.go
+++ b/store.go
@@ -9,11 +9,18 @@ import (
 	"github.com/docker/libnetwork/types"
 )
 
+func (c *controller) validateDatastoreConfig() bool {
+	if c.cfg == nil || c.cfg.Datastore.Client.Provider == "" || c.cfg.Datastore.Client.Address == "" {
+		return false
+	}
+	return true
+}
+
 func (c *controller) initDataStore() error {
 	c.Lock()
 	cfg := c.cfg
 	c.Unlock()
-	if cfg == nil {
+	if !c.validateDatastoreConfig() {
 		return fmt.Errorf("datastore initialization requires a valid configuration")
 	}
 


### PR DESCRIPTION
The configuration format for docker runtime is based on daemon flags and
hence adjusting the libnetwork configuration to accomodate it by moving
the TOML based configuration to the dnet tool.

Also changed the controller configuration via options

Signed-off-by: Madhu Venugopal <madhu@docker.com>