### PR TITLE
Fixes ip allocation for multi bridge networks

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -104,12 +104,9 @@ type driver struct {
 	sync.Mutex
 }
 
-func init() {
-	ipAllocator = ipallocator.New()
-}
-
 // New constructs a new bridge driver
 func newDriver() driverapi.Driver {
+	ipAllocator = ipallocator.New()
 	return &driver{networks: map[string]*bridgeNetwork{}}
 }
 
@@ -785,6 +782,18 @@ func (d *driver) DeleteNetwork(nid string) error {
 
 	// Programming
 	err = netlink.LinkDel(n.bridge.Link)
+
+	// Release ip addresses (ignore errors)
+	if config.FixedCIDR == nil || config.FixedCIDR.Contains(config.DefaultGatewayIPv4) {
+		if e := ipAllocator.ReleaseIP(n.bridge.bridgeIPv4, n.bridge.gatewayIPv4); e != nil {
+			logrus.Warnf("Failed to release default gateway address %s: %v", n.bridge.gatewayIPv4.String(), e)
+		}
+	}
+	if config.FixedCIDR == nil || config.FixedCIDR.Contains(n.bridge.bridgeIPv4.IP) {
+		if e := ipAllocator.ReleaseIP(n.bridge.bridgeIPv4, n.bridge.bridgeIPv4.IP); e != nil {
+			logrus.Warnf("Failed to release bridge IP %s: %v", n.bridge.bridgeIPv4.IP.String(), e)
+		}
+	}
 
 	return err
 }

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -637,7 +637,19 @@ func TestSetDefaultGw(t *testing.T) {
 	}
 
 	_, subnetv6, _ := net.ParseCIDR("2001:db8:ea9:9abc:b0c4::/80")
-	gw4 := bridgeNetworks[0].IP.To4()
+
+	var nw *net.IPNet
+	for _, n := range bridgeNetworks {
+		if err := netutils.CheckRouteOverlaps(n); err == nil {
+			nw = n
+			break
+		}
+	}
+	if nw == nil {
+		t.Skipf("Skip as no more automatic networks available")
+	}
+
+	gw4 := types.GetIPCopy(nw.IP).To4()
 	gw4[3] = 254
 	gw6 := net.ParseIP("2001:db8:ea9:9abc:b0c4::254")
 


### PR DESCRIPTION
- Do not discard errors on ip allocation for gw and bridge
- Release addresses on network delete
- Add some context on top of ipallocator returned error

Signed-off-by: Alessandro Boch <aboch@docker.com>