### PR TITLE
Update modprobe bridge output

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -108,8 +108,8 @@ func newDriver() driverapi.Driver {
 func Init(dc driverapi.DriverCallback) error {
 	// try to modprobe bridge first
 	// see gh#12177
-	if out, err := exec.Command("modprobe", "-va", "bridge", "nf_nat", "br_netfilter").Output(); err != nil {
-		logrus.Warnf("Running modprobe bridge nf_nat failed with message: %s, error: %v", out, err)
+	if out, err := exec.Command("modprobe", "-va", "bridge", "nf_nat", "br_netfilter").CombinedOutput(); err != nil {
+		logrus.Warnf("Running modprobe bridge nf_nat br_netfilter failed with message: %s, error: %v", out, err)
 	}
 	if err := iptables.RemoveExistingChain(DockerChain, iptables.Nat); err != nil {
 		logrus.Warnf("Failed to remove existing iptables entries in %s : %v", DockerChain, err)


### PR DESCRIPTION
In my host, it prints a warning, there's no useful error message:
```
WARN[0000] Running modprobe bridge nf_nat failed with message: , error: exit status 1 
```
I figure out this is because of missing br_netfilter module, so I just update the code to make it clearer.