### PR TITLE
Add Refresh() to Sandbox

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -410,18 +410,7 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 
 	sb.processOptions(options...)
 
-	err = sb.buildHostsFile()
-	if err != nil {
-		return nil, err
-	}
-
-	err = sb.updateParentHosts()
-	if err != nil {
-		return nil, err
-	}
-
-	err = sb.setupDNS()
-	if err != nil {
+	if err = sb.setupResolutionFiles(); err != nil {
 		return nil, err
 	}
 

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -1180,6 +1180,10 @@ func (f *fakeSandbox) Statistics() (map[string]*osl.InterfaceStatistics, error) 
 	return nil, nil
 }
 
+func (f *fakeSandbox) Refresh(opts ...libnetwork.SandboxOption) error {
+	return nil
+}
+
 func (f *fakeSandbox) Delete() error {
 	return nil
 }


### PR DESCRIPTION
- Convinience API which detaches the sandbox from
  all endpoints, resets and reapply config options,
  setup discovery files, reattach to the endpoints.
  No change to the osl sandbox in use.

Signed-off-by: Alessandro Boch <aboch@docker.com>