### PR TITLE
FIX incorrect usage about libnetwork.New() in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ There are many networking solutions available to suit a broad range of use-cases
 
 ```go
         // Create a new controller instance
-        controller := libnetwork.New()
+        controller, err := libnetwork.New()
+        if err != nil {
+                return
+        }
 
         // Select and configure the network driver
         networkType := "bridge"


### PR DESCRIPTION
libnetwork.New() should return a controller and an error. The
example in README.md ignore the error now, which will let the
codes can not be compiled by Go.