### PR TITLE
Fix endpoint container nil pointer error

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -793,6 +793,9 @@ func EndpointOptionGeneric(generic map[string]interface{}) EndpointOption {
 // be passed to endpoint Join method.
 func JoinOptionPriority(prio int) EndpointOption {
 	return func(ep *endpoint) {
+		if ep.container == nil {
+			return
+		}
 		ep.container.config.prio = prio
 	}
 }
@@ -801,6 +804,9 @@ func JoinOptionPriority(prio int) EndpointOption {
 // be passed to endpoint Join method.
 func JoinOptionHostname(name string) EndpointOption {
 	return func(ep *endpoint) {
+		if ep.container == nil {
+			return
+		}
 		ep.container.config.hostName = name
 	}
 }
@@ -809,6 +815,9 @@ func JoinOptionHostname(name string) EndpointOption {
 // be passed to endpoint Join method.
 func JoinOptionDomainname(name string) EndpointOption {
 	return func(ep *endpoint) {
+		if ep.container == nil {
+			return
+		}
 		ep.container.config.domainName = name
 	}
 }
@@ -817,6 +826,9 @@ func JoinOptionDomainname(name string) EndpointOption {
 // be passed to endpoint Join method.
 func JoinOptionHostsPath(path string) EndpointOption {
 	return func(ep *endpoint) {
+		if ep.container == nil {
+			return
+		}
 		ep.container.config.hostsPath = path
 	}
 }
@@ -825,6 +837,9 @@ func JoinOptionHostsPath(path string) EndpointOption {
 // which is a name and IP as strings.
 func JoinOptionExtraHost(name string, IP string) EndpointOption {
 	return func(ep *endpoint) {
+		if ep.container == nil {
+			return
+		}
 		ep.container.config.extraHosts = append(ep.container.config.extraHosts, extraHost{name: name, IP: IP})
 	}
 }
@@ -833,6 +848,9 @@ func JoinOptionExtraHost(name string, IP string) EndpointOption {
 // which needs to update the IP address for the linked container.
 func JoinOptionParentUpdate(eid string, name, ip string) EndpointOption {
 	return func(ep *endpoint) {
+		if ep.container == nil {
+			return
+		}
 		ep.container.config.parentUpdates = append(ep.container.config.parentUpdates, parentUpdate{eid: eid, name: name, ip: ip})
 	}
 }
@@ -841,6 +859,9 @@ func JoinOptionParentUpdate(eid string, name, ip string) EndpointOption {
 // be passed to endpoint Join method.
 func JoinOptionResolvConfPath(path string) EndpointOption {
 	return func(ep *endpoint) {
+		if ep.container == nil {
+			return
+		}
 		ep.container.config.resolvConfPath = path
 	}
 }
@@ -849,6 +870,9 @@ func JoinOptionResolvConfPath(path string) EndpointOption {
 // be passed to endpoint Join method.
 func JoinOptionDNS(dns string) EndpointOption {
 	return func(ep *endpoint) {
+		if ep.container == nil {
+			return
+		}
 		ep.container.config.dnsList = append(ep.container.config.dnsList, dns)
 	}
 }
@@ -857,6 +881,9 @@ func JoinOptionDNS(dns string) EndpointOption {
 // be passed to endpoint Join method.
 func JoinOptionDNSSearch(search string) EndpointOption {
 	return func(ep *endpoint) {
+		if ep.container == nil {
+			return
+		}
 		ep.container.config.dnsSearchList = append(ep.container.config.dnsSearchList, search)
 	}
 }
@@ -865,6 +892,9 @@ func JoinOptionDNSSearch(search string) EndpointOption {
 // be passed to endpoint Join method.
 func JoinOptionUseDefaultSandbox() EndpointOption {
 	return func(ep *endpoint) {
+		if ep.container == nil {
+			return
+		}
 		ep.container.config.useDefaultSandBox = true
 	}
 }
@@ -898,6 +928,9 @@ func CreateOptionPortMapping(portBindings []types.PortBinding) EndpointOption {
 // endpoint join method. Container Labels are a good example.
 func JoinOptionGeneric(generic map[string]interface{}) EndpointOption {
 	return func(ep *endpoint) {
+		if ep.container == nil {
+			return
+		}
 		ep.container.config.generic = generic
 	}
 }


### PR DESCRIPTION
```
          err = ep.Join("container1",
                libnetwork.JoinOptionDomainname("docker.io"))
```
the code in my host occurs a panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x46cc8f]

goroutine 1 [running]:
github.com/docker/libnetwork.func·010(0xc208078ea0)
	/home/gopath/src/github.com/docker/libnetwork/endpoint.go:812 +0x4f
github.com/docker/libnetwork.(*endpoint).processOptions(0xc208078ea0, 0xc20802c188, 0x1, 0x1)
	/home/gopath/src/github.com/docker/libnetwork/endpoint.go:279 +0xc1
github.com/docker/libnetwork.(*endpoint).Leave(0xc208078ea0, 0xbb7bd0, 0xa, 0xc20802c188, 0x1, 0x1, 0x0, 0x0)
	/home/gopath/src/github.com/docker/libnetwork/endpoint.go:459 +0xbb
github.com/docker/libnetwork.func·002()
	/home/gopath/src/github.com/docker/libnetwork/endpoint.go:353 +0x93
github.com/docker/libnetwork.(*endpoint).Join(0xc208078ea0, 0xbb7bd0, 0xa, 0xc20802c188, 0x1, 0x1, 0x7f78015a8c80, 0xc2080a7210)
	/home/gopath/src/github.com/docker/libnetwork/endpoint.go:424 +0x9d1
main.main()
	/home/gopath/src/test/main.go:36 +0x50f
```

As the backtrace, in `endpoint.Join`, [ctrlr.sandboxAdd failed](https://github.com/docker/libnetwork/blob/master/endpoint.go#L424), and there' are two defer:
[defer 1](https://github.com/docker/libnetwork/blob/master/endpoint.go#L350)
```
	defer func() {
		ep.joinLeaveEnd()
		if err != nil {
			if e := ep.Leave(containerID, options...); e != nil {
				log.Warnf("couldnt leave endpoint : %v", ep.name, err)
			}
		}
	}()
```
[defer 2](https://github.com/docker/libnetwork/blob/master/endpoint.go#L381)
```
	defer func() {
		if err != nil {
			ep.Lock()
			ep.container = nil
			ep.Unlock()
		}
	}()
```
defer is LIFO, so the order is defer 2 => defer 1:
[1]defer 2 sets ep.container = nil
[2]defer 1 calls [endpoint.Leave](453) => [endpoint.processOptions](https://github.com/docker/libnetwork/blob/master/endpoint.go#L459) => [JoinOptionDomainname] (https://github.com/docker/libnetwork/blob/master/endpoint.go#L812), which triggers a nil pointer error