### PR TITLE
Fix wrong print format

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -275,7 +275,7 @@ func getBackendID(cli *NetworkCli, servID string) (string, error) {
 			}
 		} else {
 			// Only print a message, don't make the caller cli fail for this
-			fmt.Fprintf(cli.out, "Failed to retrieve backend list for service %s (%v)", servID, err)
+			fmt.Fprintf(cli.out, "Failed to retrieve backend list for service %s (%v)\n", servID, err)
 		}
 	}
 


### PR DESCRIPTION
Add newline character to print error in better format

original print:
```
$ docker service publish test
$ docker service ls
Failed to retrieve backend list for service 1293e3ca8d221f9bf8a023c4bc7b9e65143c7f308bbd2d04f18f89050ab95901 (json: cannot unmarshal object into Go value of type []client.sandboxResource)SERVICE ID          NAME                NETWORK             CONTAINER
1293e3ca8d22        test                bridge
```

After applying this fix:
```
$ docker service ls
Failed to retrieve backend list for service 0ecf8700d1821bd1987e66b9da86183c9501e25307508ed6660cf112ebfc3bbc (json: cannot unmarshal object into Go value of type []client.sandboxResource)
SERVICE ID          NAME                NETWORK             CONTAINER
0ecf8700d182        test                bridge
```
Signed-off-by: Zhang Wei <zhangwei555@huawei.com>