### PR TITLE
Fix bug "...has already joined the endpoint"

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -410,7 +410,8 @@ func (ep *endpoint) Join(containerID string, options ...EndpointOption) error {
 	}
 	defer func() {
 		if err != nil {
-			if err = driver.Leave(nid, epid); err != nil {
+			// Do not alter global err variable, it's needed by the previous defer
+			if err := driver.Leave(nid, epid); err != nil {
 				log.Warnf("driver leave failed while rolling back join: %v", err)
 			}
 		}


### PR DESCRIPTION
- In case of sandboxAdd() failure, drive.Leave() call
  in first executed defer resets err to nil. Secondly
  executed defer in charge of resetting ep.container to nil
  will not be executed, leaving endpoint thinking it is still
  joined by the container.

Signed-off-by: Alessandro Boch <aboch@docker.com>