### PR TITLE
Clean up docker chain of filter table as well on driver init

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -134,10 +134,7 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 	if err := iptables.FirewalldInit(); err != nil {
 		logrus.Debugf("Fail to initialize firewalld: %v, using raw iptables instead", err)
 	}
-	if err := iptables.RemoveExistingChain(DockerChain, iptables.Nat); err != nil {
-		logrus.Warnf("Failed to remove existing iptables entries in %s : %v", DockerChain, err)
-	}
-
+	removeIPChains()
 	d := newDriver()
 	if err := d.configure(config); err != nil {
 		return err

--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -309,3 +309,15 @@ func ensureJumpRule(fromChain, toChain string) error {
 
 	return nil
 }
+
+func removeIPChains() {
+	for _, chainInfo := range []iptables.ChainInfo{
+		iptables.ChainInfo{Name: DockerChain, Table: iptables.Nat},
+		iptables.ChainInfo{Name: DockerChain, Table: iptables.Filter},
+		iptables.ChainInfo{Name: IsolationChain, Table: iptables.Filter},
+	} {
+		if err := chainInfo.Remove(); err != nil {
+			logrus.Warnf("Failed to remove existing iptables entries in table %s chain %s : %v", chainInfo.Table, chainInfo.Name, err)
+		}
+	}
+}

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -361,3 +361,11 @@ func RawCombinedOutput(args ...string) error {
 	}
 	return nil
 }
+
+// ExistChain checks if a chain exists
+func ExistChain(chain string, table Table) bool {
+	if _, err := Raw("-t", string(table), "-L", chain); err == nil {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Signed-off-by: Chun Chen <ramichen@tencent.com>

Relates to https://github.com/docker/libnetwork/pull/301.
I've seen some dirty rules left on filter table as well. I think it's better to clean up those rules.