### PR TITLE
Do not update /etc/hosts for empty endpoints

### DIFF
--- a/etchosts/etchosts.go
+++ b/etchosts/etchosts.go
@@ -68,6 +68,10 @@ func Build(path, IP, hostname, domainname string, extraContent []Record) error {
 
 // Add adds an arbitrary number of Records to an already existing /etc/hosts file
 func Add(path string, recs []Record) error {
+	if len(recs) == 0 {
+		return nil
+	}
+
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -91,6 +95,10 @@ func Add(path string, recs []Record) error {
 
 // Delete deletes an arbitrary number of Records already existing in /etc/hosts file
 func Delete(path string, recs []Record) error {
+	if len(recs) == 0 {
+		return nil
+	}
+
 	old, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/etchosts/etchosts_test.go
+++ b/etchosts/etchosts_test.go
@@ -135,6 +135,23 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestAddEmpty(t *testing.T) {
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	err = Build(file.Name(), "", "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Add(file.Name(), []Record{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestAdd(t *testing.T) {
 	file, err := ioutil.TempFile("", "")
 	if err != nil {
@@ -163,6 +180,23 @@ func TestAdd(t *testing.T) {
 
 	if expected := "2.2.2.2\ttesthostname\n"; !bytes.Contains(content, []byte(expected)) {
 		t.Fatalf("Expected to find '%s' got '%s'", expected, content)
+	}
+}
+
+func TestDeleteEmpty(t *testing.T) {
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	err = Build(file.Name(), "", "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Delete(file.Name(), []Record{}); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/network.go
+++ b/network.go
@@ -416,6 +416,11 @@ func (n *network) updateSvcRecord(ep *endpoint, isAdd bool) {
 	}
 	n.Unlock()
 
+	// If there are no records to add or delete then simply return here
+	if len(recs) == 0 {
+		return
+	}
+
 	var epList []*endpoint
 	n.WalkEndpoints(func(e Endpoint) bool {
 		cEp := e.(*endpoint)


### PR DESCRIPTION
There is no need to update the /etc/hosts files
of containers for endpoints which are created/deleted
in a network whose interface list is empty

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>