### PR TITLE
Fix ICC on Fedora systems with Firewalld

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -660,6 +660,10 @@ func (d *driver) CreateNetwork(id types.UUID, option map[string]interface{}) err
 		// Setup IPTables.
 		{config.EnableIPTables, network.setupIPTables},
 
+		//We want to track firewalld configuration so that
+		//if it is started/reloaded, the rules can be applied correctly
+		{config.EnableIPTables, network.setupFirewalld},
+
 		// Setup DefaultGatewayIPv4
 		{config.DefaultGatewayIPv4 != nil, setupGatewayIPv4},
 

--- a/drivers/bridge/link.go
+++ b/drivers/bridge/link.go
@@ -32,7 +32,12 @@ func newLink(parentIP, childIP string, ports []types.TransportPort, bridge strin
 
 func (l *link) Enable() error {
 	// -A == iptables append flag
-	return linkContainers("-A", l.parentIP, l.childIP, l.ports, l.bridge, false)
+	linkFunction := func() error {
+		return linkContainers("-A", l.parentIP, l.childIP, l.ports, l.bridge, false)
+	}
+
+	iptables.OnReloaded(func() { linkFunction() })
+	return linkFunction()
 }
 
 func (l *link) Disable() {

--- a/drivers/bridge/setup_firewalld.go
+++ b/drivers/bridge/setup_firewalld.go
@@ -1,0 +1,15 @@
+package bridge
+
+import "github.com/docker/libnetwork/iptables"
+
+func (n *bridgeNetwork) setupFirewalld(config *networkConfiguration, i *bridgeInterface) error {
+	// Sanity check.
+	if config.EnableIPTables == false {
+		return IPTableCfgError(config.BridgeName)
+	}
+
+	iptables.OnReloaded(func() { n.setupIPTables(config, i) })
+	iptables.OnReloaded(n.portMapper.ReMapAll)
+
+	return nil
+}

--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -149,7 +149,7 @@ func setIcc(bridgeIface string, iccEnable, insert bool) error {
 			iptables.Raw(append([]string{"-D", chain}, dropArgs...)...)
 
 			if !iptables.Exists(table, chain, acceptArgs...) {
-				if output, err := iptables.Raw(append([]string{"-A", chain}, acceptArgs...)...); err != nil {
+				if output, err := iptables.Raw(append([]string{"-I", chain}, acceptArgs...)...); err != nil {
 					return fmt.Errorf("Unable to allow intercontainer communication: %s", err.Error())
 				} else if len(output) != 0 {
 					return fmt.Errorf("Error enabling intercontainer communication: %s", output)

--- a/portmapper/mapper.go
+++ b/portmapper/mapper.go
@@ -179,6 +179,18 @@ func (pm *PortMapper) Unmap(host net.Addr) error {
 	return nil
 }
 
+//ReMapAll will re-apply all port mappings
+func (pm *PortMapper) ReMapAll() {
+	logrus.Debugln("Re-applying all port mappings.")
+	for _, data := range pm.currentMappings {
+		containerIP, containerPort := getIPAndPort(data.container)
+		hostIP, hostPort := getIPAndPort(data.host)
+		if err := pm.forward(iptables.Append, data.proto, hostIP, hostPort, containerIP.String(), containerPort); err != nil {
+			logrus.Errorf("Error on iptables add: %s", err)
+		}
+	}
+}
+
 func getKey(a net.Addr) string {
 	switch t := a.(type) {
 	case *net.TCPAddr:


### PR DESCRIPTION
On a system with firewalld enabled, start two containers (name them one and two, respectively). Link them together. In the first, run "nc -l -p 1234". In the other, run "nc one 1234". Prior to this patch, this will not work. After this patch, everything works as expected. 

On systems with firewalld turned off (or not present), everything still works fine. 
The  error is caused by an out-of-order IP table rule. 
Iptables -nvL on an affected system shows the following:
```
Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 DOCKER     all  --  *      docker0  0.0.0.0/0            0.0.0.0/0           
    0     0 ACCEPT     all  --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
    0     0 ACCEPT     all  --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
    0     0 ACCEPT     all  --  *      virbr0  0.0.0.0/0            192.168.122.0/24     ctstate RELATED,ESTABLISHED
    0     0 ACCEPT     all  --  virbr0 *       192.168.122.0/24     0.0.0.0/0           
    0     0 ACCEPT     all  --  virbr0 virbr0  0.0.0.0/0            0.0.0.0/0           
    0     0 REJECT     all  --  *      virbr0  0.0.0.0/0            0.0.0.0/0            reject-with icmp-port-unreachable
    0     0 REJECT     all  --  virbr0 *       0.0.0.0/0            0.0.0.0/0            reject-with icmp-port-unreachable
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
    0     0 ACCEPT     all  --  lo     *       0.0.0.0/0            0.0.0.0/0           
    0     0 FORWARD_direct  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
    0     0 FORWARD_IN_ZONES_SOURCE  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
    0     0 FORWARD_IN_ZONES  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
    0     0 FORWARD_OUT_ZONES_SOURCE  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
    0     0 FORWARD_OUT_ZONES  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
    0     0 ACCEPT     icmp --  *      *       0.0.0.0/0            0.0.0.0/0           
    0     0 DROP       all  --  *      *       0.0.0.0/0            0.0.0.0/0            ctstate INVALID
    0     0 REJECT     all  --  *      *       0.0.0.0/0            0.0.0.0/0            reject-with icmp-host-prohibited
    0     0 ACCEPT     all  --  docker0 docker0  0.0.0.0/0            0.0.0.0/0
```

The final accept rule is out of place and prevents containers from communicating. This patch simply inserts the rule instead of appending it, moving it back to the correct spot and allowing a firewalld enabled Fedora system to use ICC again. 

This patch also implements the missing firewalld functionality to re-configure IPtables and container links when firewalld is reloaded. This code was already present in libnetwork, but was not being called anywhere.


Signed-off-by: alec <abenson@wpi.edu>