### PR TITLE
Add DNS 'options' support

### DIFF
--- a/resolvconf/resolvconf.go
+++ b/resolvconf/resolvconf.go
@@ -30,6 +30,7 @@ var (
 	nsIPv6Regexp      = regexp.MustCompile(`(?m)^nameserver\s+` + ipv6Address + `\s*\n*`)
 	nsRegexp          = regexp.MustCompile(`^\s*nameserver\s*((` + ipv4Address + `)|(` + ipv6Address + `))\s*$`)
 	searchRegexp      = regexp.MustCompile(`^\s*search\s*(([^\s]+\s*)*)$`)
+	optionsRegexp     = regexp.MustCompile(`^\s*options\s*(([^\s]+\s*)*)$`)
 )
 
 var lastModified struct {
@@ -165,10 +166,25 @@ func GetSearchDomains(resolvConf []byte) []string {
 	return domains
 }
 
+// GetOptions returns options (if any) listed in /etc/resolv.conf
+// If more than one options line is encountered, only the contents of the last
+// one is returned.
+func GetOptions(resolvConf []byte) []string {
+	options := []string{}
+	for _, line := range getLines(resolvConf, []byte("#")) {
+		match := optionsRegexp.FindSubmatch(line)
+		if match == nil {
+			continue
+		}
+		options = strings.Fields(string(match[1]))
+	}
+	return options
+}
+
 // Build writes a configuration file to path containing a "nameserver" entry
-// for every element in dns, and a "search" entry for every element in
-// dnsSearch.
-func Build(path string, dns, dnsSearch []string) (string, error) {
+// for every element in dns, a "search" entry for every element in
+// dnsSearch, and an "options" entry for every element in dnsOptions.
+func Build(path string, dns, dnsSearch, dnsOptions []string) (string, error) {
 	content := bytes.NewBuffer(nil)
 	if len(dnsSearch) > 0 {
 		if searchString := strings.Join(dnsSearch, " "); strings.Trim(searchString, " ") != "." {
@@ -180,6 +196,13 @@ func Build(path string, dns, dnsSearch []string) (string, error) {
 	for _, dns := range dns {
 		if _, err := content.WriteString("nameserver " + dns + "\n"); err != nil {
 			return "", err
+		}
+	}
+	if len(dnsOptions) > 0 {
+		if optsString := strings.Join(dnsOptions, " "); strings.Trim(optsString, " ") != "" {
+			if _, err := content.WriteString("options " + optsString + "\n"); err != nil {
+				return "", err
+			}
 		}
 	}
 

--- a/sandbox.go
+++ b/sandbox.go
@@ -93,6 +93,7 @@ type resolvConfPathConfig struct {
 	resolvConfHashFile   string
 	dnsList              []string
 	dnsSearchList        []string
+	dnsOptionsList       []string
 }
 
 type containerConfig struct {
@@ -406,17 +407,21 @@ func (sb *sandbox) setupDNS() error {
 	}
 	dnsList := resolvconf.GetNameservers(resolvConf)
 	dnsSearchList := resolvconf.GetSearchDomains(resolvConf)
+	dnsOptionsList := resolvconf.GetOptions(resolvConf)
 
-	if len(sb.config.dnsList) > 0 || len(sb.config.dnsSearchList) > 0 {
+	if len(sb.config.dnsList) > 0 || len(sb.config.dnsSearchList) > 0 || len(dnsOptionsList) > 0 {
 		if len(sb.config.dnsList) > 0 {
 			dnsList = sb.config.dnsList
 		}
 		if len(sb.config.dnsSearchList) > 0 {
 			dnsSearchList = sb.config.dnsSearchList
 		}
+		if len(sb.config.dnsOptionsList) > 0 {
+			dnsOptionsList = sb.config.dnsOptionsList
+		}
 	}
 
-	hash, err := resolvconf.Build(sb.config.resolvConfPath, dnsList, dnsSearchList)
+	hash, err := resolvconf.Build(sb.config.resolvConfPath, dnsList, dnsSearchList, dnsOptionsList)
 	if err != nil {
 		return err
 	}
@@ -577,6 +582,14 @@ func OptionDNS(dns string) SandboxOption {
 func OptionDNSSearch(search string) SandboxOption {
 	return func(sb *sandbox) {
 		sb.config.dnsSearchList = append(sb.config.dnsSearchList, search)
+	}
+}
+
+// OptionDNSOptions function returns an option setter for dns options entry option to
+// be passed to container Create method.
+func OptionDNSOptions(options string) SandboxOption {
+	return func(sb *sandbox) {
+		sb.config.dnsOptionsList = append(sb.config.dnsOptionsList, options)
 	}
 }
 


### PR DESCRIPTION
This is needed to expose DNS options like 'ndots' into containers.

https://github.com/docker/docker/issues/14069

Signed-off-by: Tim Hockin <thockin@google.com>