### PR TITLE
Fix duplicate POSTROUTING MASQUERADE rules

### DIFF
--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -25,7 +25,12 @@ func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInt
 	if err != nil {
 		return fmt.Errorf("Failed to setup IP tables, cannot acquire Interface address: %s", err.Error())
 	}
-	if err = setupIPTablesInternal(config.BridgeName, addrv4, config.EnableICC, config.EnableIPMasquerade, hairpinMode, true); err != nil {
+	ipnet := addrv4.(*net.IPNet)
+	maskedAddrv4 := &net.IPNet{
+		IP:   ipnet.IP.Mask(ipnet.Mask),
+		Mask: ipnet.Mask,
+	}
+	if err = setupIPTablesInternal(config.BridgeName, maskedAddrv4, config.EnableICC, config.EnableIPMasquerade, hairpinMode, true); err != nil {
 		return fmt.Errorf("Failed to Setup IP tables: %s", err.Error())
 	}
 


### PR DESCRIPTION
Signed-off-by: Chun Chen <ramichen@tencent.com>

```
[root@c182 /data/home/gaia]# iptables -S POSTROUTING -t nat
-P POSTROUTING ACCEPT
-A POSTROUTING -s 192.168.1.0/24 ! -o docker0 -j MASQUERADE 
-A POSTROUTING -s 192.168.1.0/24 ! -o docker0 -j MASQUERADE 
-A POSTROUTING -s 192.168.1.0/24 ! -o docker0 -j MASQUERADE 

//docker log
time="2015-07-13T16:01:07.998115730+08:00" level=debug msg="/sbin/iptables, [-t nat -C POSTROUTING -s 192.168.1.1/24 ! -o docker0 -j MASQUERADE]" 
time="2015-07-13T16:01:08.000518242+08:00" level=debug msg="/sbin/iptables, [-t nat -I POSTROUTING -s 192.168.1.1/24 ! -o docker0 -j MASQUERADE]" 
```

https://github.com/docker/docker/pull/12437 removed regexp from `Exists` function and it has side effects on creating these duplicate rules with old iptable version.
Since `iptables -S POSTROUTING -t nat` print masked ip address, we should use masked ip address to check if  POSTROUTING MASQUERADE rule exits.