### PR TITLE
lock port mapper when reapplying iptables rules

### DIFF
--- a/portmapper/mapper.go
+++ b/portmapper/mapper.go
@@ -188,6 +188,8 @@ func (pm *PortMapper) Unmap(host net.Addr) error {
 
 //ReMapAll will re-apply all port mappings
 func (pm *PortMapper) ReMapAll() {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
 	logrus.Debugln("Re-applying all port mappings.")
 	for _, data := range pm.currentMappings {
 		containerIP, containerPort := getIPAndPort(data.container)


### PR DESCRIPTION
Make sure that port mapper state is not updated while we are trying to remap everything.