### PR TITLE
Cleaning up iptables nat table on driver bootup

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/ipallocator"
+	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/netutils"
 	"github.com/docker/libnetwork/options"
@@ -110,6 +111,10 @@ func Init(dc driverapi.DriverCallback) error {
 	if out, err := exec.Command("modprobe", "-va", "bridge", "nf_nat", "br_netfilter").Output(); err != nil {
 		logrus.Warnf("Running modprobe bridge nf_nat failed with message: %s, error: %v", out, err)
 	}
+	if err := iptables.RemoveExistingChain(DockerChain, iptables.Nat); err != nil {
+		logrus.Warnf("Failed to remove existing iptables entries in %s : %v", DockerChain, err)
+	}
+
 	c := driverapi.Capability{
 		Scope: driverapi.LocalScope,
 	}


### PR DESCRIPTION
This is required to have consistent behaviour as in 1.6.2.

Signed-off-by: Madhu Venugopal <madhu@docker.com>