### PR TITLE
Fix unmarshal error in endpoint interface

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -87,7 +87,7 @@ func (ep *endpoint) UnmarshalJSON(b []byte) (err error) {
 	ep.id = epMap["id"].(string)
 
 	ib, _ := json.Marshal(epMap["ep_iface"])
-	json.Unmarshal(ib, ep.iface)
+	json.Unmarshal(ib, &ep.iface)
 
 	tb, _ := json.Marshal(epMap["exposed_ports"])
 	var tPorts []types.TransportPort


### PR DESCRIPTION
Instead of passing the pointer to &ep.iface the current
code is passing the value. So the source variable is not
getting updated properly.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>