### PR TITLE
Few changes to the UI and API implementation

### DIFF
--- a/client/client_service_test.go
+++ b/client/client_service_test.go
@@ -21,7 +21,7 @@ func TestClientServiceCreate(t *testing.T) {
 	var out, errOut bytes.Buffer
 	cli := NewNetworkCli(&out, &errOut, callbackFunc)
 
-	err := cli.Cmd("docker", "service", "publish", "-net="+mockNwName, mockServiceName)
+	err := cli.Cmd("docker", "service", "publish", mockServiceName+"."+mockNwName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func TestClientServiceRm(t *testing.T) {
 	var out, errOut bytes.Buffer
 	cli := NewNetworkCli(&out, &errOut, callbackFunc)
 
-	err := cli.Cmd("docker", "service", "unpublish", "-net="+mockNwName, mockServiceName)
+	err := cli.Cmd("docker", "service", "unpublish", mockServiceName+"."+mockNwName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestClientServiceInfo(t *testing.T) {
 	var out, errOut bytes.Buffer
 	cli := NewNetworkCli(&out, &errOut, callbackFunc)
 
-	err := cli.Cmd("docker", "service", "info", "-net="+mockNwName, mockServiceName)
+	err := cli.Cmd("docker", "service", "info", mockServiceName+"."+mockNwName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestClientServiceInfoById(t *testing.T) {
 	var out, errOut bytes.Buffer
 	cli := NewNetworkCli(&out, &errOut, callbackFunc)
 
-	err := cli.Cmd("docker", "service", "info", "-net="+mockNwName, mockServiceID)
+	err := cli.Cmd("docker", "service", "info", mockServiceID+"."+mockNwName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestClientServiceJoin(t *testing.T) {
 	var out, errOut bytes.Buffer
 	cli := NewNetworkCli(&out, &errOut, callbackFunc)
 
-	err := cli.Cmd("docker", "service", "attach", "-net="+mockNwName, mockContainerID, mockServiceName)
+	err := cli.Cmd("docker", "service", "attach", mockContainerID, mockServiceName+"."+mockNwName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestClientServiceLeave(t *testing.T) {
 	var out, errOut bytes.Buffer
 	cli := NewNetworkCli(&out, &errOut, callbackFunc)
 
-	err := cli.Cmd("docker", "service", "detach", "-net="+mockNwName, mockContainerID, mockServiceName)
+	err := cli.Cmd("docker", "service", "detach", mockContainerID, mockServiceName+"."+mockNwName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/network.go
+++ b/client/network.go
@@ -9,11 +9,6 @@ import (
 
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/docker/libnetwork/netlabel"
-)
-
-const (
-	defaultDriverType = "bridge"
 )
 
 type command struct {
@@ -45,28 +40,16 @@ func (cli *NetworkCli) CmdNetwork(chain string, args ...string) error {
 // CmdNetworkCreate handles Network Create UI
 func (cli *NetworkCli) CmdNetworkCreate(chain string, args ...string) error {
 	cmd := cli.Subcmd(chain, "create", "NETWORK-NAME", "Creates a new network with a name specified by the user", false)
-	flDriver := cmd.String([]string{"d", "-driver"}, "bridge", "Driver to manage the Network")
-	cmd.Require(flag.Min, 1)
+	flDriver := cmd.String([]string{"d", "-driver"}, "", "Driver to manage the Network")
+	cmd.Require(flag.Exact, 1)
 	err := cmd.ParseFlags(args, true)
 	if err != nil {
 		return err
-	}
-	if *flDriver == "" {
-		*flDriver = defaultDriverType
 	}
 
 	// Construct network create request body
 	ops := make(map[string]interface{})
 	nc := networkCreate{Name: cmd.Arg(0), NetworkType: *flDriver, Options: ops}
-
-	// Set driver specific options
-	if *flDriver == "bridge" {
-		ops[netlabel.GenericData] = map[string]string{
-			"BridgeName":            cmd.Arg(0),
-			"AllowNonDefaultBridge": "true",
-		}
-	}
-
 	obj, _, err := readBody(cli.call("POST", "/networks", nc, nil))
 	if err != nil {
 		return err
@@ -83,7 +66,7 @@ func (cli *NetworkCli) CmdNetworkCreate(chain string, args ...string) error {
 // CmdNetworkRm handles Network Delete UI
 func (cli *NetworkCli) CmdNetworkRm(chain string, args ...string) error {
 	cmd := cli.Subcmd(chain, "rm", "NETWORK", "Deletes a network", false)
-	cmd.Require(flag.Min, 1)
+	cmd.Require(flag.Exact, 1)
 	err := cmd.ParseFlags(args, true)
 	if err != nil {
 		return err
@@ -155,7 +138,7 @@ func (cli *NetworkCli) CmdNetworkLs(chain string, args ...string) error {
 // CmdNetworkInfo handles Network Info UI
 func (cli *NetworkCli) CmdNetworkInfo(chain string, args ...string) error {
 	cmd := cli.Subcmd(chain, "info", "NETWORK", "Displays detailed information on a network", false)
-	cmd.Require(flag.Min, 1)
+	cmd.Require(flag.Exact, 1)
 	err := cmd.ParseFlags(args, true)
 	if err != nil {
 		return err

--- a/cmd/dnet/libnetwork.toml
+++ b/cmd/dnet/libnetwork.toml
@@ -1,0 +1,11 @@
+title = "LibNetwork Configuration file"
+
+[daemon]
+  debug = false
+  DefaultNetwork = "bridge"
+  DefaultDriver = "bridge"
+[cluster]
+  discovery = "token://22aa23948f4f6b31230687689636959e"
+  Address = "1.1.1.1"
+[datastore]
+  embedded = false

--- a/config/config.go
+++ b/config/config.go
@@ -101,3 +101,11 @@ func (c *Config) ProcessOptions(options ...Option) {
 		}
 	}
 }
+
+// IsValidName validates configuration objects supported by libnetwork
+func IsValidName(name string) bool {
+	if name == "" || strings.Contains(name, ".") {
+		return false
+	}
+	return true
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -41,3 +41,15 @@ func TestOptionsLabels(t *testing.T) {
 		}
 	}
 }
+
+func TestValidName(t *testing.T) {
+	if !IsValidName("test") {
+		t.Fatal("Name validation fails for a name that must be accepted")
+	}
+	if IsValidName("") {
+		t.Fatal("Name validation succeeds for a case when it is expected to fail")
+	}
+	if IsValidName("name.with.dots") {
+		t.Fatal("Name validation succeeds for a case when it is expected to fail")
+	}
+}

--- a/controller.go
+++ b/controller.go
@@ -188,6 +188,9 @@ func (c *controller) ConfigureNetworkDriver(networkType string, options map[stri
 func (c *controller) RegisterDriver(networkType string, driver driverapi.Driver, capability driverapi.Capability) error {
 	c.Lock()
 	defer c.Unlock()
+	if !config.IsValidName(networkType) {
+		return ErrInvalidName(networkType)
+	}
 	if _, ok := c.drivers[networkType]; ok {
 		return driverapi.ErrActiveRegistration(networkType)
 	}
@@ -198,7 +201,7 @@ func (c *controller) RegisterDriver(networkType string, driver driverapi.Driver,
 // NewNetwork creates a new network of the specified network type. The options
 // are network specific and modeled in a generic way.
 func (c *controller) NewNetwork(networkType, name string, options ...NetworkOption) (Network, error) {
-	if name == "" {
+	if !config.IsValidName(name) {
 		return nil, ErrInvalidName(name)
 	}
 	// Check if a network already exists with the specified network name

--- a/network.go
+++ b/network.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netlabel"
@@ -274,7 +275,7 @@ func (n *network) addEndpoint(ep *endpoint) error {
 
 func (n *network) CreateEndpoint(name string, options ...EndpointOption) (Endpoint, error) {
 	var err error
-	if name == "" {
+	if !config.IsValidName(name) {
 		return nil, ErrInvalidName(name)
 	}
 


### PR DESCRIPTION
1. replaced --net option for service UI with SERVICE.[NETWORK] format
2. Making using of the default network/driver backend support
3. NetworkName and NetworkType from the UI/API can be empty string
   and it will be replaced with DefaultNetwork and DefaultDriver

As per the design goals, we wanted to keep libnetwork core free of
handling defaults. Rather, the clients (docker & dnet) must handle the
defaultness of these entities.
Also, since there is no API to get these Default values from the
backend, UI will not handle the default values either.

Signed-off-by: Madhu Venugopal <madhu@docker.com>