### PR TITLE
Use github golang tools mirror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,12 @@ check-local: 	check-format check-code run-tests
 
 install-deps:
 	apt-get update && apt-get -y install iptables
+	git clone https://github.com/golang/tools /go/src/golang.org/x/tools
+	go install golang.org/x/tools/cmd/vet
+	go install golang.org/x/tools/cmd/goimports
+	go install golang.org/x/tools/cmd/cover
 	go get github.com/tools/godep
 	go get github.com/golang/lint/golint
-	go get golang.org/x/tools/cmd/vet
-	go get golang.org/x/tools/cmd/goimports
-	go get golang.org/x/tools/cmd/cover
 	go get github.com/mattn/goveralls
 
 coveralls:


### PR DESCRIPTION
Signed-off-by: Chun Chen <ramichen@tencent.com>

When building libnetwork, I got the following error 
```
package github.com/tools/godep
    imports github.com/kr/fs
    imports golang.org/x/tools/go/vcs: unrecognized import path "golang.org/x/tools/go/vcs"
```

This is because golang.org is blocked in China by GFW. But there is a mirror of golang.org/x/tools at github, I suggest to use this mirror repo instead.