### PR TITLE
Fixes in bridge and overlay drivers

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -163,7 +163,7 @@ func New(cfgOptions ...config.Option) (NetworkController, error) {
 			log.Debugf("Failed to Initialize Discovery : %v", err)
 		}
 		if err := c.initLocalStore(); err != nil {
-			return nil, fmt.Errorf("Failed to Initialize LocalDatastore due to %v.", err)
+			log.Debugf("Failed to Initialize LocalDatastore due to %v.", err)
 		}
 	}
 

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -516,7 +516,7 @@ func parseNetworkGenericOptions(data interface{}) (*networkConfiguration, error)
 	return config, err
 }
 
-func parseNetworkOptions(option options.Generic) (*networkConfiguration, error) {
+func parseNetworkOptions(id string, option options.Generic) (*networkConfiguration, error) {
 	var err error
 	config := &networkConfiguration{}
 
@@ -537,6 +537,9 @@ func parseNetworkOptions(option options.Generic) (*networkConfiguration, error) 
 		return nil, err
 	}
 
+	if config.BridgeName == "" && config.DisableBridgeCreation == false {
+		config.BridgeName = "br-" + id[:12]
+	}
 	return config, nil
 }
 
@@ -580,7 +583,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}) error {
 	d.Unlock()
 
 	// Parse and validate the config. It should not conflict with existing networks' config
-	config, err := parseNetworkOptions(option)
+	config, err := parseNetworkOptions(id, option)
 	if err != nil {
 		return err
 	}

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -48,18 +48,18 @@ type configuration struct {
 
 // networkConfiguration for network specific configuration
 type networkConfiguration struct {
-	BridgeName            string
-	AddressIPv4           *net.IPNet
-	FixedCIDR             *net.IPNet
-	FixedCIDRv6           *net.IPNet
-	EnableIPv6            bool
-	EnableIPMasquerade    bool
-	EnableICC             bool
-	Mtu                   int
-	DefaultGatewayIPv4    net.IP
-	DefaultGatewayIPv6    net.IP
-	DefaultBindingIP      net.IP
-	DisableBridgeCreation bool
+	BridgeName         string
+	AddressIPv4        *net.IPNet
+	FixedCIDR          *net.IPNet
+	FixedCIDRv6        *net.IPNet
+	EnableIPv6         bool
+	EnableIPMasquerade bool
+	EnableICC          bool
+	Mtu                int
+	DefaultGatewayIPv4 net.IP
+	DefaultGatewayIPv6 net.IP
+	DefaultBindingIP   net.IP
+	DefaultBridge      bool
 }
 
 // endpointConfiguration represents the user specified configuration for the sandbox endpoint
@@ -249,13 +249,13 @@ func (c *networkConfiguration) fromMap(data map[string]interface{}) error {
 		}
 	}
 
-	if i, ok := data["DisableBridgeCreation"]; ok && i != nil {
+	if i, ok := data["DefaultBridge"]; ok && i != nil {
 		if s, ok := i.(string); ok {
-			if c.DisableBridgeCreation, err = strconv.ParseBool(s); err != nil {
-				return types.BadRequestErrorf("failed to parse DisableBridgeCreation value: %s", err.Error())
+			if c.DefaultBridge, err = strconv.ParseBool(s); err != nil {
+				return types.BadRequestErrorf("failed to parse DefaultBridge value: %s", err.Error())
 			}
 		} else {
-			return types.BadRequestErrorf("invalid type for DisableBridgeCreation value")
+			return types.BadRequestErrorf("invalid type for DefaultBridge value")
 		}
 	}
 
@@ -537,7 +537,7 @@ func parseNetworkOptions(id string, option options.Generic) (*networkConfigurati
 		return nil, err
 	}
 
-	if config.BridgeName == "" && config.DisableBridgeCreation == false {
+	if config.BridgeName == "" && config.DefaultBridge == false {
 		config.BridgeName = "br-" + id[:12]
 	}
 	return config, nil

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -123,7 +123,7 @@ func TestCreateFail(t *testing.T) {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
 
-	netconfig := &networkConfiguration{BridgeName: "dummy0", DisableBridgeCreation: true}
+	netconfig := &networkConfiguration{BridgeName: "dummy0", DefaultBridge: true}
 	genericOption := make(map[string]interface{})
 	genericOption[netlabel.GenericData] = netconfig
 

--- a/drivers/bridge/setup_device.go
+++ b/drivers/bridge/setup_device.go
@@ -15,7 +15,7 @@ func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
 
 	// We only attempt to create the bridge when the requested device name is
 	// the default one.
-	if config.BridgeName != DefaultBridgeName && config.DisableBridgeCreation {
+	if config.BridgeName != DefaultBridgeName && config.DefaultBridge {
 		return NonDefaultBridgeExistError(config.BridgeName)
 	}
 

--- a/drivers/bridge/setup_device_test.go
+++ b/drivers/bridge/setup_device_test.go
@@ -33,7 +33,7 @@ func TestSetupNewBridge(t *testing.T) {
 func TestSetupNewNonDefaultBridge(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
-	config := &networkConfiguration{BridgeName: "test0", DisableBridgeCreation: true}
+	config := &networkConfiguration{BridgeName: "test0", DefaultBridge: true}
 	br := &bridgeInterface{}
 
 	err := setupDevice(config, br)

--- a/drivers/bridge/setup_ipv4.go
+++ b/drivers/bridge/setup_ipv4.go
@@ -53,7 +53,7 @@ func setupBridgeIPv4(config *networkConfiguration, i *bridgeInterface) error {
 
 	// Do not try to configure IPv4 on a non-default bridge unless you are
 	// specifically asked to do so.
-	if config.BridgeName != DefaultBridgeName && config.DisableBridgeCreation {
+	if config.BridgeName != DefaultBridgeName && config.DefaultBridge {
 		return NonDefaultBridgeNeedsIPError(config.BridgeName)
 	}
 

--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -40,6 +40,10 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}) error {
 		return fmt.Errorf("invalid network id")
 	}
 
+	if err := d.configure(); err != nil {
+		return err
+	}
+
 	n := &network{
 		id:        id,
 		driver:    d,

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -24,6 +24,9 @@ func setupDriver(t *testing.T) *driverTester {
 		t.Fatal(err)
 	}
 
+	if err := dt.d.configure(); err != nil {
+		t.Fatal(err)
+	}
 	return dt
 }
 
@@ -78,7 +81,7 @@ func TestOverlayNilConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := dt.d.configure(nil); err != nil {
+	if err := dt.d.configure(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/sandbox_externalkey.go
+++ b/sandbox_externalkey.go
@@ -138,7 +138,7 @@ func (c *controller) acceptClientConnections(sock string, l net.Listener) {
 		conn, err := l.Accept()
 		if err != nil {
 			if _, err1 := os.Stat(sock); os.IsNotExist(err1) {
-				logrus.Warnf("Unix socket %s doesnt exist. cannot accept client connections", sock)
+				logrus.Debugf("Unix socket %s doesnt exist. cannot accept client connections", sock)
 				return
 			}
 			logrus.Errorf("Error accepting connection %v", err)

--- a/store_test.go
+++ b/store_test.go
@@ -133,14 +133,18 @@ func TestLocalStoreLockTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error getting random boltdb configs %v", err)
 	}
-	ctrl, err := New(cfgOptions...)
+	ctrl1, err := New(cfgOptions...)
 	if err != nil {
 		t.Fatalf("Error new controller: %v", err)
 	}
-	defer ctrl.Stop()
+	defer ctrl1.Stop()
 	// Use the same boltdb file without closing the previous controller
-	_, err = New(cfgOptions...)
-	if err == nil {
-		t.Fatalf("Multiple boldtdb connection must fail")
+	ctrl2, _ := New(cfgOptions...)
+	if err != nil {
+		t.Fatalf("Error new controller: %v", err)
+	}
+	store := ctrl2.(*controller).localStore
+	if store != nil {
+		t.Fatalf("localstore is expected to be nil")
 	}
 }


### PR DESCRIPTION
- Using network-id as bridge name for networks created using bridge driver.
- Moved overlay configure() out of Init() and into network create.