### PR TITLE
Add TestEndToEndErrorMessage

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -2239,6 +2239,34 @@ func TestEndToEnd(t *testing.T) {
 	}
 }
 
+func TestEndToEndErrorMessage(t *testing.T) {
+	defer osl.SetupTestOSContext(t)()
+
+	rsp := newWriter()
+
+	c, err := libnetwork.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	handleRequest := NewHTTPHandler(c)
+
+	body := []byte{}
+	lr := newLocalReader(body)
+	req, err := http.NewRequest("POST", "/v1.19/networks", lr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handleRequest(rsp, req)
+
+	if len(rsp.body) == 0 {
+		t.Fatalf("Empty response body.")
+	}
+	empty := []byte("\"\"")
+	if bytes.Equal(empty, bytes.TrimSpace(rsp.body)) {
+		t.Fatalf("Empty response error message.")
+	}
+}
+
 type bre struct{}
 
 func (b *bre) Error() string {


### PR DESCRIPTION
Test if error messages from daemon are not empty strings.

Confirmed it fails without 8aa9f4e.

 --- FAIL: TestEndToEndErrorMessage (0.03s)
 	api_test.go:2266: Empty response error message.

Signed-off-by: Toshiaki Makita <makita.toshiaki@lab.ntt.co.jp>