### PR TITLE
Fix module loading return.

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/Sirupsen/logrus"
@@ -108,9 +109,7 @@ func newDriver() driverapi.Driver {
 func Init(dc driverapi.DriverCallback) error {
 	// try to modprobe bridge first
 	// see gh#12177
-	if out, err := exec.Command("modprobe", "-va", "bridge", "nf_nat", "br_netfilter").CombinedOutput(); err != nil {
-		logrus.Warnf("Running modprobe bridge nf_nat br_netfilter failed with message: %s, error: %v", out, err)
-	}
+	out, err1 := exec.Command("modprobe", "-va", "bridge", "nf_nat", "br_netfilter").CombinedOutput()
 	if err := iptables.RemoveExistingChain(DockerChain, iptables.Nat); err != nil {
 		logrus.Warnf("Failed to remove existing iptables entries in %s : %v", DockerChain, err)
 	}
@@ -118,7 +117,11 @@ func Init(dc driverapi.DriverCallback) error {
 	c := driverapi.Capability{
 		Scope: driverapi.LocalScope,
 	}
-	return dc.RegisterDriver(networkType, newDriver(), c)
+	err2 := dc.RegisterDriver(networkType, newDriver(), c)
+	if err2 != nil && err1 != nil {
+		logrus.Warnf("Running modprobe bridge nf_nat failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err1)
+	}
+	return err2
 }
 
 // Validate performs a static validation on the network configuration parameters.


### PR DESCRIPTION
The way kernel modules are loaded could lead to false warnings. This PR fixes it.
It also fixes the output of the warning: as modprobe uses stderr for failure details, Output(), that only reads stdout, should be replaced by CombinedOutput(), that reads stdout and stderr.

All the details, the tests and the validations was made in docker/docker pull requests https://github.com/docker/docker/pull/13981 and https://github.com/docker/docker/pull/13980.