### PR TITLE
Add integration test infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.so
 
 # Folders
+integration-tmp/
 _obj
 _test
 

--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// DefaultHTTPHost is used if only port is provided to -H flag e.g. docker -d -H tcp://:8080
-	DefaultHTTPHost = "127.0.0.1"
+	DefaultHTTPHost = "0.0.0.0"
 	// DefaultHTTPPort is the default http port used by dnet
 	DefaultHTTPPort = 2385
 	// DefaultUnixSocket exported

--- a/test/integration/dnet/helpers.bash
+++ b/test/integration/dnet/helpers.bash
@@ -1,0 +1,54 @@
+function start_consul() {
+    docker run -d --name=pr_consul -p 8500:8500 -p 8300-8302:8300-8302/tcp -p 8300-8302:8300-8302/udp -h consul progrium/consul -server -bootstrap
+    sleep 2
+}
+
+function stop_consul() {
+    docker stop pr_consul
+    # You cannot destroy a container in Circle CI. So do not attempt destroy in circleci
+    if [ -z "$CIRCLECI" ]; then
+	docker rm pr_consul
+    fi
+}
+
+function start_dnet() {
+    name="dnet-$1"
+    hport=$((41000+${1}-1))
+
+    bridge_ip=$(docker inspect --format '{{.NetworkSettings.Gateway}}' pr_consul)
+    mkdir -p /tmp/dnet/${name}
+    tomlfile="/tmp/dnet/${name}/libnetwork.toml"
+    cat > ${tomlfile} <<EOF
+title = "LibNetwork Configuration file"
+
+[daemon]
+  debug = false
+  defaultnetwork = "${2}"
+  defaultdriver = "${3}"
+  labels = ["com.docker.network.driver.overlay.bind_interface=eth0"]
+[datastore]
+  embedded = false
+[datastore.client]
+  provider = "consul"
+  Address = "${bridge_ip}:8500"
+EOF
+    docker run -d --name=${name}  --privileged -p ${hport}:2385 -v $(pwd)/:/go/src/github.com/docker/libnetwork -v /tmp:/tmp -w /go/src/github.com/docker/libnetwork golang:1.4 ./cmd/dnet/dnet -dD -c ${tomlfile}
+    sleep 2
+}
+
+function stop_dnet() {
+    name="dnet-$1"
+    rm -rf /tmp/dnet/${name}
+    docker stop ${name}
+    # You cannot destroy a container in Circle CI. So do not attempt destroy in circleci
+    if [ -z "$CIRCLECI" ]; then
+	docker rm ${name} || true
+    fi
+
+}
+
+function dnet_cmd() {
+    hport=$((41000+${1}-1))
+    shift
+    ./cmd/dnet/dnet -H 127.0.0.1:${hport} $*
+}

--- a/test/integration/dnet/simple.bats
+++ b/test/integration/dnet/simple.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+load helpers
+
+export BATS_TEST_CNT=0
+
+function setup() {
+    if [ "${BATS_TEST_CNT}" -eq 0 ]; then
+	start_consul
+	start_dnet 1 multihost overlay
+	export BATS_TEST_CNT=$((${BATS_TEST_CNT}+1))
+    fi
+}
+
+function teardown() {
+    export BATS_TEST_CNT=$((${BATS_TEST_CNT}-1))
+    if [ "${BATS_TEST_CNT}" -eq 0 ]; then
+	stop_dnet 1
+	stop_consul
+    fi
+}
+
+
+@test "Test default network" {
+    echo $(docker ps)
+    run dnet_cmd 1 network ls
+    echo ${output}
+    echo ${lines[1]}
+    name=$(echo ${lines[1]} | cut -d" " -f2)
+    driver=$(echo ${lines[1]} | cut -d" " -f3)
+    echo ${name} ${driver}
+    [ "$name" = "multihost" ]
+    [ "$driver" = "overlay" ]
+}


### PR DESCRIPTION
Currently libnetwork does not have any integration test infra
support to tests libnetwork code end2end purely as a black
box. This initial commit adds the infra support to enable
test cases for this.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>