### PR TITLE
Fix inability to detach service

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -360,12 +360,17 @@ func (cli *NetworkCli) CmdServiceDetach(chain string, args ...string) error {
 		return err
 	}
 
+	sandboxID, err := lookupSandboxID(cli, containerID)
+	if err != nil {
+		return err
+	}
+
 	serviceID, err := lookupServiceID(cli, nn, sn)
 	if err != nil {
 		return err
 	}
 
-	_, _, err = readBody(cli.call("DELETE", "/services/"+serviceID+"/backend/"+containerID, nil, nil))
+	_, _, err = readBody(cli.call("DELETE", "/services/"+serviceID+"/backend/"+sandboxID, nil, nil))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
CmdServiceDetach() incorrectly uses containerID where sandboxID is
expected. Thus, procDeleteSandbox() fails to find the corresponding
sandbox and returns the "Resource not found" error.

Signed-off-by: Toshiaki Makita <makita.toshiaki@lab.ntt.co.jp>