### PR TITLE
Don't broadcast creation/deletion events across cluster.

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -284,7 +284,7 @@ func (c *controller) NewNetwork(networkType, name string, options ...NetworkOpti
 
 	network.processOptions(options...)
 
-	if err := c.addNetwork(network); err != nil {
+	if err := c.addNetwork(network, false); err != nil {
 		return nil, err
 	}
 
@@ -299,7 +299,7 @@ func (c *controller) NewNetwork(networkType, name string, options ...NetworkOpti
 	return network, nil
 }
 
-func (c *controller) addNetwork(n *network) error {
+func (c *controller) addNetwork(n *network, networkFromStore bool) error {
 
 	c.Lock()
 	// Check if a driver for the specified network type is available
@@ -320,9 +320,11 @@ func (c *controller) addNetwork(n *network) error {
 	d := n.driver
 	n.Unlock()
 
-	// Create the network
-	if err := d.CreateNetwork(n.id, n.generic); err != nil {
-		return err
+	if !networkFromStore {
+		// Create the network
+		if err := d.CreateNetwork(n.id, n.generic); err != nil {
+			return err
+		}
 	}
 	if err := n.watchEndpoints(); err != nil {
 		return err

--- a/endpoint.go
+++ b/endpoint.go
@@ -405,19 +405,32 @@ func (ep *endpoint) Delete() error {
 		}
 	}()
 
-	if err = ep.deleteEndpoint(); err != nil {
+	if err = ep.deleteEndpoint(false); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (ep *endpoint) deleteEndpoint() error {
+func (ep *endpoint) deleteEndpoint(endpointFromStore bool) error {
 	ep.Lock()
 	n := ep.network
 	name := ep.name
 	epid := ep.id
 	ep.Unlock()
+
+	if !endpointFromStore {
+		n.Lock()
+		nid := n.id
+		driver := n.driver
+		n.Unlock()
+		if err := driver.DeleteEndpoint(nid, epid); err != nil {
+			if _, ok := err.(types.ForbiddenError); ok {
+				return err
+			}
+			log.Warnf("driver error deleting endpoint %s : %v", name)
+		}
+	}
 
 	n.Lock()
 	_, ok := n.endpoints[epid]
@@ -426,20 +439,8 @@ func (ep *endpoint) deleteEndpoint() error {
 		return nil
 	}
 
-	nid := n.id
-	driver := n.driver
 	delete(n.endpoints, epid)
 	n.Unlock()
-
-	if err := driver.DeleteEndpoint(nid, epid); err != nil {
-		if _, ok := err.(types.ForbiddenError); ok {
-			n.Lock()
-			n.endpoints[epid] = ep
-			n.Unlock()
-			return err
-		}
-		log.Warnf("driver error deleting endpoint %s : %v", name, err)
-	}
 
 	n.updateSvcRecord(ep, false)
 	return nil

--- a/store.go
+++ b/store.go
@@ -51,7 +51,7 @@ func (c *controller) newNetworkFromStore(n *network) error {
 	n.endpoints = endpointTable{}
 	n.Unlock()
 
-	return c.addNetwork(n)
+	return c.addNetwork(n, true)
 }
 
 func (c *controller) updateNetworkToStore(n *network) error {
@@ -107,7 +107,7 @@ func (c *controller) newEndpointFromStore(key string, ep *endpoint) error {
 	_, err := n.EndpointByID(id)
 	if err != nil {
 		if _, ok := err.(ErrNoSuchEndpoint); ok {
-			return n.addEndpoint(ep)
+			return n.addEndpoint(ep, true)
 		}
 	}
 	return err
@@ -210,7 +210,7 @@ func (c *controller) watchNetworks() error {
 					if err := c.store.GetObject(datastore.Key(existing.Key()...), &tmp); err != datastore.ErrKeyNotFound {
 						continue
 					}
-					if err := existing.deleteNetwork(); err != nil {
+					if err := existing.deleteNetwork(true); err != nil {
 						log.Debugf("Delete failed %s: %s", existing.name, err)
 					}
 				}
@@ -285,7 +285,7 @@ func (n *network) watchEndpoints() error {
 					if err := cs.GetObject(datastore.Key(existing.Key()...), &tmp); err != datastore.ErrKeyNotFound {
 						continue
 					}
-					if err := existing.deleteEndpoint(); err != nil {
+					if err := existing.deleteEndpoint(true); err != nil {
 						log.Debugf("Delete failed %s: %s", existing.name, err)
 					}
 				}


### PR DESCRIPTION
A user makes one of the following requests in a single host:

network create
network delete
service publish
service unpublish
After the request is successful on one host, the same request is replicated
in every host. The requests are also sent again when docker daemon is
restarted. This means that in a 1000 node system, a single user request
gets converted into 1000 requests on the driver's backend.

This commit prevents this broadcast from happening.

Addresses the following enhancement:
https://github.com/docker/libnetwork/issues/313

Signed-off-by: Gurucharan Shetty <gshetty@nicira.com>