### PR TITLE
Add missing sandboxes routes

### DIFF
--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -199,6 +199,10 @@ func (d *dnetConnection) dnetDaemon() error {
 	post.Methods("GET", "PUT", "POST", "DELETE").HandlerFunc(httpHandler)
 	post = r.PathPrefix("/services").Subrouter()
 	post.Methods("GET", "PUT", "POST", "DELETE").HandlerFunc(httpHandler)
+	post = r.PathPrefix("/{.*}/sandboxes").Subrouter()
+	post.Methods("GET", "PUT", "POST", "DELETE").HandlerFunc(httpHandler)
+	post = r.PathPrefix("/sandboxes").Subrouter()
+	post.Methods("GET", "PUT", "POST", "DELETE").HandlerFunc(httpHandler)
 	return http.ListenAndServe(d.addr, r)
 }
 


### PR DESCRIPTION
Signed-off-by: Toshiaki Makita <makita.toshiaki@lab.ntt.co.jp>

---
Note: Docker has the same problem in api/server/server_experimental_unix.go.
"docker service attach" doesn't work.