### PR TITLE
Add a network namespace driver to libnetwork

### DIFF
--- a/docs/namespace.md
+++ b/docs/namespace.md
@@ -1,0 +1,14 @@
+Namespace Driver
+=============
+
+The namespace driver allows containers to use pre-defined network namespaces.
+A namespace may be created with ip netns add namespace-name-here
+
+## Configuration
+
+The namespace driver can be configured with Docker's --net flag.
+
+## Usage
+
+The driver can invoked by running a docker container with --net=namespace:path/to/namespace
+    e.g. docker run -it --net=namespace:/var/run/netns/alec docker.io/fedora /bin/bash

--- a/drivers/namespace/namespace.go
+++ b/drivers/namespace/namespace.go
@@ -1,0 +1,129 @@
+package namespace
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/docker/libnetwork/driverapi"
+	"github.com/docker/libnetwork/netlabel"
+	"github.com/docker/libnetwork/options"
+	"github.com/docker/libnetwork/sandbox"
+	"github.com/docker/libnetwork/types"
+)
+
+const networkType = "namespace"
+
+type driver struct {
+	network types.UUID
+	sync.Mutex
+}
+
+// networkConfiguration for network specific configuration
+type endpointConfig struct {
+	ContainerID     string
+	CustomNamespace string
+}
+
+// Init registers a new instance of namespace driver
+func Init(dc driverapi.DriverCallback) error {
+	c := driverapi.Capability{
+		Scope: driverapi.LocalScope,
+	}
+	return dc.RegisterDriver(networkType, &driver{}, c)
+}
+
+func (d *driver) Config(option map[string]interface{}) error {
+	return nil
+}
+
+func (d *driver) CreateNetwork(id types.UUID, option map[string]interface{}) error {
+	d.Lock()
+	defer d.Unlock()
+
+	d.network = id
+	return nil
+}
+
+func (d *driver) DeleteNetwork(nid types.UUID) error {
+	return nil
+}
+
+func (d *driver) CreateEndpoint(nid, eid types.UUID, epInfo driverapi.EndpointInfo, epOptions map[string]interface{}) error {
+	return nil
+}
+
+func (d *driver) DeleteEndpoint(nid, eid types.UUID) error {
+	return nil
+}
+
+func (d *driver) EndpointOperInfo(nid, eid types.UUID) (map[string]interface{}, error) {
+	return make(map[string]interface{}, 0), nil
+}
+
+// Join method is invoked when a Sandbox is attached to an endpoint.
+func (d *driver) Join(nid, eid types.UUID, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+	//Symlink the namespace that the user provided to docker's namespace directory
+	config, err := parseNamespaceOptions(options)
+	if err != nil {
+		return err
+	}
+	return symlinkNamespace(config)
+}
+
+// Leave method is invoked when a Sandbox detaches from an endpoint.
+func (d *driver) Leave(nid, eid types.UUID) error {
+	return nil
+}
+
+func (d *driver) Type() string {
+	return networkType
+}
+
+//parseNamespaceOptions parses the generic options into an endpointConfig struct
+//The location of the network namespace to use, as well as the
+//Container ID are passed into the driver via generic options.
+func parseNamespaceOptions(nOptions map[string]interface{}) (*endpointConfig, error) {
+	if nOptions == nil {
+		return nil, nil
+	}
+	genericData, ok := nOptions[netlabel.GenericNamespaceOptions]
+	if ok && genericData != nil {
+		switch opt := genericData.(type) {
+		case options.Generic:
+			opaqueConfig, err := options.GenerateFromModel(opt, &endpointConfig{})
+			if err != nil {
+				return nil, err
+			}
+			return opaqueConfig.(*endpointConfig), nil
+		case *endpointConfig:
+			return opt, nil
+		default:
+			return nil, fmt.Errorf("did not recognize options type: %v\n", opt)
+		}
+	}
+	return nil, fmt.Errorf("nil or non-existent generic namespace opts in join options")
+}
+
+//Symlinks the container's network namespace file in /var/run/docker/netns/{id} to the
+//custom namespace path provided
+func symlinkNamespace(epConfig *endpointConfig) error {
+	if epConfig == nil {
+		return fmt.Errorf("cannot join namespace: nil namespace options provided")
+	}
+
+	if epConfig.CustomNamespace == "" {
+		return fmt.Errorf("cannot join namespace: no namespace path provided")
+	}
+
+	if epConfig.ContainerID == "" {
+		return fmt.Errorf("cannot join namespace: no container ID provided")
+	}
+
+	if _, err := os.Stat(epConfig.CustomNamespace); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("cannot join namespace: %v", err)
+		}
+	}
+	return os.Symlink(epConfig.CustomNamespace, sandbox.GenerateKey(epConfig.ContainerID))
+}

--- a/drivers/namespace/namespace_test.go
+++ b/drivers/namespace/namespace_test.go
@@ -1,0 +1,49 @@
+package namespace
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/docker/libnetwork/netlabel"
+	_ "github.com/docker/libnetwork/netutils"
+	"github.com/docker/libnetwork/options"
+)
+
+func TestDriver(t *testing.T) {
+	d := &driver{}
+
+	if d.Type() != networkType {
+		t.Fatalf("Unexpected network type returned by driver")
+	}
+
+	err := d.CreateNetwork("first", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if d.network != "first" {
+		t.Fatalf("Unexpected network id stored")
+	}
+}
+
+func TestParseNamespaceOptions(t *testing.T) {
+	testOptions := options.Generic{
+		netlabel.GenericNamespaceOptions: options.Generic{
+			"ContainerID":     "12345",
+			"CustomNamespace": "/var/run/netns/alec",
+		},
+	}
+	expectedConfig := &endpointConfig{
+		ContainerID:     "12345",
+		CustomNamespace: "/var/run/netns/alec",
+	}
+
+	config, err := parseNamespaceOptions(testOptions)
+	if err != nil {
+		t.Fatalf("error in TestParseNamespaceOptions: %v", err)
+	}
+
+	if !reflect.DeepEqual(config, expectedConfig) {
+		t.Fatalf("expected parseConfig to return %+v, got %+v instead", expectedConfig, config)
+	}
+}

--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -111,7 +111,7 @@ func (n *network) destroySandbox() {
 }
 
 func (n *network) initSandbox() error {
-	sbox, err := sandbox.NewSandbox(sandbox.GenerateKey(string(n.id)), true)
+	sbox, err := sandbox.NewSandbox(sandbox.GenerateKey(string(n.id)), true, false)
 	if err != nil {
 		return fmt.Errorf("could not create network sandbox: %v", err)
 	}

--- a/drivers_linux.go
+++ b/drivers_linux.go
@@ -4,6 +4,7 @@ import (
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/drivers/bridge"
 	"github.com/docker/libnetwork/drivers/host"
+	"github.com/docker/libnetwork/drivers/namespace"
 	"github.com/docker/libnetwork/drivers/null"
 	o "github.com/docker/libnetwork/drivers/overlay"
 	"github.com/docker/libnetwork/drivers/remote"
@@ -15,6 +16,7 @@ func initDrivers(dc driverapi.DriverCallback) error {
 		host.Init,
 		null.Init,
 		remote.Init,
+		namespace.Init,
 		o.Init,
 	} {
 		if err := fn(dc); err != nil {

--- a/netlabel/labels.go
+++ b/netlabel/labels.go
@@ -35,6 +35,9 @@ const (
 
 	// OverlayNeighborIP constant represents overlay driver neighbor IP
 	OverlayNeighborIP = DriverPrefix + ".overlay.neighbor_ip"
+
+	//GenericNamespaceOptions constant represents generic options for the namespace driver
+	GenericNamespaceOptions = DriverPrefix + ".namespace.generic"
 )
 
 // Key extracts the key portion of the label

--- a/sandbox/namespace_linux.go
+++ b/sandbox/namespace_linux.go
@@ -138,12 +138,22 @@ func GenerateKey(containerID string) string {
 
 // NewSandbox provides a new sandbox instance created in an os specific way
 // provided a key which uniquely identifies the sandbox
-func NewSandbox(key string, osCreate bool) (Sandbox, error) {
+// osCreate determines if a new namespace should be created (--net=host)
+// customSandbox determines if a predefined sandbox should be used (--net=namesapace)
+func NewSandbox(key string, osCreate bool, customSandbox bool) (Sandbox, error) {
+	if customSandbox {
+		//Verify that the file exists. It should be symlinked at this point
+		if _, err := os.Stat(key); os.IsNotExist(err) {
+			err := fmt.Errorf("Could not make sandbox. No such file or directory: %s", key)
+			return nil, err
+		}
+		return &networkNamespace{path: key}, nil
+	}
+
 	err := createNetworkNamespace(key, osCreate)
 	if err != nil {
 		return nil, err
 	}
-
 	return &networkNamespace{path: key}, nil
 }
 

--- a/sandbox/namespace_windows.go
+++ b/sandbox/namespace_windows.go
@@ -13,7 +13,7 @@ func GenerateKey(containerID string) string {
 
 // NewSandbox provides a new sandbox instance created in an os specific way
 // provided a key which uniquely identifies the sandbox
-func NewSandbox(key string, osCreate bool) (Sandbox, error) {
+func NewSandbox(key string, osCreate bool, customSandbox bool) (Sandbox, error) {
 	return nil, nil
 }
 

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -24,7 +24,7 @@ func TestSandboxCreate(t *testing.T) {
 		t.Fatalf("Failed to obtain a key: %v", err)
 	}
 
-	s, err := NewSandbox(key, true)
+	s, err := NewSandbox(key, true, false)
 	if err != nil {
 		t.Fatalf("Failed to create a new sandbox: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestSandboxCreateTwice(t *testing.T) {
 		t.Fatalf("Failed to obtain a key: %v", err)
 	}
 
-	_, err = NewSandbox(key, true)
+	_, err = NewSandbox(key, true, false)
 	if err != nil {
 		t.Fatalf("Failed to create a new sandbox: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestSandboxCreateTwice(t *testing.T) {
 
 	// Create another sandbox with the same key to see if we handle it
 	// gracefully.
-	s, err := NewSandbox(key, true)
+	s, err := NewSandbox(key, true, false)
 	if err != nil {
 		t.Fatalf("Failed to create a new sandbox: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestSandboxGC(t *testing.T) {
 		t.Fatalf("Failed to obtain a key: %v", err)
 	}
 
-	s, err := NewSandbox(key, true)
+	s, err := NewSandbox(key, true, false)
 	if err != nil {
 		t.Fatalf("Failed to create a new sandbox: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestAddRemoveInterface(t *testing.T) {
 		t.Fatalf("Failed to obtain a key: %v", err)
 	}
 
-	s, err := NewSandbox(key, true)
+	s, err := NewSandbox(key, true, false)
 	if err != nil {
 		t.Fatalf("Failed to create a new sandbox: %v", err)
 	}

--- a/sandbox/sandbox_unsupported.go
+++ b/sandbox/sandbox_unsupported.go
@@ -11,7 +11,7 @@ var (
 
 // NewSandbox provides a new sandbox instance created in an os specific way
 // provided a key which uniquely identifies the sandbox
-func NewSandbox(key string, osCreate bool) (Sandbox, error) {
+func NewSandbox(key string, osCreate bool, customSandbox bool) (Sandbox, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/sandboxdata_test.go
+++ b/sandboxdata_test.go
@@ -22,7 +22,7 @@ func TestSandboxAddEmpty(t *testing.T) {
 	ctrlr := createEmptyCtrlr()
 	ep := createEmptyEndpoint()
 
-	if _, err := ctrlr.sandboxAdd(sandbox.GenerateKey("sandbox1"), true, ep); err != nil {
+	if _, err := ctrlr.sandboxAdd(sandbox.GenerateKey("sandbox1"), ep.container.config, ep); err != nil {
 		t.Fatal(err)
 	}
 
@@ -48,15 +48,15 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 
 	sKey := sandbox.GenerateKey("sandbox1")
 
-	if _, err := ctrlr.sandboxAdd(sKey, true, ep1); err != nil {
+	if _, err := ctrlr.sandboxAdd(sKey, ep1.container.config, ep1); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := ctrlr.sandboxAdd(sKey, true, ep2); err != nil {
+	if _, err := ctrlr.sandboxAdd(sKey, ep2.container.config, ep2); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := ctrlr.sandboxAdd(sKey, true, ep3); err != nil {
+	if _, err := ctrlr.sandboxAdd(sKey, ep3.container.config, ep3); err != nil {
 		t.Fatal(err)
 	}
 
@@ -77,7 +77,7 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 	}
 
 	// Re-add ep3 back
-	if _, err := ctrlr.sandboxAdd(sKey, true, ep3); err != nil {
+	if _, err := ctrlr.sandboxAdd(sKey, ep3.container.config, ep3); err != nil {
 		t.Fatal(err)
 	}
 
@@ -109,11 +109,11 @@ func TestSandboxAddSamePrio(t *testing.T) {
 
 	sKey := sandbox.GenerateKey("sandbox1")
 
-	if _, err := ctrlr.sandboxAdd(sKey, true, ep1); err != nil {
+	if _, err := ctrlr.sandboxAdd(sKey, ep1.container.config, ep1); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := ctrlr.sandboxAdd(sKey, true, ep2); err != nil {
+	if _, err := ctrlr.sandboxAdd(sKey, ep2.container.config, ep2); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This driver allows containers to run in a pre-defined network namespace (can be created via "ip netns add __", for example). It works by simply creating a symbolic link between the network namespace in /var/run/docker/netns/{id} and the provided network namespace.

This patch provides very similar functionality to the patch proposed here:
https://github.com/docker/docker/pull/8216

However, this patch integrates into libnetwork and better conforms with Docker's "batteries included but removable" design goals. The namespace driver included in this PR offers Docker users much greater flexibility when deploying containers and removes the need for unsupported third party tools that attempt to achieve similar functionality.
 
Signed-off-by: Alec Benson <albenson@redhat.com>