### PR TITLE
Update error return in bridge driver's getNetwork

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -453,7 +453,7 @@ func (d *driver) getNetwork(id types.UUID) (*bridgeNetwork, error) {
 		return nw, nil
 	}
 
-	return nil, nil
+	return nil, types.NotFoundErrorf("network not found: %s", id)
 }
 
 func parseNetworkGenericOptions(data interface{}) (*networkConfiguration, error) {


### PR DESCRIPTION
The usage of getNetwork can cause nil pointer error when the network not found
```
	network, err := d.getNetwork(nid)
	if err != nil {
		return err
	}

	endpoint, err := network.getEndpoint(eid)
	if err != nil {
		return err
	}
```