### PR TITLE
Fix bug for `docker service ls`

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -268,14 +268,12 @@ func getBackendID(cli *NetworkCli, servID string) (string, error) {
 	)
 
 	if obj, _, err = readBody(cli.call("GET", "/services/"+servID+"/backend", nil, nil)); err == nil {
-		var bkl []sandboxResource
-		if err := json.NewDecoder(bytes.NewReader(obj)).Decode(&bkl); err == nil {
-			if len(bkl) > 0 {
-				bk = bkl[0].ID
-			}
+		var sr sandboxResource
+		if err := json.NewDecoder(bytes.NewReader(obj)).Decode(&sr); err == nil {
+			bk = sr.ContainerID
 		} else {
 			// Only print a message, don't make the caller cli fail for this
-			fmt.Fprintf(cli.out, "Failed to retrieve backend list for service %s (%v)", servID, err)
+			fmt.Fprintf(cli.out, "Failed to retrieve backend list for service %s (%v)\n", servID, err)
 		}
 	}
 


### PR DESCRIPTION
fix bug for `docker service ls` error:
"Failed to retrieve backend list for service xxx (json: cannot
unmarshal object into Go value of type []client.sandboxResource)"

Detailed error info is like this:
```
$ docker service publish test
$ docker service ls
Failed to retrieve backend list for service 1293e3ca8d221f9bf8a023c4bc7b9e65143c7f308bbd2d04f18f89050ab95901 (json: cannot unmarshal object into Go value of type []client.sandboxResource)SERVICE ID          NAME                NETWORK             CONTAINER
1293e3ca8d22        test                bridge
```

It looks like we are trying to unmarshal body into wrong object format.
I'm not very familiar with this part of code, let me know if there is any problem about this. :)

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>