### PR TITLE
Fixing Vagrant to use ubuntu 15.04 to pull Experimental docker version

### DIFF
--- a/docs/Vagrantfile
+++ b/docs/Vagrantfile
@@ -20,11 +20,12 @@ apt-get -y install bridge-utils
 wget -qO- https://experimental.docker.com/ | sh
 gpasswd -a vagrant docker
 echo DOCKER_OPTS=\\"--default-network=overlay:multihost --kv-store=consul:192.168.33.10:8500 --label=com.docker.network.driver.overlay.bind_interface=eth1 --label=com.docker.network.driver.overlay.neighbor_ip=192.168.33.11\\" >> /etc/default/docker
-service docker restart
+cp /vagrant/vagrant-systemd/docker.service /etc/systemd/system/
+systemctl daemon-reload
+systemctl restart docker.service
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-
   config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
   num_nodes = 2
   base_ip = "192.168.33."
@@ -42,7 +43,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   num_nodes.times do |n|
     config.vm.define "net-#{n+1}" do |net|
-      net.vm.box = "chef/ubuntu-14.10"
+      net.vm.box = "ubuntu/vivid64"
       net_ip = net_ips[n]
       net_index = n+1
       net.vm.hostname = "net-#{net_index}"

--- a/docs/vagrant-systemd/docker.service
+++ b/docs/vagrant-systemd/docker.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network.target docker.socket
+Requires=docker.socket
+
+[Service]
+EnvironmentFile=-/etc/default/docker
+ExecStart=/usr/bin/docker daemon -H fd:// $DOCKER_OPTS
+MountFlags=slave
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION

14.10 reached EOL recently and hence experimental builds are not built for
that distro any more. Upgrading it to 15.04 means handling the systemd
specific docker daemon configs required for multi-host networking.

Signed-off-by: Madhu Venugopal <madhu@docker.com>