### PR TITLE
Misc fixes to ip allocation in bridge driver

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -947,8 +947,7 @@ func (d *driver) CreateEndpoint(nid, eid types.UUID, epInfo driverapi.EndpointIn
 	}
 
 	// v4 address for the sandbox side pipe interface
-	sub := types.GetIPNetCopy(n.bridge.bridgeIPv4)
-	sub.IP = sub.IP.Mask(sub.Mask)
+	sub := types.GetIPNetCanonical(n.bridge.bridgeIPv4)
 	ip4, err := ipAllocator.RequestIP(sub, nil)
 	if err != nil {
 		return err
@@ -1075,7 +1074,8 @@ func (d *driver) DeleteEndpoint(nid, eid types.UUID) error {
 	n.releasePorts(ep)
 
 	// Release the v4 address allocated to this endpoint's sandbox interface
-	err = ipAllocator.ReleaseIP(n.bridge.bridgeIPv4, ep.addr.IP)
+	sub := types.GetIPNetCanonical(n.bridge.bridgeIPv4)
+	err = ipAllocator.ReleaseIP(sub, ep.addr.IP)
 	if err != nil {
 		return err
 	}

--- a/drivers/bridge/setup_ipv4.go
+++ b/drivers/bridge/setup_ipv4.go
@@ -76,7 +76,8 @@ func setupBridgeIPv4(config *networkConfiguration, i *bridgeInterface) error {
 }
 
 func allocateBridgeIP(config *networkConfiguration, i *bridgeInterface) error {
-	ipAllocator.RequestIP(i.bridgeIPv4, i.bridgeIPv4.IP)
+	sub := types.GetIPNetCanonical(i.bridgeIPv4)
+	ipAllocator.RequestIP(sub, i.bridgeIPv4.IP)
 	return nil
 }
 
@@ -112,8 +113,7 @@ func setupGatewayIPv4(config *networkConfiguration, i *bridgeInterface) error {
 	}
 
 	// Pass the real network subnet to ip allocator (no host bits set)
-	sub := types.GetIPNetCopy(i.bridgeIPv4)
-	sub.IP = sub.IP.Mask(sub.Mask)
+	sub := types.GetIPNetCanonical(i.bridgeIPv4)
 	if _, err := ipAllocator.RequestIP(sub, config.DefaultGatewayIPv4); err != nil {
 		return err
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -173,6 +173,16 @@ func GetIPNetCopy(from *net.IPNet) *net.IPNet {
 	return &net.IPNet{IP: GetIPCopy(from.IP), Mask: bm}
 }
 
+// GetIPNetCanonical returns the canonical form for the passed network
+func GetIPNetCanonical(nw *net.IPNet) *net.IPNet {
+	if nw == nil {
+		return nil
+	}
+	c := GetIPNetCopy(nw)
+	c.IP = c.IP.Mask(nw.Mask)
+	return c
+}
+
 // CompareIPNet returns equal if the two IP Networks are equal
 func CompareIPNet(a, b *net.IPNet) bool {
 	if a == b {


### PR DESCRIPTION
Two changes were missing:
- On allocation of bridge ip was not passing canonical subnet
- Canonical subnet has to be passed on ip release
  as well, otherwise ipallocator will attempt
  ip release from a non registered nw, and addresses do not get actually released

Signed-off-by: Alessandro Boch <aboch@docker.com>