### PR TITLE
Simplify and fix os.MkdirAll() usage

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -297,12 +297,7 @@ func (ep *endpoint) processOptions(options ...EndpointOption) {
 }
 
 func createBasePath(dir string) error {
-	err := os.MkdirAll(dir, 0644)
-	if err != nil && !os.IsExist(err) {
-		return err
-	}
-
-	return nil
+	return os.MkdirAll(dir, 0644)
 }
 
 func createFile(path string) error {

--- a/sandbox/namespace_linux.go
+++ b/sandbox/namespace_linux.go
@@ -48,7 +48,7 @@ func init() {
 
 func createBasePath() {
 	err := os.MkdirAll(prefix, 0644)
-	if err != nil && !os.IsExist(err) {
+	if err != nil {
 		panic("Could not create net namespace path directory")
 	}
 


### PR DESCRIPTION
Please review; I think it's of moderate importance as ignoring error from MkdirAll can lead to some other error later and it could be hard to track the cause down to failed MkdirAll.