### PR TITLE
fix bug that can't show remote container

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -456,6 +456,16 @@ func (ep *endpoint) getSandbox() (*sandbox, bool) {
 	ps, ok := c.sandboxes[sid]
 	c.Unlock()
 
+	// if sid isn't empty but ps is nil, that means
+	// sandbox is connected remotely
+	if sid != "" && ps == nil {
+		ps = &sandbox{
+			id:          sid,
+			containerID: remoteCID,
+		}
+		ok = true
+	}
+
 	return ps, ok
 }
 

--- a/network.go
+++ b/network.go
@@ -437,7 +437,7 @@ func (n *network) updateSvcRecord(ep *endpoint, isAdd bool) {
 
 	var sbList []*sandbox
 	n.WalkEndpoints(func(e Endpoint) bool {
-		if sb, hasSandbox := e.(*endpoint).getSandbox(); hasSandbox {
+		if sb, hasSandbox := e.(*endpoint).getSandbox(); hasSandbox && !sb.isRemote() {
 			sbList = append(sbList, sb)
 		}
 		return false

--- a/sandbox.go
+++ b/sandbox.go
@@ -17,6 +17,10 @@ import (
 	"github.com/docker/libnetwork/types"
 )
 
+const (
+	remoteCID = "remote"
+)
+
 // Sandbox provides the control over the network container entity. It is a one to one mapping with the container.
 type Sandbox interface {
 	// ID returns the ID of the sandbox
@@ -122,6 +126,10 @@ func (sb *sandbox) Key() string {
 
 func (sb *sandbox) Labels() map[string]interface{} {
 	return sb.config.generic
+}
+
+func (sb *sandbox) isRemote() bool {
+	return sb.containerID == remoteCID
 }
 
 func (sb *sandbox) Statistics() (map[string]*osl.InterfaceStatistics, error) {


### PR DESCRIPTION
Fixes #506

docker service ls can't show container connected remotely, change docker
UI to show "remote" under container ID column for remote container

With this patch, docker service ls will show container which is connected remotely as:
```
$ docker service ls
SERVICE ID          NAME                 NETWORK             CONTAINER
952ca0bf32f3        test1                dev                 remote
699df54a9e62        serene_brahmagupta   bridge              4f5089652b98
```

ping @aboch ...

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>
