### PR TITLE
Fixed a bug in DeleteEndpoint to properly release v6 ip

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -1047,7 +1047,11 @@ func (d *driver) DeleteEndpoint(nid, eid types.UUID) error {
 
 	// Release the v6 address allocated to this endpoint's sandbox interface
 	if config.EnableIPv6 {
-		err := ipAllocator.ReleaseIP(n.bridge.bridgeIPv6, ep.addrv6.IP)
+		network := n.bridge.bridgeIPv6
+		if config.FixedCIDRv6 != nil {
+			network = config.FixedCIDRv6
+		}
+		err := ipAllocator.ReleaseIP(network, ep.addrv6.IP)
 		if err != nil {
 			return err
 		}

--- a/drivers/bridge/setup_fixedcidrv6_test.go
+++ b/drivers/bridge/setup_fixedcidrv6_test.go
@@ -29,9 +29,16 @@ func TestSetupFixedCIDRv6(t *testing.T) {
 		t.Fatalf("Failed to setup bridge FixedCIDRv6: %v", err)
 	}
 
+	var ip net.IP
 	if ip, err := ipAllocator.RequestIP(config.FixedCIDRv6, nil); err != nil {
 		t.Fatalf("Failed to request IP to allocator: %v", err)
 	} else if expected := "2002:db8::1"; ip.String() != expected {
 		t.Fatalf("Expected allocated IP %s, got %s", expected, ip)
+	}
+
+	if err := ipAllocator.ReleaseIP(config.FixedCIDRv6, ip); err != nil {
+		t.Fatalf("Failed to release IP from allocator: %v", err)
+	} else if _, err := ipAllocator.RequestIP(config.FixedCIDRv6, ip); err != nil {
+		t.Fatalf("Failed to request a released IP: %v", err)
 	}
 }


### PR DESCRIPTION
When fixed-cidrv6 is used, the allocation and release must happen from
the appropriate network. Allocation is done properly in createendpoint,
but the DeleteEndpoint wasnt taking care of this case.

Signed-off-by: Madhu Venugopal <madhu@docker.com>