### PR TITLE
Fix for zookeeper backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all all-local build build-local check check-code check-format run-tests check-local integration-tests install-deps coveralls circle-ci
+.PHONY: all all-local build build-local check check-code check-format run-tests check-local integration-tests install-deps coveralls circle-ci start-services
 SHELL=/bin/bash
 build_image=libnetwork-build
 dockerargs = --privileged -v $(shell pwd):/go/src/github.com/docker/libnetwork -w /go/src/github.com/docker/libnetwork
@@ -67,10 +67,10 @@ run-tests:
 	done
 	@echo "Done running tests"
 
-check-local:	check-format check-code run-tests
+check-local: 	check-format check-code start-services run-tests
 
 install-deps:
-	apt-get update && apt-get -y install iptables
+	apt-get update && apt-get -y install iptables zookeeperd
 	git clone https://github.com/golang/tools /go/src/golang.org/x/tools
 	go install golang.org/x/tools/cmd/vet
 	go install golang.org/x/tools/cmd/goimports
@@ -88,3 +88,6 @@ coveralls:
 circle-ci:
 	@${cidocker} make install-deps build-local check-local coveralls
 	make integration-tests
+
+start-services:
+	service zookeeper start

--- a/store_test.go
+++ b/store_test.go
@@ -1,0 +1,20 @@
+package libnetwork
+
+import (
+	"testing"
+
+	"github.com/docker/libnetwork/config"
+)
+
+func TestZooKeeperBackend(t *testing.T) {
+	testNewController(t, "zk", "127.0.0.1:2181")
+}
+
+func testNewController(t *testing.T, provider, url string) error {
+	netOptions := []config.Option{}
+	netOptions = append(netOptions, config.OptionKVProvider(provider))
+	netOptions = append(netOptions, config.OptionKVProviderURL(url))
+
+	_, err := New(netOptions...)
+	return err
+}


### PR DESCRIPTION
Signed-off-by: Chun Chen <ramichen@tencent.com>

For both etcd and zookeeper, it's not allowed to watch a not exist node.
Tested on my laptop. Please don't review until https://github.com/docker/libkv/pull/41 get's in.