### PR TITLE
Overlay driver should assign interface mac based on the IP

### DIFF
--- a/drivers/overlay/ov_endpoint.go
+++ b/drivers/overlay/ov_endpoint.go
@@ -73,7 +73,7 @@ func (d *driver) CreateEndpoint(nid, eid types.UUID, epInfo driverapi.EndpointIn
 
 	binary.BigEndian.PutUint32(ep.addr.IP, bridgeSubnetInt+ipID)
 
-	ep.mac = netutils.GenerateRandomMAC()
+	ep.mac = netutils.GenerateMACFromIP(ep.addr.IP)
 
 	err = epInfo.AddInterface(1, ep.mac, *ep.addr, net.IPNet{})
 	if err != nil {


### PR DESCRIPTION
After a container restart sometimes the same IP that was assigned before gets assigned. But the mac is randomly generated. So other containers in the same overlay will have a connectivity issue till a new ARP gets generated.

Closes #395 

Signed-off-by: Santhosh Manohar <santhosh@docker.com>