### PR TITLE
Move test specific functions to a testutils package.

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/docker/libnetwork"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/options"
-	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
 )
 
@@ -178,7 +178,7 @@ func TestJson(t *testing.T) {
 }
 
 func TestCreateDeleteNetwork(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, err := libnetwork.New()
 	if err != nil {
@@ -256,7 +256,7 @@ func TestCreateDeleteNetwork(t *testing.T) {
 }
 
 func TestGetNetworksAndEndpoints(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, err := libnetwork.New()
 	if err != nil {
@@ -529,7 +529,7 @@ func TestGetNetworksAndEndpoints(t *testing.T) {
 }
 
 func TestProcGetServices(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, err := libnetwork.New()
 	if err != nil {
@@ -702,7 +702,7 @@ func TestProcGetServices(t *testing.T) {
 }
 
 func TestProcGetService(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, nw := createTestNetwork(t, "network")
 	ep1, err := nw.CreateEndpoint("db")
@@ -754,7 +754,7 @@ func TestProcGetService(t *testing.T) {
 }
 
 func TestProcPublishUnpublishService(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, _ := createTestNetwork(t, "network")
 	vars := make(map[string]string)
@@ -886,7 +886,7 @@ func TestProcPublishUnpublishService(t *testing.T) {
 }
 
 func TestAttachDetachBackend(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, nw := createTestNetwork(t, "network")
 	ep1, err := nw.CreateEndpoint("db")
@@ -1026,7 +1026,7 @@ func TestDetectGetNetworksInvalidQueryComposition(t *testing.T) {
 }
 
 func TestDetectGetEndpointsInvalidQueryComposition(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, _ := createTestNetwork(t, "network")
 
@@ -1038,7 +1038,7 @@ func TestDetectGetEndpointsInvalidQueryComposition(t *testing.T) {
 }
 
 func TestDetectGetServicesInvalidQueryComposition(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, _ := createTestNetwork(t, "network")
 
@@ -1055,7 +1055,7 @@ func TestFindNetworkUtilPanic(t *testing.T) {
 }
 
 func TestFindNetworkUtil(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, nw := createTestNetwork(t, "network")
 	nid := nw.ID()
@@ -1118,7 +1118,7 @@ func TestFindNetworkUtil(t *testing.T) {
 }
 
 func TestCreateDeleteEndpoints(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, err := libnetwork.New()
 	if err != nil {
@@ -1244,7 +1244,7 @@ func TestCreateDeleteEndpoints(t *testing.T) {
 }
 
 func TestJoinLeave(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, err := libnetwork.New()
 	if err != nil {
@@ -1403,7 +1403,7 @@ func TestJoinLeave(t *testing.T) {
 }
 
 func TestFindEndpointUtilPanic(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	defer checkPanic(t)
 	c, nw := createTestNetwork(t, "network")
 	nid := nw.ID()
@@ -1411,14 +1411,14 @@ func TestFindEndpointUtilPanic(t *testing.T) {
 }
 
 func TestFindServiceUtilPanic(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	defer checkPanic(t)
 	c, _ := createTestNetwork(t, "network")
 	findService(c, "random_service", -1)
 }
 
 func TestFindEndpointUtil(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, nw := createTestNetwork(t, "network")
 	nid := nw.ID()
@@ -1687,7 +1687,7 @@ func TestwriteJSON(t *testing.T) {
 }
 
 func TestHttpHandlerUninit(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	c, err := libnetwork.New()
 	if err != nil {
@@ -1756,7 +1756,7 @@ func TestHttpHandlerUninit(t *testing.T) {
 }
 
 func TestHttpHandlerBadBody(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	rsp := newWriter()
 
@@ -1788,7 +1788,7 @@ func TestHttpHandlerBadBody(t *testing.T) {
 }
 
 func TestEndToEnd(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	rsp := newWriter()
 
@@ -2240,7 +2240,7 @@ func TestEndToEnd(t *testing.T) {
 }
 
 func TestEndToEndErrorMessage(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	rsp := newWriter()
 

--- a/bitseq/sequence_test.go
+++ b/bitseq/sequence_test.go
@@ -3,7 +3,7 @@ package bitseq
 import (
 	"testing"
 
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 func TestSequenceGetAvailableBit(t *testing.T) {

--- a/client/client_service_test.go
+++ b/client/client_service_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 func TestClientServiceInvalidCommand(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 // nopCloser is used to provide a dummy CallFunc for Cmd()

--- a/cmd/dnet/dnet_test.go
+++ b/cmd/dnet/dnet_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/libnetwork/netutils"
+	"github.com/docker/libnetwork/testutils"
 )
 
 const dnetCommandName = "dnet"
@@ -15,7 +15,7 @@ const dnetCommandName = "dnet"
 var origStdOut = os.Stdout
 
 func TestDnetDaemonCustom(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
+	if !testutils.IsRunningInContainer() {
 		t.Skip("This test must run inside a container ")
 	}
 	customPort := 4567
@@ -36,7 +36,7 @@ func TestDnetDaemonCustom(t *testing.T) {
 }
 
 func TestDnetDaemonInvalidCustom(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
+	if !testutils.IsRunningInContainer() {
 		t.Skip("This test must run inside a container ")
 	}
 	customPort := 4668
@@ -57,7 +57,7 @@ func TestDnetDaemonInvalidCustom(t *testing.T) {
 }
 
 func TestDnetDaemonInvalidParams(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
+	if !testutils.IsRunningInContainer() {
 		t.Skip("This test must run inside a container ")
 	}
 	args := []string{dnetCommandName, "-d=false", "-H=tcp:/127.0.0.1:8080"}
@@ -74,7 +74,7 @@ func TestDnetDaemonInvalidParams(t *testing.T) {
 }
 
 func TestDnetDefaultsWithFlags(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
+	if !testutils.IsRunningInContainer() {
 		t.Skip("This test must run inside a container ")
 	}
 	doneChan := make(chan bool)
@@ -97,7 +97,7 @@ func TestDnetDefaultsWithFlags(t *testing.T) {
 }
 
 func TestDnetMain(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
+	if !testutils.IsRunningInContainer() {
 		t.Skip("This test must run inside a container ")
 	}
 	customPort := 4568

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/libnetwork/netlabel"
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 func TestInvalidConfig(t *testing.T) {

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/docker/libnetwork/config"
-	_ "github.com/docker/libnetwork/netutils"
 	"github.com/docker/libnetwork/options"
+	_ "github.com/docker/libnetwork/testutils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/netutils"
-	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 )
 
 func TestCreateFullOptions(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	config := &configuration{
@@ -69,7 +69,7 @@ func TestCreateFullOptions(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.Config(nil); err != nil {
@@ -102,7 +102,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreateFail(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.Config(nil); err != nil {
@@ -119,7 +119,7 @@ func TestCreateFail(t *testing.T) {
 }
 
 func TestCreateMultipleNetworks(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 	dd, _ := d.(*driver)
 
@@ -283,7 +283,7 @@ func TestQueryEndpointInfoHairpin(t *testing.T) {
 }
 
 func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 	dd, _ := d.(*driver)
 
@@ -354,7 +354,7 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 }
 
 func TestCreateLinkWithOptions(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.Config(nil); err != nil {
@@ -413,7 +413,7 @@ func getPortMapping() []types.PortBinding {
 }
 
 func TestLinkContainers(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	d := newDriver()
 
@@ -630,7 +630,7 @@ func TestValidateConfig(t *testing.T) {
 }
 
 func TestSetDefaultGw(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.Config(nil); err != nil {

--- a/drivers/bridge/interface_test.go
+++ b/drivers/bridge/interface_test.go
@@ -3,12 +3,12 @@ package bridge
 import (
 	"testing"
 
-	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 	"github.com/vishvananda/netlink"
 )
 
 func TestInterfaceDefaultName(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	config := &networkConfiguration{}
 	if _ = newInterface(config); config.BridgeName != DefaultBridgeName {
@@ -17,7 +17,7 @@ func TestInterfaceDefaultName(t *testing.T) {
 }
 
 func TestAddressesEmptyInterface(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	inf := newInterface(&networkConfiguration{})
 	addrv4, addrsv6, err := inf.addresses()

--- a/drivers/bridge/network_test.go
+++ b/drivers/bridge/network_test.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netlabel"
-	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 	"github.com/vishvananda/netlink"
 )
 
 func TestLinkCreate(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 	dr := d.(*driver)
 
@@ -109,7 +109,7 @@ func TestLinkCreate(t *testing.T) {
 }
 
 func TestLinkCreateTwo(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.Config(nil); err != nil {
@@ -145,7 +145,7 @@ func TestLinkCreateTwo(t *testing.T) {
 }
 
 func TestLinkCreateNoEnableIPv6(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.Config(nil); err != nil {
@@ -179,7 +179,7 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 }
 
 func TestLinkDelete(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	if err := d.Config(nil); err != nil {

--- a/drivers/bridge/port_mapping_test.go
+++ b/drivers/bridge/port_mapping_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/libnetwork/netlabel"
-	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
 )
 
@@ -18,7 +18,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestPortMappingConfig(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 
 	config := &configuration{

--- a/drivers/bridge/setup_device_test.go
+++ b/drivers/bridge/setup_device_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 
 	"github.com/docker/libnetwork/netutils"
-	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 	"github.com/vishvananda/netlink"
 )
 
 func TestSetupNewBridge(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	config := &networkConfiguration{BridgeName: DefaultBridgeName}
 	br := &bridgeInterface{}
@@ -31,7 +31,7 @@ func TestSetupNewBridge(t *testing.T) {
 }
 
 func TestSetupNewNonDefaultBridge(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	config := &networkConfiguration{BridgeName: "test0"}
 	br := &bridgeInterface{}
@@ -47,7 +47,7 @@ func TestSetupNewNonDefaultBridge(t *testing.T) {
 }
 
 func TestSetupDeviceUp(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	config := &networkConfiguration{BridgeName: DefaultBridgeName}
 	br := &bridgeInterface{}
@@ -66,7 +66,7 @@ func TestSetupDeviceUp(t *testing.T) {
 }
 
 func TestGenerateRandomMAC(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	mac1 := netutils.GenerateRandomMAC()
 	mac2 := netutils.GenerateRandomMAC()

--- a/drivers/bridge/setup_fixedcidrv4_test.go
+++ b/drivers/bridge/setup_fixedcidrv4_test.go
@@ -4,11 +4,11 @@ import (
 	"net"
 	"testing"
 
-	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 )
 
 func TestSetupFixedCIDRv4(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	config := &networkConfiguration{
 		BridgeName:  DefaultBridgeName,
@@ -35,7 +35,7 @@ func TestSetupFixedCIDRv4(t *testing.T) {
 }
 
 func TestSetupBadFixedCIDRv4(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	config := &networkConfiguration{
 		BridgeName:  DefaultBridgeName,

--- a/drivers/bridge/setup_fixedcidrv6_test.go
+++ b/drivers/bridge/setup_fixedcidrv6_test.go
@@ -4,11 +4,11 @@ import (
 	"net"
 	"testing"
 
-	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 )
 
 func TestSetupFixedCIDRv6(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	config := &networkConfiguration{}
 	br := newInterface(config)

--- a/drivers/bridge/setup_ip_tables_test.go
+++ b/drivers/bridge/setup_ip_tables_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/docker/libnetwork/iptables"
-	"github.com/docker/libnetwork/osl"
 	"github.com/docker/libnetwork/portmapper"
+	"github.com/docker/libnetwork/testutils"
 )
 
 const (
@@ -15,7 +15,7 @@ const (
 
 func TestProgramIPTable(t *testing.T) {
 	// Create a test bridge with a basic bridge configuration (name + IPv4).
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 	createTestBridge(getBasicTestConfig(), &bridgeInterface{}, t)
 
 	// Store various iptables chain rules we care for.
@@ -39,7 +39,7 @@ func TestProgramIPTable(t *testing.T) {
 
 func TestSetupIPChains(t *testing.T) {
 	// Create a test bridge with a basic bridge configuration (name + IPv4).
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	driverconfig := &configuration{
 		EnableIPTables: true,

--- a/drivers/bridge/setup_ipv4_test.go
+++ b/drivers/bridge/setup_ipv4_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/libnetwork/netutils"
-	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 	"github.com/vishvananda/netlink"
 )
 
@@ -21,7 +21,7 @@ func setupTestInterface(t *testing.T) (*networkConfiguration, *bridgeInterface) 
 }
 
 func TestSetupBridgeIPv4Fixed(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	ip, netw, err := net.ParseCIDR("192.168.1.1/24")
 	if err != nil {
@@ -53,7 +53,7 @@ func TestSetupBridgeIPv4Fixed(t *testing.T) {
 }
 
 func TestSetupBridgeIPv4Auto(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	var toBeChosen *net.IPNet
 	for _, n := range bridgeNetworks {
@@ -90,7 +90,7 @@ func TestSetupBridgeIPv4Auto(t *testing.T) {
 }
 
 func TestSetupGatewayIPv4(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	ip, nw, _ := net.ParseCIDR("192.168.0.24/16")
 	nw.IP = ip

--- a/drivers/bridge/setup_ipv6_test.go
+++ b/drivers/bridge/setup_ipv6_test.go
@@ -7,12 +7,12 @@ import (
 	"net"
 	"testing"
 
-	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 	"github.com/vishvananda/netlink"
 )
 
 func TestSetupIPv6(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	config, br := setupTestInterface(t)
 	if err := setupBridgeIPv6(config, br); err != nil {
@@ -48,7 +48,7 @@ func TestSetupIPv6(t *testing.T) {
 }
 
 func TestSetupGatewayIPv6(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	_, nw, _ := net.ParseCIDR("2001:db8:ea9:9abc:ffff::/80")
 	gw := net.ParseIP("2001:db8:ea9:9abc:ffff::254")

--- a/drivers/bridge/setup_verify_test.go
+++ b/drivers/bridge/setup_verify_test.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 	"github.com/vishvananda/netlink"
 )
 
@@ -23,7 +23,7 @@ func setupVerifyTest(t *testing.T) *bridgeInterface {
 }
 
 func TestSetupVerify(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
 	inf := setupVerifyTest(t)
@@ -40,7 +40,7 @@ func TestSetupVerify(t *testing.T) {
 }
 
 func TestSetupVerifyBad(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
 	inf := setupVerifyTest(t)
@@ -58,7 +58,7 @@ func TestSetupVerifyBad(t *testing.T) {
 }
 
 func TestSetupVerifyMissing(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
 	inf := setupVerifyTest(t)
@@ -71,7 +71,7 @@ func TestSetupVerifyMissing(t *testing.T) {
 }
 
 func TestSetupVerifyIPv6(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
 	inf := setupVerifyTest(t)
@@ -92,7 +92,7 @@ func TestSetupVerifyIPv6(t *testing.T) {
 }
 
 func TestSetupVerifyIPv6Missing(t *testing.T) {
-	defer osl.SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	addrv4 := net.IPv4(192, 168, 1, 1)
 	inf := setupVerifyTest(t)

--- a/drivers/host/host_test.go
+++ b/drivers/host/host_test.go
@@ -3,7 +3,7 @@ package host
 import (
 	"testing"
 
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
 )
 

--- a/drivers/null/null_test.go
+++ b/drivers/null/null_test.go
@@ -3,7 +3,7 @@ package null
 import (
 	"testing"
 
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
 )
 

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/docker/libnetwork/driverapi"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 type driverTester struct {

--- a/drivers/remote/driver_test.go
+++ b/drivers/remote/driver_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/libnetwork/driverapi"
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
 )
 

--- a/etchosts/etchosts_test.go
+++ b/etchosts/etchosts_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 func TestBuildDefault(t *testing.T) {

--- a/hostdiscovery/hostdiscovery_test.go
+++ b/hostdiscovery/hostdiscovery_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 
 	"github.com/docker/libnetwork/config"
 	"github.com/docker/swarm/discovery"

--- a/idm/idm_test.go
+++ b/idm/idm_test.go
@@ -3,7 +3,7 @@ package idm
 import (
 	"testing"
 
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 func TestNew(t *testing.T) {

--- a/ipallocator/allocator_test.go
+++ b/ipallocator/allocator_test.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"net"
 	"testing"
+
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 func TestConversion(t *testing.T) {

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/libnetwork/bitseq"
 	"github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/datastore"
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 var ds datastore.DataStore

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 const chainName = "DOCKEREST"

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netlabel"
-	"github.com/docker/libnetwork/netutils"
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -256,8 +256,8 @@ func TestHost(t *testing.T) {
 }
 
 func TestBridge(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	ip, subnet, err := net.ParseCIDR("192.168.100.1/24")
@@ -329,8 +329,8 @@ func TestBridge(t *testing.T) {
 }
 
 func TestUnknownDriver(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	_, err := createTestNetwork("unknowndriver", "testnetwork", options.Generic{})
@@ -356,8 +356,8 @@ func TestNilRemoteDriver(t *testing.T) {
 }
 
 func TestDuplicateNetwork(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	// Creating a default bridge name network (can't be removed)
@@ -377,8 +377,8 @@ func TestDuplicateNetwork(t *testing.T) {
 }
 
 func TestNetworkName(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	netOption := options.Generic{
@@ -414,8 +414,8 @@ func TestNetworkName(t *testing.T) {
 }
 
 func TestNetworkType(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	netOption := options.Generic{
@@ -441,8 +441,8 @@ func TestNetworkType(t *testing.T) {
 }
 
 func TestNetworkID(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	netOption := options.Generic{
@@ -468,8 +468,8 @@ func TestNetworkID(t *testing.T) {
 }
 
 func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	netOption := options.Generic{
@@ -509,8 +509,8 @@ func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
 }
 
 func TestUnknownNetwork(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	netOption := options.Generic{
@@ -541,8 +541,8 @@ func TestUnknownNetwork(t *testing.T) {
 }
 
 func TestUnknownEndpoint(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	ip, subnet, err := net.ParseCIDR("192.168.100.1/24")
@@ -589,8 +589,8 @@ func TestUnknownEndpoint(t *testing.T) {
 }
 
 func TestNetworkEndpointsWalkers(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
@@ -721,8 +721,8 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 }
 
 func TestDuplicateEndpoint(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	netOption := options.Generic{
@@ -771,8 +771,8 @@ func TestDuplicateEndpoint(t *testing.T) {
 }
 
 func TestControllerQuery(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	// Create network 1
@@ -875,8 +875,8 @@ func TestControllerQuery(t *testing.T) {
 }
 
 func TestNetworkQuery(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
@@ -997,8 +997,8 @@ func checkSandbox(t *testing.T, info libnetwork.EndpointInfo) {
 }
 
 func TestEndpointJoin(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
@@ -1189,8 +1189,8 @@ func (f *fakeSandbox) Delete() error {
 }
 
 func TestEndpointDeleteWithActiveContainer(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	n, err := createTestNetwork(bridgeNetType, "testnetwork", options.Generic{
@@ -1253,8 +1253,8 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 }
 
 func TestEndpointMultipleJoins(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	n, err := createTestNetwork(bridgeNetType, "testmultiple", options.Generic{
@@ -1325,8 +1325,8 @@ func TestEndpointMultipleJoins(t *testing.T) {
 }
 
 func TestLeaveAll(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	n, err := createTestNetwork(bridgeNetType, "testnetwork", options.Generic{
@@ -1389,8 +1389,8 @@ func TestLeaveAll(t *testing.T) {
 }
 
 func TestontainerInvalidLeave(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	n, err := createTestNetwork(bridgeNetType, "testnetwork", options.Generic{
@@ -1456,8 +1456,8 @@ func TestontainerInvalidLeave(t *testing.T) {
 }
 
 func TestEndpointUpdateParent(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	n, err := createTestNetwork("bridge", "testnetwork", options.Generic{
@@ -1542,8 +1542,8 @@ func TestEndpointUpdateParent(t *testing.T) {
 }
 
 func TestEnableIPv6(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	tmpResolvConf := []byte("search pommesfrites.fr\nnameserver 12.34.56.78\nnameserver 2001:4860:4860::8888\n")
@@ -1638,8 +1638,8 @@ func TestEnableIPv6(t *testing.T) {
 }
 
 func TestResolvConfHost(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	tmpResolvConf := []byte("search localhost.net\nnameserver 127.0.0.1\nnameserver 2001:4860:4860::8888\n")
@@ -1717,8 +1717,8 @@ func TestResolvConfHost(t *testing.T) {
 }
 
 func TestResolvConf(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	tmpResolvConf1 := []byte("search pommesfrites.fr\nnameserver 12.34.56.78\nnameserver 2001:4860:4860::8888\n")
@@ -1870,7 +1870,7 @@ func TestResolvConf(t *testing.T) {
 }
 
 func TestInvalidRemoteDriver(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
+	if !testutils.IsRunningInContainer() {
 		t.Skip("Skipping test when not running inside a Container")
 	}
 
@@ -1920,7 +1920,7 @@ func TestInvalidRemoteDriver(t *testing.T) {
 }
 
 func TestValidRemoteDriver(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
+	if !testutils.IsRunningInContainer() {
 		t.Skip("Skipping test when not running inside a Container")
 	}
 
@@ -1999,7 +1999,7 @@ func createGlobalInstance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if netutils.IsRunningInContainer() {
+	if testutils.IsRunningInContainer() {
 		testns = origns
 	} else {
 		testns, err = netns.New()

--- a/netutils/utils_test.go
+++ b/netutils/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"testing"
 
+	_ "github.com/docker/libnetwork/testutils"
 	"github.com/vishvananda/netlink"
 )
 

--- a/ns/init_linux.go
+++ b/ns/init_linux.go
@@ -1,0 +1,43 @@
+package ns
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/vishvananda/netns"
+)
+
+var initNs netns.NsHandle
+
+// Init initializes a new network namespace
+func Init() {
+	var err error
+	initNs, err = netns.Get()
+	if err != nil {
+		log.Errorf("could not get initial namespace: %v", err)
+	}
+}
+
+// SetNamespace sets the initial namespace handler
+func SetNamespace() error {
+	if err := netns.Set(initNs); err != nil {
+		linkInfo, linkErr := getLink()
+		if linkErr != nil {
+			linkInfo = linkErr.Error()
+		}
+
+		return fmt.Errorf("failed to set to initial namespace, %v, initns fd %d: %v", linkInfo, initNs, err)
+	}
+	return nil
+}
+
+// ParseHandlerInt transforms the namespace handler into a integer
+func ParseHandlerInt() int {
+	return int(initNs)
+}
+
+func getLink() (string, error) {
+	return os.Readlink(fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), syscall.Gettid()))
+}

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 func TestGenerate(t *testing.T) {

--- a/osl/sandbox_test.go
+++ b/osl/sandbox_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/pkg/reexec"
+	"github.com/docker/libnetwork/testutils"
 )
 
 func TestMain(m *testing.M) {
@@ -16,7 +17,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestSandboxCreate(t *testing.T) {
-	defer SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	key, err := newKey(t)
 	if err != nil {
@@ -72,7 +73,7 @@ func TestSandboxCreate(t *testing.T) {
 }
 
 func TestSandboxCreateTwice(t *testing.T) {
-	defer SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	key, err := newKey(t)
 	if err != nil {
@@ -122,7 +123,7 @@ func TestSandboxGC(t *testing.T) {
 }
 
 func TestAddRemoveInterface(t *testing.T) {
-	defer SetupTestOSContext(t)()
+	defer testutils.SetupTestOSContext(t)()
 
 	key, err := newKey(t)
 	if err != nil {

--- a/osl/sandbox_unsupported_test.go
+++ b/osl/sandbox_unsupported_test.go
@@ -7,9 +7,7 @@ import (
 	"testing"
 )
 
-var (
-	ErrNotImplemented = errors.New("not implemented")
-)
+var ErrNotImplemented = errors.New("not implemented")
 
 func newKey(t *testing.T) (string, error) {
 	return nil, ErrNotImplemented

--- a/portallocator/portallocator_test.go
+++ b/portallocator/portallocator_test.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"testing"
 
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 func resetPortAllocator() {

--- a/portmapper/mapper_test.go
+++ b/portmapper/mapper_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/libnetwork/iptables"
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 func init() {

--- a/resolvconf/resolvconf_test.go
+++ b/resolvconf/resolvconf_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/pkg/ioutils"
-	_ "github.com/docker/libnetwork/netutils"
+	_ "github.com/docker/libnetwork/testutils"
 )
 
 func TestGet(t *testing.T) {

--- a/sandbox_test.go
+++ b/sandbox_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/docker/libnetwork/netlabel"
-	"github.com/docker/libnetwork/netutils"
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/testutils"
 )
 
 func createEmptyCtrlr() *controller {
@@ -83,8 +83,8 @@ func TestSandboxAddEmpty(t *testing.T) {
 }
 
 func TestSandboxAddMultiPrio(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	c, nw, _ := getTestEnv(t)
@@ -160,8 +160,8 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 }
 
 func TestSandboxAddSamePrio(t *testing.T) {
-	if !netutils.IsRunningInContainer() {
-		defer osl.SetupTestOSContext(t)()
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
 	}
 
 	c, nw1, nw2 := getTestEnv(t)

--- a/testutils/context.go
+++ b/testutils/context.go
@@ -1,9 +1,11 @@
-package osl
+package testutils
 
 import (
 	"runtime"
 	"syscall"
 	"testing"
+
+	"github.com/docker/libnetwork/ns"
 )
 
 // SetupTestOSContext joins a new network namespace, and returns its associated
@@ -26,7 +28,7 @@ func SetupTestOSContext(t *testing.T) func() {
 
 	// Since we are switching to a new test namespace make
 	// sure to re-initialize initNs context
-	nsInit()
+	ns.Init()
 
 	return func() {
 		if err := syscall.Close(fd); err != nil {

--- a/testutils/net.go
+++ b/testutils/net.go
@@ -1,4 +1,4 @@
-package netutils
+package testutils
 
 import "flag"
 


### PR DESCRIPTION
This way we won't vendor test related functions in docker anymore.
It also moves netns related functions to a new ns package to be able to
call the ns init function in tests. I think this also helps with the
overall package isolation.

Signed-off-by: David Calavera <david.calavera@gmail.com>