### PR TITLE
Introduce multi-node integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,7 @@ cidocker = docker run ${ciargs} ${dockerargs} golang:1.4
 all: ${build_image}.created build check integration-tests clean
 
 integration-tests: ./cmd/dnet/dnet
-	@if [ ! -d ./integration-tmp ]; then \
-	    mkdir -p ./integration-tmp;	\
-	    git clone https://github.com/sstephenson/bats.git ./integration-tmp/bats; \
-	    ./integration-tmp/bats/install.sh ./integration-tmp; \
-	fi
-	@./integration-tmp/bin/bats ./test/integration/dnet
+	@./test/integration/dnet/run-integration-tests.sh
 
 ./cmd/dnet/dnet:
 	make build-local
@@ -76,7 +71,7 @@ run-tests:
 	done
 	@echo "Done running tests"
 
-check-local: 	check-format check-code start-services run-tests
+check-local:	check-format check-code start-services run-tests
 
 install-deps:
 	apt-get update && apt-get -y install iptables zookeeperd

--- a/test/integration/dnet/dnet.bats
+++ b/test/integration/dnet/dnet.bats
@@ -3,13 +3,13 @@
 load helpers
 
 @test "Test dnet custom port" {
-    start_dnet 1 a none null 4567
+    start_dnet 1 a 4567
     dnet_cmd 4567 network ls
     stop_dnet 1 a
 }
 
 @test "Test dnet invalid custom port" {
-    start_dnet 1 b none null 4567
+    start_dnet 1 b 4567
     run dnet_cmd 4568 network ls
     echo ${output}
     [ "$status" -ne 0 ]
@@ -17,7 +17,7 @@ load helpers
 }
 
 @test "Test dnet invalid params" {
-    start_dnet 1 c none null
+    start_dnet 1 c
     run dnet_cmd 8080 network ls
     echo ${output}
     [ "$status" -ne 0 ]

--- a/test/integration/dnet/helpers.bash
+++ b/test/integration/dnet/helpers.bash
@@ -2,6 +2,10 @@ function inst_id2port() {
     echo $((41000+${1}-1))
 }
 
+function dnet_container_name() {
+    echo dnet-$1-$2
+}
+
 function start_consul() {
     stop_consul
     docker run -d \
@@ -25,18 +29,19 @@ function stop_consul() {
 
 function start_dnet() {
     stop_dnet $1 $2
-    name="dnet-$1-$2"
-    if [ -z "$5" ]
+    name=$(dnet_container_name $1 $2)
+    if [ -z "$3" ]
     then
 	hport=$((41000+${1}-1))
 	cport=2385
 	hopt=""
     else
-	hport=$5
-	cport=$5
+	hport=$3
+	cport=$3
 	hopt="-H tcp://0.0.0.0:${cport}"
     fi
 
+    bridge_ip=$(docker inspect --format '{{.NetworkSettings.Gateway}}' pr_consul)
     mkdir -p /tmp/dnet/${name}
     tomlfile="/tmp/dnet/${name}/libnetwork.toml"
     cat > ${tomlfile} <<EOF
@@ -44,22 +49,13 @@ title = "LibNetwork Configuration file"
 
 [daemon]
   debug = false
-  defaultnetwork = "${3}"
-  defaultdriver = "${4}"
   labels = ["com.docker.network.driver.overlay.bind_interface=eth0"]
 [datastore]
   embedded = false
-EOF
-    if [ "${4}" == "overlay" ]
-    then
-	bridge_ip=$(docker inspect --format '{{.NetworkSettings.Gateway}}' pr_consul)
-	cat >> ${tomlfile} <<EOF
 [datastore.client]
   provider = "consul"
   Address = "${bridge_ip}:8500"
 EOF
-    fi
-
     docker run \
 	   -d \
 	   --name=${name}  \
@@ -79,14 +75,13 @@ function skip_for_circleci() {
 }
 
 function stop_dnet() {
-    name="dnet-$1-$2"
+    name=$(dnet_container_name $1 $2)
     rm -rf /tmp/dnet/${name} || true
     docker stop ${name} || true
     # You cannot destroy a container in Circle CI. So do not attempt destroy in circleci
     if [ -z "$CIRCLECI" ]; then
 	docker rm -f ${name} || true
     fi
-
 }
 
 function dnet_cmd() {

--- a/test/integration/dnet/multi.bats
+++ b/test/integration/dnet/multi.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "Test multinode network create" {
+    echo $(docker ps)
+    for i in `seq 1 3`;
+    do
+	oname="mh$i"
+	run dnet_cmd $(inst_id2port $i) network create -d test ${oname}
+	echo ${output}
+	[ "$status" -eq 0 ]
+
+	for j in `seq 1 3`;
+	do
+	    line=$(dnet_cmd $(inst_id2port $j) network ls | grep ${oname})
+	    echo ${output}
+	    [ "$status" -eq 0 ]
+	    echo ${line}
+	    name=$(echo ${line} | cut -d" " -f2)
+	    driver=$(echo ${line} | cut -d" " -f3)
+	    echo ${name} ${driver}
+	    [ "$name" = "$oname" ]
+	    [ "$driver" = "test" ]
+	done
+
+	# Always try to remove the network from the first node
+	dnet_cmd $(inst_id2port 1) network rm ${oname}
+    done
+}
+
+@test "Test multinode service create" {
+    echo $(docker ps)
+    dnet_cmd $(inst_id2port 1) network create -d test multihost
+    for i in `seq 1 3`;
+    do
+	oname="svc$i"
+	run dnet_cmd $(inst_id2port $i) service publish ${oname}.multihost
+	echo ${output}
+	[ "$status" -eq 0 ]
+
+	for j in `seq 1 3`;
+	do
+	    run dnet_cmd $(inst_id2port $j) service ls
+	    [ "$status" -eq 0 ]
+	    echo ${output}
+	    echo ${lines[1]}
+	    svc=$(echo ${lines[1]} | cut -d" " -f2)
+	    network=$(echo ${lines[1]} | cut -d" " -f3)
+	    echo ${svc} ${network}
+	    [ "$network" = "multihost" ]
+	    [ "$svc" = "${oname}" ]
+	done
+	dnet_cmd $(inst_id2port 2) service unpublish ${oname}.multihost
+    done
+    dnet_cmd $(inst_id2port 3) network rm multihost
+}
+
+@test "Test multinode service attach" {
+    echo $(docker ps)
+    dnet_cmd $(inst_id2port 2) network create -d test multihost
+    dnet_cmd $(inst_id2port 3) service publish svc.multihost
+    for i in `seq 1 3`;
+    do
+	dnet_cmd $(inst_id2port $i) container create container_${i}
+	dnet_cmd $(inst_id2port $i) service attach container_${i} svc.multihost
+	run dnet_cmd $(inst_id2port $i) service ls
+	[ "$status" -eq 0 ]
+	echo ${output}
+	echo ${lines[1]}
+	container=$(echo ${lines[1]} | cut -d" " -f4)
+	[ "$container" = "container_$i" ]
+	for j in `seq 1 3`;
+	do
+	    if [ "$j" = "$i" ]; then
+		continue
+	    fi
+	    dnet_cmd $(inst_id2port $j) container create container_${j}
+	    run dnet_cmd $(inst_id2port $j) service attach container_${j} svc.multihost
+	    echo ${output}
+	    [ "$status" -ne 0 ]
+	    dnet_cmd $(inst_id2port $j) container rm container_${j}
+	done
+	dnet_cmd $(inst_id2port $i) service detach container_${i} svc.multihost
+	dnet_cmd $(inst_id2port $i) container rm container_${i}
+    done
+    dnet_cmd $(inst_id2port 1) service unpublish svc.multihost
+    dnet_cmd $(inst_id2port 3) network rm multihost
+}
+
+@test "Test multinode network and service delete" {
+    echo $(docker ps)
+    for i in `seq 1 3`;
+    do
+	oname="mh$i"
+	osvc="svc$i"
+	dnet_cmd $(inst_id2port $i) network create -d test ${oname}
+	dnet_cmd $(inst_id2port $i) service publish ${osvc}.${oname}
+	dnet_cmd $(inst_id2port $i) container create container_${i}
+	dnet_cmd $(inst_id2port $i) service attach container_${i} ${osvc}.${oname}
+
+	for j in `seq 1 3`;
+	do
+	    run dnet_cmd $(inst_id2port 2) service unpublish ${osvc}.${oname}
+	    echo ${output}
+	    [ "$status" -ne 0 ]
+	    run dnet_cmd $(inst_id2port $j) network rm ${oname}
+	    echo ${output}
+	    [ "$status" -ne 0 ]
+	done
+
+	dnet_cmd $(inst_id2port $i) service detach container_${i} ${osvc}.${oname}
+	dnet_cmd $(inst_id2port $i) container rm container_${i}
+
+	# Always try to remove the service from different nodes
+	dnet_cmd $(inst_id2port 2) service unpublish ${osvc}.${oname}
+	dnet_cmd $(inst_id2port 3) network rm ${oname}
+    done
+}

--- a/test/integration/dnet/run-integration-tests.sh
+++ b/test/integration/dnet/run-integration-tests.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ ! -d ./integration-tmp ]; then
+    mkdir -p ./integration-tmp
+    git clone https://github.com/sstephenson/bats.git ./integration-tmp/bats
+    ./integration-tmp/bats/install.sh ./integration-tmp
+fi
+
+declare -A cmap
+
+trap "cleanup_containers" EXIT SIGINT
+
+function cleanup_containers() {
+    for c in "${!cmap[@]}";
+    do
+	docker stop $c || true
+	if [ -z "$CIRCLECI" ]; then
+	    docker rm -f $c || true
+	fi
+    done
+
+    unset cmap
+}
+
+source ./test/integration/dnet/helpers.bash
+
+# Suite setup
+start_consul 1>/dev/null 2>&1
+cmap[pr_consul]=pr_consul
+
+# Test dnet configuration options
+./integration-tmp/bin/bats ./test/integration/dnet/dnet.bats
+
+# Test a single node configuration with a global scope test driver
+
+## Setup
+start_dnet 1 simple 1>/dev/null 2>&1
+cmap[dnet-1-simple]=dnet-1-simple
+
+## Run the test cases
+./integration-tmp/bin/bats ./test/integration/dnet/simple.bats
+
+## Teardown
+stop_dnet 1 simple 1>/dev/null 2>&1
+unset cmap[dnet-1-simple]
+
+# Test multi node configuration with a global scope test driver
+
+## Setup
+start_dnet 1 multi 1>/dev/null 2>&1
+cmap[dnet-1-multi]=dnet-1-multi
+start_dnet 2 multi 1>/dev/null 2>&1
+cmap[dnet-2-multi]=dnet-2-multi
+start_dnet 3 multi 1>/dev/null 2>&1
+cmap[dnet-3-multi]=dnet-3-multi
+
+## Run the test cases
+./integration-tmp/bin/bats ./test/integration/dnet/multi.bats
+
+## Teardown
+stop_dnet 1 multi 1>/dev/null 2>&1
+unset cmap[dnet-1-multi]
+stop_dnet 2 multi 1>/dev/null 2>&1
+unset cmap[dnet-2-multi]
+stop_dnet 3 multi 1>/dev/null 2>&1
+unset cmap[dnet-3-multi]
+
+# Suite teardowm
+stop_consul 1>/dev/null 2>&1
+unset cmap[pr_consul]


### PR DESCRIPTION
    - Create a wrapper script to run intergation tests
      so that setups and teardowns happen in more
      optimal manner
    - Add traps to cleanup containers on failure or
      user interrupt
    - Introduce basic multi-node integration tests
    - Removed default network, default driver tests
      as they may not be useful in the near future

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>