### PR TITLE
Fix panic due to mismatched types

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -29,6 +29,18 @@ func (e CannotSetFieldError) Error() string {
 	return fmt.Sprintf("cannot set field %q of type %q", e.Field, e.Type)
 }
 
+// TypeMismatchError is the error returned when the type of the generic value
+// for a field mismatches the type of the destination structure.
+type TypeMismatchError struct {
+	Field      string
+	ExpectType string
+	ActualType string
+}
+
+func (e TypeMismatchError) Error() string {
+	return fmt.Sprintf("type mismatch, field %s require type %v, actual type %v", e.Field, e.ExpectType, e.ActualType)
+}
+
 // Generic is an basic type to store arbitrary settings.
 type Generic map[string]interface{}
 
@@ -61,6 +73,9 @@ func GenerateFromModel(options Generic, model interface{}) (interface{}, error) 
 		}
 		if !field.CanSet() {
 			return nil, CannotSetFieldError{name, resType.String()}
+		}
+		if reflect.TypeOf(value) != field.Type() {
+			return nil, TypeMismatchError{name, field.Type().String(), reflect.TypeOf(value).String()}
 		}
 		field.Set(reflect.ValueOf(value))
 	}

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -95,3 +95,14 @@ func TestFieldCannotBeSet(t *testing.T) {
 		t.Fatalf("expected %q in error message, got %s", expected, err.Error())
 	}
 }
+
+func TestTypeMismatchError(t *testing.T) {
+	type Model struct{ Foo int }
+	_, err := GenerateFromModel(Generic{"Foo": "bar"}, Model{})
+
+	if _, ok := err.(TypeMismatchError); !ok {
+		t.Fatalf("expected TypeMismatchError, got %#v", err)
+	} else if expected := "type mismatch"; !strings.Contains(err.Error(), expected) {
+		t.Fatalf("expected %q in error message, got %s", expected, err.Error())
+	}
+}


### PR DESCRIPTION
Signed-off-by: Chun Chen <ramichen@tencent.com>

If initializing bridge driver with `netOption := options.Generic{"EnableIPMasquerade": "true"}`, it will cause a panic.
```
panic: reflect.Set: value of type string is not assignable to type int [recovered]
	panic: reflect.Set: value of type string is not assignable to type int

goroutine 5 [running]:
testing.func·006()
	/usr/src/go/src/testing/testing.go:441 +0x181
reflect.Value.assignTo(0x5358c0, 0xc20802a4b0, 0x58, 0x5bd6d0, 0xb, 0x5351c0, 0x0, 0x0, 0x0, 0x0)
	/usr/src/go/src/reflect/value.go:2125 +0x368
reflect.Value.Set(0x5351c0, 0xc20802a4e0, 0xc2, 0x5358c0, 0xc20802a4b0, 0x58)
	/usr/src/go/src/reflect/value.go:1298 +0x96
github.com/docker/libnetwork/options.GenerateFromModel(0xc20800a510, 0x574220, 0xc20802a498, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/docker/libnetwork/options/options.go:80 +0x50e
github.com/docker/libnetwork/options.TestTypeMismatchError(0xc20805c000)
	/go/src/github.com/docker/libnetwork/options/options_test.go:101 +0x12b
testing.tRunner(0xc20805c000, 0x689920)
	/usr/src/go/src/testing/testing.go:447 +0xbf
created by testing.RunTests
	/usr/src/go/src/testing/testing.go:555 +0xa8b

goroutine 1 [chan receive]:
testing.RunTests(0x5f9670, 0x6898c0, 0x5, 0x5, 0xfee215509c16cb01)
	/usr/src/go/src/testing/testing.go:556 +0xad6
testing.(*M).Run(0xc208052140, 0x692fe0)
	/usr/src/go/src/testing/testing.go:485 +0x6c
main.main()
	github.com/docker/libnetwork/options/_test/_testmain.go:60 +0x1d5
exit status 2
```