### PR TITLE
deadlock fix in RemoveStaticRoute

### DIFF
--- a/sandbox/route_linux.go
+++ b/sandbox/route_linux.go
@@ -177,7 +177,6 @@ func (n *networkNamespace) AddStaticRoute(r *types.StaticRoute) error {
 }
 
 func (n *networkNamespace) RemoveStaticRoute(r *types.StaticRoute) error {
-	n.Lock()
 
 	err := removeRoute(n.nsPath(), r.Destination, r.NextHop)
 	if err == nil {


### PR DESCRIPTION
there was an extra Lock(), which caused a deadlock during static route removal.