### PR TITLE
Remove unused config check

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -442,7 +442,7 @@ func (d *driver) Config(option map[string]interface{}) error {
 	}
 
 	if config.EnableIPForwarding {
-		return setupIPForwarding(config)
+		return setupIPForwarding()
 	}
 
 	return nil

--- a/drivers/bridge/errors.go
+++ b/drivers/bridge/errors.go
@@ -115,17 +115,6 @@ func (eim ErrInvalidMtu) Error() string {
 // BadRequest denotes the type of this error
 func (eim ErrInvalidMtu) BadRequest() {}
 
-// ErrIPFwdCfg is returned when ip forwarding setup is invoked when the configuration
-// not enabled.
-type ErrIPFwdCfg struct{}
-
-func (eipf *ErrIPFwdCfg) Error() string {
-	return "unexpected request to enable IP Forwarding"
-}
-
-// BadRequest denotes the type of this error
-func (eipf *ErrIPFwdCfg) BadRequest() {}
-
 // ErrInvalidPort is returned when the container or host port specified in the port binding is not valid.
 type ErrInvalidPort string
 

--- a/drivers/bridge/setup_ip_forwarding.go
+++ b/drivers/bridge/setup_ip_forwarding.go
@@ -10,12 +10,7 @@ const (
 	ipv4ForwardConfPerm = 0644
 )
 
-func setupIPForwarding(config *configuration) error {
-	// Sanity Check
-	if config.EnableIPForwarding == false {
-		return &ErrIPFwdCfg{}
-	}
-
+func setupIPForwarding() error {
 	// Enable IPv4 forwarding
 	if err := ioutil.WriteFile(ipv4ForwardConf, []byte{'1', '\n'}, ipv4ForwardConfPerm); err != nil {
 		return fmt.Errorf("Setup IP forwarding failed: %v", err)

--- a/drivers/bridge/setup_ip_forwarding_test.go
+++ b/drivers/bridge/setup_ip_forwarding_test.go
@@ -16,12 +16,8 @@ func TestSetupIPForwarding(t *testing.T) {
 		writeIPForwardingSetting(t, []byte{'0', '\n'})
 	}
 
-	// Create test interface with ip forwarding setting enabled
-	config := &configuration{
-		EnableIPForwarding: true}
-
 	// Set IP Forwarding
-	if err := setupIPForwarding(config); err != nil {
+	if err := setupIPForwarding(); err != nil {
 		t.Fatalf("Failed to setup IP forwarding: %v", err)
 	}
 
@@ -29,26 +25,6 @@ func TestSetupIPForwarding(t *testing.T) {
 	procSetting = readCurrentIPForwardingSetting(t)
 	if bytes.Compare(procSetting, []byte("1\n")) != 0 {
 		t.Fatalf("Failed to effectively setup IP forwarding")
-	}
-}
-
-func TestUnexpectedSetupIPForwarding(t *testing.T) {
-	// Read current setting and ensure the original value gets restored
-	procSetting := readCurrentIPForwardingSetting(t)
-	defer reconcileIPForwardingSetting(t, procSetting)
-
-	// Create test interface without ip forwarding setting enabled
-	config := &configuration{
-		EnableIPForwarding: false}
-
-	// Attempt Set IP Forwarding
-	err := setupIPForwarding(config)
-	if err == nil {
-		t.Fatal("Setup IP forwarding was expected to fail")
-	}
-
-	if _, ok := err.(*ErrIPFwdCfg); !ok {
-		t.Fatalf("Setup IP forwarding failed with unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
This seems redunant:
https://github.com/docker/libnetwork/compare/docker:master...runcom:remove-unused-config-check?expand=1#diff-d7584a11ca25df23d34e42758563aba7L15
`ErrIPFwdCfg` is not used anymore, the function doesn't depend on the config...
The test for `ErrIPFwdCfg` is removed

Since it's only called checking the config from the outside. Hope it's good :)

Signed-off-by: Antonio Murdaca <runcom@linux.com>