### PR TITLE
set the kv-provider driver labels only if it is a valid config

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -211,7 +211,7 @@ func (c *controller) RegisterDriver(networkType string, driver driverapi.Driver,
 		}
 	}
 
-	if capability.Scope == driverapi.GlobalScope {
+	if capability.Scope == driverapi.GlobalScope && c.validateDatastoreConfig() {
 		opt[netlabel.KVProvider] = c.cfg.Datastore.Client.Provider
 		opt[netlabel.KVProviderURL] = c.cfg.Datastore.Client.Address
 	}


### PR DESCRIPTION
without this fix, overlay driver returns an error and that causes the
daemon to quit.

Signed-off-by: Madhu Venugopal <madhu@docker.com>