### PR TITLE
Fix bridge driver panic in CreateNetwork

### DIFF
--- a/Godeps/_workspace/src/github.com/docker/libkv/.travis.yml
+++ b/Godeps/_workspace/src/github.com/docker/libkv/.travis.yml
@@ -11,8 +11,8 @@ sudo: false
 before_install:
   # Symlink below is needed for Travis CI to work correctly on personal forks of libkv
   - ln -s $HOME/gopath/src/github.com/${TRAVIS_REPO_SLUG///libkv/} $HOME/gopath/src/github.com/docker
-  - go get code.google.com/p/go.tools/cmd/vet
-  - go get code.google.com/p/go.tools/cmd/cover
+  - go get golang.org/x/tools/cmd/vet
+  - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
   - go get github.com/golang/lint/golint
   - go get github.com/GeertJohan/fgt

--- a/Godeps/_workspace/src/github.com/docker/libkv/libkv.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/libkv.go
@@ -1,11 +1,9 @@
 package libkv
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/consul"
 	"github.com/docker/libkv/store/etcd"
-	"github.com/docker/libkv/store/mock"
 	"github.com/docker/libkv/store/zookeeper"
 )
 
@@ -15,17 +13,15 @@ type Initialize func(addrs []string, options *store.Config) (store.Store, error)
 var (
 	// Backend initializers
 	initializers = map[store.Backend]Initialize{
-		store.MOCK:   mock.InitializeMock,
-		store.CONSUL: consul.InitializeConsul,
-		store.ETCD:   etcd.InitializeEtcd,
-		store.ZK:     zookeeper.InitializeZookeeper,
+		store.CONSUL: consul.New,
+		store.ETCD:   etcd.New,
+		store.ZK:     zookeeper.New,
 	}
 )
 
 // NewStore creates a an instance of store
 func NewStore(backend store.Backend, addrs []string, options *store.Config) (store.Store, error) {
 	if init, exists := initializers[backend]; exists {
-		log.WithFields(log.Fields{"backend": backend}).Debug("Initializing store service")
 		return init(addrs, options)
 	}
 

--- a/Godeps/_workspace/src/github.com/docker/libkv/libkv_test.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/libkv_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/consul"
 	"github.com/docker/libkv/store/etcd"
-	"github.com/docker/libkv/store/mock"
 	"github.com/docker/libkv/store/zookeeper"
 	"github.com/stretchr/testify/assert"
 )
@@ -63,16 +62,6 @@ func TestNewStoreZookeeper(t *testing.T) {
 
 	if _, ok := kv.(*zookeeper.Zookeeper); !ok {
 		t.Fatal("Error while initializing store zookeeper")
-	}
-}
-
-func TestNewStoreMock(t *testing.T) {
-	kv, err := NewStore(store.MOCK, []string{}, &store.Config{})
-	assert.NoError(t, err)
-	assert.NotNil(t, kv)
-
-	if _, ok := kv.(*mock.Mock); !ok {
-		t.Fatal("Error while initializing mock store")
 	}
 }
 

--- a/Godeps/_workspace/src/github.com/docker/libkv/script/travis_consul.sh
+++ b/Godeps/_workspace/src/github.com/docker/libkv/script/travis_consul.sh
@@ -12,7 +12,7 @@ unzip "${CONSUL_VERSION}_linux_amd64.zip"
 
 # make config for minimum ttl
 touch config.json
-echo "{\"session_ttl_min\": \"2s\"}" >> config.json
+echo "{\"session_ttl_min\": \"1s\"}" >> config.json
 
 # check
 ./consul --version

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/consul/consul.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/consul/consul.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store"
 	api "github.com/hashicorp/consul/api"
 )
@@ -32,9 +31,9 @@ type consulLock struct {
 	lock *api.Lock
 }
 
-// InitializeConsul creates a new Consul client given
-// a list of endpoints and optional tls config
-func InitializeConsul(endpoints []string, options *store.Config) (store.Store, error) {
+// New creates a new Consul client given a list
+// of endpoints and optional tls config
+func New(endpoints []string, options *store.Config) (store.Store, error) {
 	s := &Consul{}
 
 	// Create Consul client
@@ -60,7 +59,6 @@ func InitializeConsul(endpoints []string, options *store.Config) (store.Store, e
 	// Creates a new client
 	client, err := api.NewClient(config)
 	if err != nil {
-		log.Errorf("Couldn't initialize consul client..")
 		return nil, err
 	}
 	s.client = client
@@ -101,8 +99,9 @@ func (s *Consul) refreshSession(pair *api.KVPair) error {
 
 	if session == "" {
 		entry := &api.SessionEntry{
-			Behavior: api.SessionBehaviorDelete,
-			TTL:      s.ephemeralTTL.String(),
+			Behavior:  api.SessionBehaviorDelete,       // Delete the key when the session expires
+			TTL:       ((s.ephemeralTTL) / 2).String(), // Consul multiplies the TTL by 2x
+			LockDelay: 1 * time.Millisecond,            // Virtually disable lock delay
 		}
 
 		// Create the key session
@@ -110,19 +109,19 @@ func (s *Consul) refreshSession(pair *api.KVPair) error {
 		if err != nil {
 			return err
 		}
-	}
 
-	lockOpts := &api.LockOptions{
-		Key:     pair.Key,
-		Session: session,
-	}
+		lockOpts := &api.LockOptions{
+			Key:     pair.Key,
+			Session: session,
+		}
 
-	// Lock and ignore if lock is held
-	// It's just a placeholder for the
-	// ephemeral behavior
-	lock, _ := s.client.LockOpts(lockOpts)
-	if lock != nil {
-		lock.Lock(nil)
+		// Lock and ignore if lock is held
+		// It's just a placeholder for the
+		// ephemeral behavior
+		lock, _ := s.client.LockOpts(lockOpts)
+		if lock != nil {
+			lock.Lock(nil)
+		}
 	}
 
 	_, _, err = s.client.Session().Renew(session, nil)
@@ -312,7 +311,6 @@ func (s *Consul) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*
 			// Get all the childrens
 			pairs, meta, err := kv.List(directory, opts)
 			if err != nil {
-				log.Errorf("consul: %v", err)
 				return
 			}
 
@@ -324,18 +322,18 @@ func (s *Consul) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*
 			opts.WaitIndex = meta.LastIndex
 
 			// Return children KV pairs to the channel
-			kv := []*store.KVPair{}
+			kvpairs := []*store.KVPair{}
 			for _, pair := range pairs {
 				if pair.Key == directory {
 					continue
 				}
-				kv = append(kv, &store.KVPair{
+				kvpairs = append(kvpairs, &store.KVPair{
 					Key:       pair.Key,
 					Value:     pair.Value,
 					LastIndex: pair.ModifyIndex,
 				})
 			}
-			watchCh <- kv
+			watchCh <- kvpairs
 		}
 	}()
 
@@ -377,11 +375,16 @@ func (l *consulLock) Unlock() error {
 // AtomicPut put a value at "key" if the key has not been
 // modified in the meantime, throws an error if this is the case
 func (s *Consul) AtomicPut(key string, value []byte, previous *store.KVPair, options *store.WriteOptions) (bool, *store.KVPair, error) {
+
+	p := &api.KVPair{Key: s.normalize(key), Value: value}
+
 	if previous == nil {
-		return false, nil, store.ErrPreviousNotSpecified
+		// Consul interprets ModifyIndex = 0 as new key.
+		p.ModifyIndex = 0
+	} else {
+		p.ModifyIndex = previous.LastIndex
 	}
 
-	p := &api.KVPair{Key: s.normalize(key), Value: value, ModifyIndex: previous.LastIndex}
 	if work, _, err := s.client.KV().CAS(p, nil); err != nil {
 		return false, nil, err
 	} else if !work {

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/consul/consul_test.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/consul/consul_test.go
@@ -5,13 +5,14 @@ import (
 	"time"
 
 	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
 func makeConsulClient(t *testing.T) store.Store {
 	client := "localhost:8500"
 
-	kv, err := InitializeConsul(
+	kv, err := New(
 		[]string{client},
 		&store.Config{
 			ConnectionTimeout: 3 * time.Second,
@@ -30,7 +31,7 @@ func TestConsulStore(t *testing.T) {
 	kv := makeConsulClient(t)
 	backup := makeConsulClient(t)
 
-	store.TestStore(t, kv, backup)
+	testutils.RunTestStore(t, kv, backup)
 }
 
 func TestGetActiveSession(t *testing.T) {

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/etcd/etcd_test.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/etcd/etcd_test.go
@@ -5,12 +5,13 @@ import (
 	"time"
 
 	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/testutils"
 )
 
 func makeEtcdClient(t *testing.T) store.Store {
 	client := "localhost:4001"
 
-	kv, err := InitializeEtcd(
+	kv, err := New(
 		[]string{client},
 		&store.Config{
 			ConnectionTimeout: 3 * time.Second,
@@ -29,5 +30,5 @@ func TestEtcdStore(t *testing.T) {
 	kv := makeEtcdClient(t)
 	backup := makeEtcdClient(t)
 
-	store.TestStore(t, kv, backup)
+	testutils.RunTestStore(t, kv, backup)
 }

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/mock/mock.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/mock/mock.go
@@ -16,8 +16,8 @@ type Mock struct {
 	Options *store.Config
 }
 
-// InitializeMock creates a Mock store.
-func InitializeMock(endpoints []string, options *store.Config) (store.Store, error) {
+// New creates a Mock store
+func New(endpoints []string, options *store.Config) (store.Store, error) {
 	s := &Mock{}
 	s.Endpoints = endpoints
 	s.Options = options

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/store.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/store.go
@@ -10,14 +10,12 @@ import (
 type Backend string
 
 const (
-	// MOCK backend
-	MOCK Backend = "mock"
 	// CONSUL backend
-	CONSUL = "consul"
+	CONSUL Backend = "consul"
 	// ETCD backend
-	ETCD = "etcd"
+	ETCD Backend = "etcd"
 	// ZK backend
-	ZK = "zk"
+	ZK Backend = "zk"
 )
 
 var (
@@ -79,7 +77,8 @@ type Store interface {
 	// DeleteTree deletes a range of keys under a given directory
 	DeleteTree(directory string) error
 
-	// Atomic operation on a single value
+	// Atomic CAS operation on a single value.
+	// Pass previous = nil to create a new key.
 	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error)
 
 	// Atomic delete of a single value

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/zookeeper/zookeeper.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/zookeeper/zookeeper.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store"
 	zk "github.com/samuel/go-zookeeper/zk"
 )
@@ -25,9 +24,9 @@ type zookeeperLock struct {
 	value  []byte
 }
 
-// InitializeZookeeper creates a new Zookeeper client
-// given a list of endpoints and an optional tls config
-func InitializeZookeeper(endpoints []string, options *store.Config) (store.Store, error) {
+// New creates a new Zookeeper client given a
+// list of endpoints and an optional tls config
+func New(endpoints []string, options *store.Config) (store.Store, error) {
 	s := &Zookeeper{}
 	s.timeout = defaultTimeout
 
@@ -41,7 +40,6 @@ func InitializeZookeeper(endpoints []string, options *store.Config) (store.Store
 	// Connect to Zookeeper
 	conn, _, err := zk.Connect(endpoints, s.timeout)
 	if err != nil {
-		log.Error(err)
 		return nil, err
 	}
 	s.client = conn
@@ -267,23 +265,47 @@ func (s *Zookeeper) DeleteTree(directory string) error {
 // AtomicPut put a value at "key" if the key has not been
 // modified in the meantime, throws an error if this is the case
 func (s *Zookeeper) AtomicPut(key string, value []byte, previous *store.KVPair, _ *store.WriteOptions) (bool, *store.KVPair, error) {
-	if previous == nil {
-		return false, nil, store.ErrPreviousNotSpecified
-	}
 
-	meta, err := s.client.Set(store.Normalize(key), value, int32(previous.LastIndex))
-	if err != nil {
-		// Compare Failed
-		if err == zk.ErrBadVersion {
-			return false, nil, store.ErrKeyModified
+	var lastIndex uint64
+	if previous != nil {
+		meta, err := s.client.Set(store.Normalize(key), value, int32(previous.LastIndex))
+		if err != nil {
+			// Compare Failed
+			if err == zk.ErrBadVersion {
+				return false, nil, store.ErrKeyModified
+			}
+			return false, nil, err
 		}
-		return false, nil, err
+		lastIndex = uint64(meta.Version)
+	} else {
+		// Interpret previous == nil as create operation.
+		_, err := s.client.Create(store.Normalize(key), value, 0, zk.WorldACL(zk.PermAll))
+		if err != nil {
+			// Zookeeper will complain if the directory doesn't exist.
+			if err == zk.ErrNoNode {
+				// Create the directory
+				parts := store.SplitKey(key)
+				parts = parts[:len(parts)-1]
+				if err = s.createFullPath(parts, false); err != nil {
+					// Failed to create the directory.
+					return false, nil, err
+				}
+				if _, err := s.client.Create(store.Normalize(key), value, 0, zk.WorldACL(zk.PermAll)); err != nil {
+					return false, nil, err
+				}
+
+			} else {
+				// Unhandled error
+				return false, nil, err
+			}
+		}
+		lastIndex = 0 // Newly created nodes have version 0.
 	}
 
 	pair := &store.KVPair{
 		Key:       key,
 		Value:     value,
-		LastIndex: uint64(meta.Version),
+		LastIndex: lastIndex,
 	}
 
 	return true, pair, nil

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/zookeeper/zookeeper_test.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/zookeeper/zookeeper_test.go
@@ -5,12 +5,13 @@ import (
 	"time"
 
 	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/testutils"
 )
 
 func makeZkClient(t *testing.T) store.Store {
 	client := "localhost:2181"
 
-	kv, err := InitializeZookeeper(
+	kv, err := New(
 		[]string{client},
 		&store.Config{
 			ConnectionTimeout: 3 * time.Second,
@@ -29,5 +30,5 @@ func TestZkStore(t *testing.T) {
 	kv := makeZkClient(t)
 	backup := makeZkClient(t)
 
-	store.TestStore(t, kv, backup)
+	testutils.RunTestStore(t, kv, backup)
 }

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -98,6 +98,7 @@ type bridgeNetwork struct {
 
 type driver struct {
 	config      *configuration
+	configured  bool
 	network     *bridgeNetwork
 	natChain    *iptables.ChainInfo
 	filterChain *iptables.ChainInfo
@@ -108,7 +109,7 @@ type driver struct {
 // New constructs a new bridge driver
 func newDriver() driverapi.Driver {
 	ipAllocator = ipallocator.New()
-	return &driver{networks: map[string]*bridgeNetwork{}}
+	return &driver{networks: map[string]*bridgeNetwork{}, config: &configuration{}}
 }
 
 // Init registers a new instance of bridge driver
@@ -433,29 +434,26 @@ func (d *driver) Config(option map[string]interface{}) error {
 	d.Lock()
 	defer d.Unlock()
 
-	if d.config != nil {
+	if d.configured {
 		return &ErrConfigExists{}
 	}
 
 	genericData, ok := option[netlabel.GenericData]
-	if ok && genericData != nil {
-		switch opt := genericData.(type) {
-		case options.Generic:
-			opaqueConfig, err := options.GenerateFromModel(opt, &configuration{})
-			if err != nil {
-				return err
-			}
-			config = opaqueConfig.(*configuration)
-		case *configuration:
-			config = opt
-		default:
-			return &ErrInvalidDriverConfig{}
-		}
+	if !ok || genericData == nil {
+		return nil
+	}
 
-		d.config = config
-	} else {
-		config = &configuration{}
-		d.config = config
+	switch opt := genericData.(type) {
+	case options.Generic:
+		opaqueConfig, err := options.GenerateFromModel(opt, &configuration{})
+		if err != nil {
+			return err
+		}
+		config = opaqueConfig.(*configuration)
+	case *configuration:
+		config = opt
+	default:
+		return &ErrInvalidDriverConfig{}
 	}
 
 	if config.EnableIPForwarding {
@@ -467,9 +465,13 @@ func (d *driver) Config(option map[string]interface{}) error {
 
 	if config.EnableIPTables {
 		d.natChain, d.filterChain, err = setupIPChains(config)
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
+	d.configured = true
+	d.config = config
 	return nil
 }
 
@@ -566,12 +568,20 @@ func (d *driver) getNetworks() []*bridgeNetwork {
 
 // Create a new network using bridge plugin
 func (d *driver) CreateNetwork(id string, option map[string]interface{}) error {
-	var err error
+	var (
+		err          error
+		configLocked bool
+	)
 
 	defer osl.InitOSContext()()
 
 	// Sanity checks
 	d.Lock()
+	if !d.configured {
+		configLocked = true
+		d.configured = true
+	}
+
 	if _, ok := d.networks[id]; ok {
 		d.Unlock()
 		return types.ForbiddenErrorf("network %s exists", id)
@@ -610,6 +620,10 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}) error {
 	defer func() {
 		if err != nil {
 			d.Lock()
+			if configLocked {
+				d.configured = false
+			}
+
 			delete(d.networks, id)
 			d.Unlock()
 		}
@@ -651,7 +665,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}) error {
 	bridgeSetup.queueStep(setupBridgeIPv4)
 
 	enableIPv6Forwarding := false
-	if d.config != nil && d.config.EnableIPForwarding && config.FixedCIDRv6 != nil {
+	if d.config.EnableIPForwarding && config.FixedCIDRv6 != nil {
 		enableIPv6Forwarding = true
 	}
 

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -68,6 +68,19 @@ func TestCreateFullOptions(t *testing.T) {
 	}
 }
 
+func TestCreateNoConfig(t *testing.T) {
+	defer osl.SetupTestOSContext(t)()
+	d := newDriver()
+
+	netconfig := &networkConfiguration{BridgeName: DefaultBridgeName}
+	genericOption := make(map[string]interface{})
+	genericOption[netlabel.GenericData] = netconfig
+
+	if err := d.CreateNetwork("dummy", genericOption); err != nil {
+		t.Fatalf("Failed to create bridge: %v", err)
+	}
+}
+
 func TestCreate(t *testing.T) {
 	defer osl.SetupTestOSContext(t)()
 	d := newDriver()


### PR DESCRIPTION
Bridge driver panics in `CreateNetwork` if called without
a prior `Config` call. This causes issues in dnet which
tries to create network using default driver configuration.
It should be valid to call `CreateNetwork` without a prior
`Config` call in which case we need to assume default driver
config.

Fixed this by properly initializing the driver config pointer.
Also introduced a `configured` bool to make sure that still
`Config` is called exactly once for the instance of the bridge
driver.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>