### PR TITLE
Sometimes fdb points to wrong vtep

### DIFF
--- a/drivers/overlay/peerdb.go
+++ b/drivers/overlay/peerdb.go
@@ -190,9 +190,13 @@ func (d *driver) peerDbUpdateSandbox(nid types.UUID) {
 			continue
 		}
 
+		// Go captures variables by reference. The pEntry could be
+		// pointing to the same memory location for every iteration. Make
+		// a copy of pEntry before capturing it in the following closure.
+		entry := pEntry
 		op := func() {
-			if err := d.peerAdd(nid, pEntry.eid, pKey.peerIP,
-				pKey.peerMac, pEntry.vtep,
+			if err := d.peerAdd(nid, entry.eid, pKey.peerIP,
+				pKey.peerMac, entry.vtep,
 				false); err != nil {
 				fmt.Printf("peerdbupdate in sandbox failed for ip %s and mac %s: %v",
 					pKey.peerIP, pKey.peerMac, err)


### PR DESCRIPTION
When you start a container after some other container has already
been started in the same network, the current container will have
an fdb which points to a wrong vtep to reach the already started
container. This makes the network connectivity to not work. The root
cause of the issue is because of golang does variable capture by
reference in closures and so we cannot use the return values from
range iterators directly. It needs to be copied to a locally scoped
variable and then use that copy as a capture variable in the closure.

Fixes #338 

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>