### PR TITLE
Always pass a previous KVPair to AtomicPut

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -127,7 +127,7 @@ func (ds *datastore) PutObjectAtomic(kvObject KV) error {
 	if kvObject.Exists() {
 		previous = &store.KVPair{Key: Key(kvObject.Key()...), LastIndex: kvObject.Index()}
 	} else {
-		previous = nil
+		previous = &store.KVPair{}
 	}
 	_, pair, err := ds.store.AtomicPut(Key(kvObject.Key()...), kvObjValue, previous, nil)
 	if err != nil {


### PR DESCRIPTION
There is a breakage where `PutObjectAtomic` is trying to
call `AtomicPut` with a `nil` previous K/V pair value. `AtomicPut`
does not like this and it should atleast be an empty k/v pair.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>