### PR TITLE
Fix bug "...has already joined the endpoint"

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -415,7 +415,8 @@ func (ep *endpoint) Join(containerID string, options ...EndpointOption) error {
 	}
 	defer func() {
 		if err != nil {
-			if err = driver.Leave(nid, epid); err != nil {
+			// Do not alter global err variable, it's needed by the previous defer
+			if err := driver.Leave(nid, epid); err != nil {
 				log.Warnf("driver leave failed while rolling back join: %v", err)
 			}
 		}


### PR DESCRIPTION
- In case of sandboxAdd() failure, drive.Leave() call
  in first executed defer reset err to nil. Secondly
  executed defer in charge of resetting ep.container to nil
  will not get executed.

- Porting to release 0.4 branch

Signed-off-by: Alessandro Boch <aboch@docker.com>