### PR TITLE
Return an empty config if nil

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -169,6 +169,9 @@ func (c *controller) hostLeaveCallback(hosts []net.IP) {
 func (c *controller) Config() config.Config {
 	c.Lock()
 	defer c.Unlock()
+	if c.cfg == nil {
+		return config.Config{}
+	}
 	return *c.cfg
 }
 


### PR DESCRIPTION
Since the Config is a read-only entity, Confg() method returned a value
instead of the pointer. In cases the config is nil, we should return an
empty config.

Signed-off-by: Madhu Venugopal <madhu@docker.com>