### PR TITLE
Don't discard error message on sending response

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -168,6 +168,9 @@ func makeHandler(ctrl libnetwork.NetworkController, fct processor) http.HandlerF
 		}
 
 		res, rsp := fct(ctrl, mux.Vars(req), body)
+		if !rsp.isOK() {
+			res = rsp.Status
+		}
 		if res != nil {
 			writeJSON(w, rsp.StatusCode, res)
 		}


### PR DESCRIPTION
Error messages are always discarded and it makes diagnostic difficult
when error occurs.

Before:
$ dnet network create -d overlay ov1
error : ""
$ docker network create -d overlay ov1
Error response from daemon: ""

After:
$ dnet network create -d overlay ov1
error : "no datastore configured. cannot obtain vxlan id"
$ docker network create -d overlay ov1
Error response from daemon: "no datastore configured. cannot obtain vxlan id"

Signed-off-by: Toshiaki Makita <makita.toshiaki@lab.ntt.co.jp>