### PR TITLE
Cleanup external sandbox from test

### DIFF
--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -52,7 +52,6 @@ func TestMain(m *testing.M) {
 
 	err := controller.ConfigureNetworkDriver(bridgeNetType, genericOption)
 	if err != nil {
-		//m.Fatal(err)
 		os.Exit(1)
 	}
 
@@ -1243,6 +1242,7 @@ func TestExternalKey(t *testing.T) {
 		if err := cnt.Delete(); err != nil {
 			t.Fatal(err)
 		}
+		osl.GC()
 	}()
 
 	// Join endpoint to sandbox before SetKey
@@ -1270,8 +1270,14 @@ func TestExternalKey(t *testing.T) {
 	}
 
 	// Create a new OS sandbox using the osl API before using it in SetKey
-	if _, err := osl.NewSandbox("ValidKey", true); err != nil {
+	if extOsBox, err := osl.NewSandbox("ValidKey", true); err != nil {
 		t.Fatalf("Failed to create new osl sandbox")
+	} else {
+		defer func() {
+			if err := extOsBox.Destroy(); err != nil {
+				log.Warnf("Failed to remove os sandbox: %v", err)
+			}
+		}()
 	}
 
 	if err := sbox.SetKey("ValidKey"); err != nil {


### PR DESCRIPTION
- otherwise "ValidKey" file is left behind

Signed-off-by: Alessandro Boch <aboch@docker.com>