### PR TITLE
Fix duplicated iptables rules

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -99,7 +99,8 @@ func NewChain(name, bridge string, table Table, hairpinMode bool) (*Chain, error
 	case Nat:
 		preroute := []string{
 			"-m", "addrtype",
-			"--dst-type", "LOCAL"}
+			"--dst-type", "LOCAL",
+			"-j", c.Name}
 		if !Exists(Nat, "PREROUTING", preroute...) {
 			if err := c.Prerouting(Append, preroute...); err != nil {
 				return nil, fmt.Errorf("Failed to inject docker in PREROUTING chain: %s", err)
@@ -107,7 +108,8 @@ func NewChain(name, bridge string, table Table, hairpinMode bool) (*Chain, error
 		}
 		output := []string{
 			"-m", "addrtype",
-			"--dst-type", "LOCAL"}
+			"--dst-type", "LOCAL",
+			"-j", c.Name}
 		if !hairpinMode {
 			output = append(output, "!", "--dst", "127.0.0.0/8")
 		}
@@ -228,7 +230,7 @@ func (c *Chain) Prerouting(action Action, args ...string) error {
 	if len(args) > 0 {
 		a = append(a, args...)
 	}
-	if output, err := Raw(append(a, "-j", c.Name)...); err != nil {
+	if output, err := Raw(a...); err != nil {
 		return err
 	} else if len(output) != 0 {
 		return ChainError{Chain: "PREROUTING", Output: output}
@@ -242,7 +244,7 @@ func (c *Chain) Output(action Action, args ...string) error {
 	if len(args) > 0 {
 		a = append(a, args...)
 	}
-	if output, err := Raw(append(a, "-j", c.Name)...); err != nil {
+	if output, err := Raw(a...); err != nil {
 		return err
 	} else if len(output) != 0 {
 		return ChainError{Chain: "OUTPUT", Output: output}
@@ -254,9 +256,9 @@ func (c *Chain) Output(action Action, args ...string) error {
 func (c *Chain) Remove() error {
 	// Ignore errors - This could mean the chains were never set up
 	if c.Table == Nat {
-		c.Prerouting(Delete, "-m", "addrtype", "--dst-type", "LOCAL")
-		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "!", "--dst", "127.0.0.0/8")
-		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL") // Created in versions <= 0.1.6
+		c.Prerouting(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "-j", c.Name)
+		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "!", "--dst", "127.0.0.0/8", "-j", c.Name)
+		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "-j", c.Name) // Created in versions <= 0.1.6
 
 		c.Prerouting(Delete)
 		c.Output(Delete)

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -131,16 +131,11 @@ func TestPrerouting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rule := []string{
-		"-j", natChain.Name}
-
-	rule = append(rule, args...)
-
-	if !Exists(natChain.Table, "PREROUTING", rule...) {
+	if !Exists(natChain.Table, "PREROUTING", args...) {
 		t.Fatalf("rule does not exist")
 	}
 
-	delRule := append([]string{"-D", "PREROUTING", "-t", string(Nat)}, rule...)
+	delRule := append([]string{"-D", "PREROUTING", "-t", string(Nat)}, args...)
 	if _, err = Raw(delRule...); err != nil {
 		t.Fatal(err)
 	}
@@ -156,17 +151,12 @@ func TestOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rule := []string{
-		"-j", natChain.Name}
-
-	rule = append(rule, args...)
-
-	if !Exists(natChain.Table, "OUTPUT", rule...) {
+	if !Exists(natChain.Table, "OUTPUT", args...) {
 		t.Fatalf("rule does not exist")
 	}
 
 	delRule := append([]string{"-D", "OUTPUT", "-t",
-		string(natChain.Table)}, rule...)
+		string(natChain.Table)}, args...)
 	if _, err = Raw(delRule...); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The `iptables.Exists` function is wrong in two ways:
1. The iptables -C call doesn't add `-j DOCKER` and fails to match
2. The long path takes ordering into account in comparison and fails to match

This patch fixes issue 1 by including `-j DOCKER` in the check.

Sorry for the lack of test: it's super late and I can't think anymore, but we definitely need to add one (I can try and do this tomorrow, or feel free to PR against my branch and I'll take it).

Fixes docker/docker#13956