### PR TITLE
Reading the top level element (network) from datastore on init

### DIFF
--- a/cmd/dnet/libnetwork.toml
+++ b/cmd/dnet/libnetwork.toml
@@ -2,10 +2,11 @@ title = "LibNetwork Configuration file"
 
 [daemon]
   debug = false
-  DefaultNetwork = "bridge"
-  DefaultDriver = "bridge"
 [cluster]
   discovery = "token://22aa23948f4f6b31230687689636959e"
   Address = "1.1.1.1"
 [datastore]
   embedded = false
+[datastore.client]
+  provider = "consul"
+  Address = "localhost:8500"


### PR DESCRIPTION
Currently we rely on watch to catchup after the init. But there could be
a small time window on which, we might end up in a race condition on
network creates. By reading and populating networks during init, we
avoid any such conditions, especially for default network handling.

Signed-off-by: Madhu Venugopal <madhu@docker.com>