### PR TITLE
Fix incorrect error handling in bitseq constructor

### DIFF
--- a/bitseq/sequence.go
+++ b/bitseq/sequence.go
@@ -55,12 +55,11 @@ func NewHandle(app string, ds datastore.DataStore, id string, numElements uint32
 	h.watchForChanges()
 
 	// Get the initial status from the ds if present.
-	err := h.store.GetObject(datastore.Key(h.Key()...), h)
-	if err != datastore.ErrKeyNotFound {
+	if err := h.store.GetObject(datastore.Key(h.Key()...), h); err != nil && err != datastore.ErrKeyNotFound {
 		return nil, err
 	}
 
-	return h, err
+	return h, nil
 }
 
 // Sequence reresents a recurring sequence of 32 bits long bitmasks


### PR DESCRIPTION
- We must ignore key not found error when querying
  datastore for initial state.
- Regression introduced by e2a63dff5a38a0f26f7f0c36356f3a6a28f4efeb

Signed-off-by: Alessandro Boch <aboch@docker.com>