### PR TITLE
BitSequence should unmarshal data during get

### DIFF
--- a/bitseq/store.go
+++ b/bitseq/store.go
@@ -40,7 +40,12 @@ func (h *Handle) Value() []byte {
 
 // SetValue unmarshals the data from the KV store
 func (h *Handle) SetValue(value []byte) error {
-	return h.FromByteArray(value)
+	var b []byte
+	if err := json.Unmarshal(value, &b); err != nil {
+		return err
+	}
+
+	return h.FromByteArray(b)
 }
 
 // Index returns the latest DB Index as seen by this object


### PR DESCRIPTION
When bit sequence is trying to get key/value from the
data store it should always unmarshall the json data
before using it, as the data is JSON marshalled before
storing it in the data store.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>