### PR TITLE
Datastore handles creating objects atomically.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -76,7 +76,7 @@
 		},
 		{
 			"ImportPath": "github.com/docker/libkv",
-			"Rev": "ab16c3d4a8785a9877c62d0b11ea4441cf09120c"
+			"Rev": "60c7c881345b3c67defc7f93a8297debf041d43c"
 		},
 		{
 			"ImportPath": "github.com/godbus/dbus",

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/netlabel"
 )
 
@@ -57,6 +58,7 @@ type Option func(c *Config)
 // OptionDefaultNetwork function returns an option setter for a default network
 func OptionDefaultNetwork(dn string) Option {
 	return func(c *Config) {
+		log.Infof("Option DefaultNetwork: %s", dn)
 		c.Daemon.DefaultNetwork = strings.TrimSpace(dn)
 	}
 }
@@ -64,6 +66,7 @@ func OptionDefaultNetwork(dn string) Option {
 // OptionDefaultDriver function returns an option setter for default driver
 func OptionDefaultDriver(dd string) Option {
 	return func(c *Config) {
+		log.Infof("Option DefaultDriver: %s", dd)
 		c.Daemon.DefaultDriver = strings.TrimSpace(dd)
 	}
 }
@@ -82,6 +85,7 @@ func OptionLabels(labels []string) Option {
 // OptionKVProvider function returns an option setter for kvstore provider
 func OptionKVProvider(provider string) Option {
 	return func(c *Config) {
+		log.Infof("Option OptionKVProvider: %s", provider)
 		c.Datastore.Client.Provider = strings.TrimSpace(provider)
 	}
 }
@@ -89,6 +93,7 @@ func OptionKVProvider(provider string) Option {
 // OptionKVProviderURL function returns an option setter for kvstore url
 func OptionKVProviderURL(url string) Option {
 	return func(c *Config) {
+		log.Infof("Option OptionKVProviderURL: %s", url)
 		c.Datastore.Client.Address = strings.TrimSpace(url)
 	}
 }

--- a/controller.go
+++ b/controller.go
@@ -262,6 +262,7 @@ func (c *controller) NewNetwork(networkType, name string, options ...NetworkOpti
 	}
 
 	if err := c.updateNetworkToStore(network); err != nil {
+		log.Warnf("couldnt create network %s: %v", network.name, err)
 		if e := network.Delete(); e != nil {
 			log.Warnf("couldnt cleanup network %s: %v", network.name, err)
 		}

--- a/endpoint.go
+++ b/endpoint.go
@@ -124,6 +124,7 @@ type endpoint struct {
 	generic       map[string]interface{}
 	joinLeaveDone chan struct{}
 	dbIndex       uint64
+	dbExists      bool
 	sync.Mutex
 }
 
@@ -258,6 +259,10 @@ func (ep *endpoint) Value() []byte {
 	return b
 }
 
+func (ep *endpoint) SetValue(value []byte) error {
+	return json.Unmarshal(value, ep)
+}
+
 func (ep *endpoint) Index() uint64 {
 	ep.Lock()
 	defer ep.Unlock()
@@ -268,6 +273,13 @@ func (ep *endpoint) SetIndex(index uint64) {
 	ep.Lock()
 	defer ep.Unlock()
 	ep.dbIndex = index
+	ep.dbExists = true
+}
+
+func (ep *endpoint) Exists() bool {
+	ep.Lock()
+	defer ep.Unlock()
+	return ep.dbExists
 }
 
 func (ep *endpoint) processOptions(options ...EndpointOption) {

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -35,10 +35,11 @@ type Allocator struct {
 	// Allocated addresses in each address space's internal subnet
 	addresses map[subnetKey]*bitseq.Handle
 	// Datastore
-	store   datastore.DataStore
-	App     string
-	ID      string
-	dbIndex uint64
+	store    datastore.DataStore
+	App      string
+	ID       string
+	dbIndex  uint64
+	dbExists bool
 	sync.Mutex
 }
 
@@ -100,6 +101,7 @@ func (a *Allocator) subnetConfigFromStore(kvPair *store.KVPair) {
 	if a.dbIndex < kvPair.LastIndex {
 		a.subnets = byteArrayToSubnets(kvPair.Value)
 		a.dbIndex = kvPair.LastIndex
+		a.dbExists = true
 	}
 	a.Unlock()
 }

--- a/ipam/store.go
+++ b/ipam/store.go
@@ -39,6 +39,12 @@ func (a *Allocator) Value() []byte {
 	return b
 }
 
+// SetValue unmarshalls the data from the KV store.
+func (a *Allocator) SetValue(value []byte) error {
+	a.subnets = byteArrayToSubnets(value)
+	return nil
+}
+
 func subnetsToByteArray(m map[subnetKey]*SubnetInfo) ([]byte, error) {
 	if m == nil {
 		return nil, nil
@@ -94,7 +100,15 @@ func (a *Allocator) Index() uint64 {
 func (a *Allocator) SetIndex(index uint64) {
 	a.Lock()
 	a.dbIndex = index
+	a.dbExists = true
 	a.Unlock()
+}
+
+// Exists method is true if this object has been stored in the DB.
+func (a *Allocator) Exists() bool {
+	a.Lock()
+	defer a.Unlock()
+	return a.dbExists
 }
 
 func (a *Allocator) watchForChanges() error {

--- a/network.go
+++ b/network.go
@@ -67,6 +67,7 @@ type network struct {
 	generic     options.Generic
 	dbIndex     uint64
 	svcRecords  svcMap
+	dbExists    bool
 	stopWatchCh chan struct{}
 	sync.Mutex
 }
@@ -116,6 +117,10 @@ func (n *network) Value() []byte {
 	return b
 }
 
+func (n *network) SetValue(value []byte) error {
+	return json.Unmarshal(value, n)
+}
+
 func (n *network) Index() uint64 {
 	n.Lock()
 	defer n.Unlock()
@@ -125,7 +130,14 @@ func (n *network) Index() uint64 {
 func (n *network) SetIndex(index uint64) {
 	n.Lock()
 	n.dbIndex = index
+	n.dbExists = true
 	n.Unlock()
+}
+
+func (n *network) Exists() bool {
+	n.Lock()
+	defer n.Unlock()
+	return n.dbExists
 }
 
 func (n *network) EndpointCnt() uint64 {
@@ -292,7 +304,9 @@ func (n *network) CreateEndpoint(name string, options ...EndpointOption) (Endpoi
 		return nil, types.ForbiddenErrorf("service endpoint with name %s already exists", name)
 	}
 
-	ep := &endpoint{name: name, iFaces: []*endpointInterface{}, generic: make(map[string]interface{})}
+	ep := &endpoint{name: name,
+		iFaces:  []*endpointInterface{},
+		generic: make(map[string]interface{})}
 	ep.id = types.UUID(stringid.GenerateRandomID())
 	ep.network = n
 	ep.processOptions(options...)


### PR DESCRIPTION
This commit relies on https://github.com/docker/libkv/commit/60c7c881345b3c67defc7f93a8297debf041d43c

In that commit, AtomicPutCreate takes previous = nil to Atomically create keys
that don't exist.  We need a create operation that is atomic to prevent races
between multiple libnetworks creating the same object.

Previously, we just created new KVs with an index of 0 and wrote them to the
datastore.  Consul accepts this behaviour and interprets index of 0 as
non-existing, but other data backends do no.

 - Add Exists() to the KV interface.  SetIndex() should also modify a KV so
   that it exists.
 - Call SetIndex() from within the GetObject() method on DataStore interface.
   - This ensures objects have the updated values for exists and index.
 - Add SetValue() to the KV interface.  This allows implementers to define
   their own method to marshall and unmarshall (as bitseq and allocator have).
 - Update existing users of the DataStore (endpoint, network, bitseq,
   allocator) to new interfaces.
 - Fix UTs.