### PR TITLE
Add a Multiple function in iptables.go

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -116,8 +116,10 @@ func Init(dc driverapi.DriverCallback) error {
 	if err := iptables.FirewalldInit(); err != nil {
 		logrus.Debugf("Fail to initialize firewalld: %v, using raw iptables instead", err)
 	}
-	if err := iptables.RemoveExistingChain(DockerChain, iptables.Nat); err != nil {
-		logrus.Warnf("Failed to remove existing iptables entries in %s : %v", DockerChain, err)
+	if iptables.ExistChain(iptables.Nat, DockerChain) {
+		if err := iptables.RemoveExistingChain(DockerChain, iptables.Nat); err != nil {
+			logrus.Warnf("Failed to remove existing iptables entries in %s : %v", DockerChain, err)
+		}
 	}
 
 	c := driverapi.Capability{

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -23,10 +23,16 @@ func TestNewChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if !ExistChain(Nat, chainName) {
+		t.Fatalf("chain should exist")
+	}
 
 	filterChain, err = NewChain(chainName, "lo", Filter, false)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !ExistChain(Filter, chainName) {
+		t.Fatalf("chain should exist")
 	}
 }
 
@@ -37,8 +43,7 @@ func TestForward(t *testing.T) {
 	dstPort := 4321
 	proto := "tcp"
 
-	err := natChain.Forward(Insert, ip, port, proto, dstAddr, dstPort)
-	if err != nil {
+	if err := natChain.Forward(Insert, ip, port, proto, dstAddr, dstPort); err != nil {
 		t.Fatal(err)
 	}
 
@@ -79,6 +84,10 @@ func TestForward(t *testing.T) {
 	if !Exists(natChain.Table, "POSTROUTING", masqRule...) {
 		t.Fatalf("MASQUERADE rule does not exist")
 	}
+
+	// Clean up the rules in case of disturbing other tests
+	natChain.Forward(Delete, ip, port, proto, dstAddr, dstPort)
+	testCleanupForward(t, natChain.ForwardRules(ip, port, proto, dstAddr, dstPort), "TestForward")
 }
 
 func TestLink(t *testing.T) {
@@ -199,6 +208,58 @@ func RunConcurrencyTest(t *testing.T, allowXlock bool) {
 		}()
 	}
 	wg.Wait()
+
+	// Clean up the rules in case of disturbing other tests
+	forwardRules := natChain.ForwardRules(ip, port, proto, dstAddr, dstPort)
+	for i := 0; i < 10; i++ {
+		natChain.Multiple(Delete, forwardRules, "FORWARD")
+	}
+	testCleanupForward(t, forwardRules, "RunConcurrencyTest")
+}
+
+func TestMultiple(t *testing.T) {
+	var err error
+	ip := net.ParseIP("192.168.1.1")
+	port := 1234
+	dstAddr := "172.17.0.1"
+	dstPort := 4321
+	proto := "tcp"
+	forwardRules := natChain.ForwardRules(ip, port, proto, dstAddr, dstPort)
+	// test when creating multiple rules, if one of them fails, should cleanup the previously succeeded ones
+	// remove filter chain, so the DNAT rule should been created first and removed because of failed to create filter rule
+	removeFilterChain(t)
+	if ExistChain(Filter, chainName) {
+		t.Fatalf("chain should have be deleted")
+	}
+	if err = natChain.Multiple(Append, forwardRules, "FORWARD"); err == nil {
+		//since filter chain is removed, create forward rules should fail
+		t.Fatalf("should fail to create forward rules")
+	}
+	// no rules should exist
+	testCleanupForward(t, forwardRules, "TestMultiple")
+
+	if filterChain, err = NewChain(chainName, "lo", Filter, false); err != nil {
+		t.Fatal(err)
+	}
+
+	//test if failed to cleanup the first one rule, should continue to cleanup all rules
+	masquerade := []string{
+		"-p", proto,
+		"-s", dstAddr,
+		"-d", strconv.Itoa(dstPort),
+		"--dport", strconv.Itoa(port),
+		"-j", "MASQUERADE"}
+	//
+	if _, err = Raw(append([]string{string(Append), "POSTROUTING", "-t", string(Nat)}, masquerade...)...); err != nil {
+		t.Fatal("Failed to create masquerade rules")
+	}
+
+	if err = natChain.Multiple(Delete, forwardRules, "FORWARD"); err == nil {
+		// since we didn't create DNAT rule, should fail
+		t.Fatal("should fail to delete forward rules")
+	}
+	// no rules should exist
+	testCleanupForward(t, forwardRules, "TestMultiple")
 }
 
 func TestCleanup(t *testing.T) {
@@ -206,18 +267,17 @@ func TestCleanup(t *testing.T) {
 	var rules []byte
 
 	// Cleanup filter/FORWARD first otherwise output of iptables-save is dirty
-	link := []string{"-t", string(filterChain.Table),
-		string(Delete), "FORWARD",
-		"-o", filterChain.Bridge,
-		"-j", filterChain.Name}
-	if _, err = Raw(link...); err != nil {
-		t.Fatal(err)
-	}
-	filterChain.Remove()
+	removeFilterChain(t)
 
 	err = RemoveExistingChain(chainName, Nat)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if ExistChain(Filter, chainName) {
+		t.Fatalf("chain should have been deleted")
+	}
+	if ExistChain(Nat, chainName) {
+		t.Fatalf("chain should have been deleted")
 	}
 
 	rules, err = exec.Command("iptables-save").Output()
@@ -227,4 +287,29 @@ func TestCleanup(t *testing.T) {
 	if strings.Contains(string(rules), chainName) {
 		t.Fatalf("Removing chain failed. %s found in iptables-save", chainName)
 	}
+}
+
+func testCleanupForward(t *testing.T, rules [][]string, testCase string) {
+	if Exists(natChain.Table, natChain.Name, rules[0]...) {
+		t.Fatalf("DNAT rule exists in test case %s", testCase)
+	}
+
+	if Exists(filterChain.Table, filterChain.Name, rules[1]...) {
+		t.Fatalf("FILTER rule exists in test case %s", testCase)
+	}
+
+	if Exists(natChain.Table, "POSTROUTING", rules[2]...) {
+		t.Fatalf("MASQUERADE rule exists in test case %s", testCase)
+	}
+}
+
+func removeFilterChain(t *testing.T) {
+	link := []string{"-t", string(filterChain.Table),
+		string(Delete), "FORWARD",
+		"-o", filterChain.Bridge,
+		"-j", filterChain.Name}
+	if _, err := Raw(link...); err != nil {
+		t.Fatal(err)
+	}
+	filterChain.Remove()
 }


### PR DESCRIPTION
We happened to cleaned filter table and removed DOCKER chain from filter table by mistake(docker daemon is running). Creating containers started to fail afterwards. And we found lots of unused DNAT rules left in DOCKER chain of nat table. See the following rules. 

What's more worse, because of the unused rules, it can wrongly forward network packets from ports which is in use by other processes (we use userland-proxy to determine whether a port is in use, but we haven't got there in the above case).

This is because `Forward()` in `iptables.go` doesn't create rules atomically.

```
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54108 ! -i docker0 -j DNAT --to-destination 192.168.1.65:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54109 ! -i docker0 -j DNAT --to-destination 192.168.1.65:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54110 ! -i docker0 -j DNAT --to-destination 192.168.1.65:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54111 ! -i docker0 -j DNAT --to-destination 192.168.1.65:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54112 ! -i docker0 -j DNAT --to-destination 192.168.1.66:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54113 ! -i docker0 -j DNAT --to-destination 192.168.1.66:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54114 ! -i docker0 -j DNAT --to-destination 192.168.1.66:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54115 ! -i docker0 -j DNAT --to-destination 192.168.1.66:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54116 ! -i docker0 -j DNAT --to-destination 192.168.1.66:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54117 ! -i docker0 -j DNAT --to-destination 192.168.1.66:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54118 ! -i docker0 -j DNAT --to-destination 192.168.1.66:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54119 ! -i docker0 -j DNAT --to-destination 192.168.1.66:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54120 ! -i docker0 -j DNAT --to-destination 192.168.1.66:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54121 ! -i docker0 -j DNAT --to-destination 192.168.1.66:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54122 ! -i docker0 -j DNAT --to-destination 192.168.1.67:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54123 ! -i docker0 -j DNAT --to-destination 192.168.1.67:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54124 ! -i docker0 -j DNAT --to-destination 192.168.1.67:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54125 ! -i docker0 -j DNAT --to-destination 192.168.1.67:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54126 ! -i docker0 -j DNAT --to-destination 192.168.1.67:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54127 ! -i docker0 -j DNAT --to-destination 192.168.1.67:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54128 ! -i docker0 -j DNAT --to-destination 192.168.1.67:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54129 ! -i docker0 -j DNAT --to-destination 192.168.1.67:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54130 ! -i docker0 -j DNAT --to-destination 192.168.1.67:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54131 ! -i docker0 -j DNAT --to-destination 192.168.1.67:22
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54132 ! -i docker0 -j DNAT --to-destination 192.168.1.68:36000
iptables --wait -t nat -D DOCKER -p tcp -d 0/0 --dport 54133 ! -i docker0 -j DNAT --to-destination 192.168.1.68:36000
```

This PR add a `Multiple()` function in `iptables.go` which guaranteed to add multiple rules atomically or clean multiple rules cleanly.
Also fix a return bug in Remove()

Signed-off-by: Chun Chen ramichen@tencent.com
