### PR TITLE
Enhance remote network driver to change scope

### DIFF
--- a/cmd/ovrouter/ovrouter.go
+++ b/cmd/ovrouter/ovrouter.go
@@ -29,6 +29,10 @@ func (r *router) RegisterDriver(name string, driver driverapi.Driver, c driverap
 	return nil
 }
 
+func (r *router) RefreshDriver(name string, driver driverapi.Driver, c driverapi.Capability) error {
+	return &driverapi.ErrNotImplemented{}
+}
+
 func (ep *endpoint) Interfaces() []driverapi.InterfaceInfo {
 	return nil
 }

--- a/controller.go
+++ b/controller.go
@@ -243,6 +243,23 @@ func (c *controller) RegisterDriver(networkType string, driver driverapi.Driver,
 	return nil
 }
 
+// RefreshDriver is api to refresh driver named networkType
+func (c *controller) RefreshDriver(networkType string, driver driverapi.Driver, capability driverapi.Capability) error {
+	c.Lock()
+	defer c.Unlock()
+	if !config.IsValidName(networkType) {
+		return ErrInvalidName(networkType)
+	}
+
+	if _, ok := c.drivers[networkType]; !ok {
+		return driverapi.ErrReActiveRegistration(networkType)
+	}
+
+	c.drivers[networkType] = &driverData{driver, capability}
+	log.Debugf("change scope for network type (%s)", networkType)
+	return nil
+}
+
 // NewNetwork creates a new network of the specified network type. The options
 // are network specific and modeled in a generic way.
 func (c *controller) NewNetwork(networkType, name string, options ...NetworkOption) (Network, error) {

--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -109,6 +109,7 @@ type JoinInfo interface {
 type DriverCallback interface {
 	// RegisterDriver provides a way for Remote drivers to dynamically register new NetworkType and associate with a driver instance
 	RegisterDriver(name string, driver Driver, capability Capability) error
+	RefreshDriver(name string, driver Driver, capability Capability) error
 }
 
 // Scope indicates the drivers scope capability

--- a/driverapi/errors.go
+++ b/driverapi/errors.go
@@ -54,3 +54,11 @@ func (ar ErrActiveRegistration) Error() string {
 
 // Forbidden denotes the type of this error
 func (ar ErrActiveRegistration) Forbidden() {}
+
+// ErrReActiveRegistration represents an error when a driver isn't registered before so it can't be re-activated
+type ErrReActiveRegistration string
+
+// Error interface for ErrReActiveRegistration
+func (ar ErrReActiveRegistration) Error() string {
+	return fmt.Sprintf("Driver hasn't been registered before for type %q", string(ar))
+}

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -59,6 +59,11 @@ func (dt *driverTester) RegisterDriver(name string, drv driverapi.Driver,
 	return nil
 }
 
+func (dt *driverTester) RefreshDriver(name string, drv driverapi.Driver,
+	cap driverapi.Capability) error {
+	return &driverapi.ErrNotImplemented{}
+}
+
 func TestOverlayInit(t *testing.T) {
 	if err := Init(&driverTester{t: t}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Related issue: #486
Remote network driver may need to change scope to local instead of
default global scope, now we can use daemon label
--label=com.docker.network.driver.XXX.scope=local to change remote
driver's visibility to local.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>