### PR TITLE
Bug in bridge network mask

### DIFF
--- a/drivers/bridge/setup_ipv4.go
+++ b/drivers/bridge/setup_ipv4.go
@@ -31,9 +31,9 @@ func init() {
 		bridgeNetworks = append(bridgeNetworks, &net.IPNet{IP: []byte{10, byte(i), 42, 1}, Mask: mask})
 	}
 	// 192.168.[42-44].1/24
-	mask[2] = 255
+	mask24 := []byte{255, 255, 255, 0}
 	for i := 42; i < 45; i++ {
-		bridgeNetworks = append(bridgeNetworks, &net.IPNet{IP: []byte{192, 168, byte(i), 1}, Mask: mask})
+		bridgeNetworks = append(bridgeNetworks, &net.IPNet{IP: []byte{192, 168, byte(i), 1}, Mask: mask24})
 	}
 }
 

--- a/drivers/bridge/setup_ipv4_test.go
+++ b/drivers/bridge/setup_ipv4_test.go
@@ -98,3 +98,14 @@ func TestSetupGatewayIPv4(t *testing.T) {
 		t.Fatalf("Set Default Gateway failed. Expected %v, Found %v", gw, br.gatewayIPv4)
 	}
 }
+
+func TestCheckPreallocatedBridgeNetworks(t *testing.T) {
+	// Just make sure the bridge networks are created the way we want (172.17.x.x/16)
+	for i := 0; i < len(bridgeNetworks); i++ {
+		fb := bridgeNetworks[i].IP[0]
+		ones, _ := bridgeNetworks[i].Mask.Size()
+		if ((fb == 172 || fb == 10) && ones != 16) || (fb == 192 && ones != 24) {
+			t.Fatalf("Wrong mask for preallocated bridge network: %s", bridgeNetworks[i].String())
+		}
+	}
+}


### PR DESCRIPTION
- that was causing all the statically allocated bridge networks to be /24

Signed-off-by: Alessandro Boch <aboch@docker.com>