### PR TITLE
Honor driver side resolv.conf file

### DIFF
--- a/drivers/host/host.go
+++ b/drivers/host/host.go
@@ -40,7 +40,11 @@ func (d *driver) EndpointOperInfo(nid, eid types.UUID) (map[string]interface{}, 
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
 func (d *driver) Join(nid, eid types.UUID, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
-	return (jinfo.SetHostsPath("/etc/hosts"))
+	if err := jinfo.SetHostsPath("/etc/hosts"); err != nil {
+		return err
+	}
+
+	return jinfo.SetResolvConfPath("/etc/resolv.conf")
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.

--- a/endpoint.go
+++ b/endpoint.go
@@ -2,6 +2,7 @@ package libnetwork
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -567,9 +568,19 @@ func (ep *endpoint) updateDNS(resolvConf []byte) error {
 	return os.Rename(tmpResolvFile.Name(), container.config.resolvConfPath)
 }
 
+func copyFile(src, dst string) error {
+	sBytes, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(dst, sBytes, 0644)
+}
+
 func (ep *endpoint) setupDNS() error {
 	ep.Lock()
 	container := ep.container
+	joinInfo := ep.joinInfo
 	ep.Unlock()
 
 	if container == nil {
@@ -584,6 +595,14 @@ func (ep *endpoint) setupDNS() error {
 	err := createBasePath(dir)
 	if err != nil {
 		return err
+	}
+
+	if joinInfo.resolvConfPath != "" {
+		if err := copyFile(joinInfo.resolvConfPath, container.config.resolvConfPath); err != nil {
+			return fmt.Errorf("could not copy source resolv.conf file %s to %s: %v", joinInfo.resolvConfPath, container.config.resolvConfPath, err)
+		}
+
+		return nil
 	}
 
 	resolvConf, err := resolvconf.Get()

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -1119,6 +1119,74 @@ func TestEnableIPv6(t *testing.T) {
 	}
 }
 
+func TestResolvConfHost(t *testing.T) {
+	if !netutils.IsRunningInContainer() {
+		defer netutils.SetupTestNetNS(t)()
+	}
+
+	tmpResolvConf := []byte("search localhost.net\nnameserver 127.0.0.1\nnameserver 2001:4860:4860::8888")
+
+	//take a copy of resolv.conf for restoring after test completes
+	resolvConfSystem, err := ioutil.ReadFile("/etc/resolv.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	//cleanup
+	defer func() {
+		if err := ioutil.WriteFile("/etc/resolv.conf", resolvConfSystem, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	n, err := createTestNetwork("host", "testnetwork", options.Generic{}, options.Generic{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ep1, err := n.CreateEndpoint("ep1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ioutil.WriteFile("/etc/resolv.conf", tmpResolvConf, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	resolvConfPath := "/tmp/libnetwork_test/resolv.conf"
+	defer os.Remove(resolvConfPath)
+
+	_, err = ep1.Join(containerID,
+		libnetwork.JoinOptionResolvConfPath(resolvConfPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err = ep1.Leave(containerID)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	finfo, err := os.Stat(resolvConfPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmode := (os.FileMode)(0644)
+	if finfo.Mode() != fmode {
+		t.Fatalf("Expected file mode %s, got %s", fmode.String(), finfo.Mode().String())
+	}
+
+	content, err := ioutil.ReadFile(resolvConfPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(content, tmpResolvConf) {
+		t.Fatalf("Expected %s, Got %s", string(tmpResolvConf), string(content))
+	}
+}
+
 func TestResolvConf(t *testing.T) {
 	if !netutils.IsRunningInContainer() {
 		defer netutils.SetupTestNetNS(t)()


### PR DESCRIPTION
For the moment in 1.7.1 since we provide a resolv.conf set api
to the driver honor that so that for host driver we can use the
the host's /etc/resolv.conf file as is rather than putting the
contents through a filtering logic.

It should be noted that the driver side capability to set the
resolv.conf file is most likely going to go away in the future
but this should be fine for 1.7.1

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>