### PR TITLE
Make lookupSandboxID() reliable

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -87,6 +87,8 @@ func setupMockHTTPCallback() {
 				return nopCloser{bytes.NewBufferString("")}, dummyHTTPHdr, 400, fmt.Errorf("Bad Request")
 			} else if strings.Contains(path, fmt.Sprintf("sandboxes?container-id=%s", mockContainerID)) {
 				rsp = string(mockSbListJSON)
+			} else if strings.Contains(path, fmt.Sprintf("sandboxes?partial-container-id=%s", mockContainerID)) {
+				rsp = string(mockSbListJSON)
 			}
 		case "POST":
 			var data []byte

--- a/client/service.go
+++ b/client/service.go
@@ -115,7 +115,7 @@ func lookupContainerID(cli *NetworkCli, cnNameID string) (string, error) {
 }
 
 func lookupSandboxID(cli *NetworkCli, containerID string) (string, error) {
-	obj, _, err := readBody(cli.call("GET", fmt.Sprintf("/sandboxes?container-id=%s", containerID), nil, nil))
+	obj, _, err := readBody(cli.call("GET", fmt.Sprintf("/sandboxes?partial-container-id=%s", containerID), nil, nil))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- it is supposed to be called after lookupContainerID()
  but the latter is not guaranteed to succeed and in
  case of connection error will return what was passed
  to it.
  So in order to be able to operate with both long and short
  container ids in case of lookupContainerID() failure,
  always search by `partial-container-id`

Signed-off-by: Alessandro Boch <aboch@docker.com>