### PR TITLE
Add negotiation process for driver scope

### DIFF
--- a/docs/remote.md
+++ b/docs/remote.md
@@ -49,6 +49,16 @@ When loaded, a remote driver process receives an HTTP POST on the URL `/Plugin.A
 
 Other entries in the list value are allowed; `"NetworkDriver"` indicates that the plugin should be registered with LibNetwork as a driver.
 
+### Set capability
+
+After Handshake, the remote driver will receive another POST message to the URL `/NetworkDriver.GetCapabilities` with no payload. The driver's response should have the form:
+
+{
+	"Scope": "local"
+}
+
+Value of "Scope" should be either "local" or "global" which indicates the capability of remote driver, values beyond these will fail driver's registration and return an error to the caller.
+
 ### Create network
 
 When the proxy is asked to create a network, the remote process shall receive a POST to the URL `/NetworkDriver.CreateNetwork` of the form

--- a/drivers/remote/api/api.go
+++ b/drivers/remote/api/api.go
@@ -16,6 +16,12 @@ func (r *Response) GetError() string {
 	return r.Err
 }
 
+// GetCapabilityResponse is the response of GetCapability request
+type GetCapabilityResponse struct {
+	Response
+	Scope string
+}
+
 // CreateNetworkRequest requests a new network.
 type CreateNetworkRequest struct {
 	// A network ID that remote plugins are expected to store for future


### PR DESCRIPTION
Related issue:  #486

Add one capability negotiation interaction process after plugin handshake, use
this to determine plugin's capability instead of default "global" scope.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>