### PR TITLE
Moved InterfaceStatistics from osl into types package

### DIFF
--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -1172,7 +1172,7 @@ func (f *fakeSandbox) Labels() map[string]interface{} {
 	return nil
 }
 
-func (f *fakeSandbox) Statistics() (map[string]*osl.InterfaceStatistics, error) {
+func (f *fakeSandbox) Statistics() (map[string]*types.InterfaceStatistics, error) {
 	return nil, nil
 }
 

--- a/osl/interface_linux.go
+++ b/osl/interface_linux.go
@@ -156,7 +156,7 @@ func (i *nwIface) Remove() error {
 }
 
 // Returns the sandbox's side veth interface statistics
-func (i *nwIface) Statistics() (*InterfaceStatistics, error) {
+func (i *nwIface) Statistics() (*types.InterfaceStatistics, error) {
 	i.Lock()
 	n := i.ns
 	i.Unlock()
@@ -165,7 +165,7 @@ func (i *nwIface) Statistics() (*InterfaceStatistics, error) {
 	path := n.path
 	n.Unlock()
 
-	s := &InterfaceStatistics{}
+	s := &types.InterfaceStatistics{}
 
 	err := nsInvoke(path, func(nsFD int) error { return nil }, func(callerFD int) error {
 		// For some reason ioutil.ReadFile(netStatsFile) reads the file in
@@ -356,7 +356,7 @@ const (
 	base         = "[ ]*%s:([ ]+[0-9]+){16}"
 )
 
-func scanInterfaceStats(data, ifName string, i *InterfaceStatistics) error {
+func scanInterfaceStats(data, ifName string, i *types.InterfaceStatistics) error {
 	var (
 		bktStr string
 		bkt    uint64

--- a/osl/sandbox.go
+++ b/osl/sandbox.go
@@ -2,7 +2,6 @@
 package osl
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/docker/libnetwork/types"
@@ -150,22 +149,5 @@ type Interface interface {
 	Remove() error
 
 	// Statistics returns the statistics for this interface
-	Statistics() (*InterfaceStatistics, error)
-}
-
-// InterfaceStatistics represents the interface's statistics
-type InterfaceStatistics struct {
-	RxBytes   uint64
-	RxPackets uint64
-	RxErrors  uint64
-	RxDropped uint64
-	TxBytes   uint64
-	TxPackets uint64
-	TxErrors  uint64
-	TxDropped uint64
-}
-
-func (is *InterfaceStatistics) String() string {
-	return fmt.Sprintf("\nRxBytes: %d, RxPackets: %d, RxErrors: %d, RxDropped: %d, TxBytes: %d, TxPackets: %d, TxErrors: %d, TxDropped: %d",
-		is.RxBytes, is.RxPackets, is.RxErrors, is.RxDropped, is.TxBytes, is.TxPackets, is.TxErrors, is.TxDropped)
+	Statistics() (*types.InterfaceStatistics, error)
 }

--- a/osl/sandbox_linux_test.go
+++ b/osl/sandbox_linux_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/libnetwork/netutils"
+	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 )
@@ -162,7 +163,7 @@ func TestScanStatistics(t *testing.T) {
 			"    lo:  783782    1853    0    0    0     0          0         0   783782    1853    0    0    0     0       0          0\n" +
 			"lxcbr0:       0       0    0    0    0     0          0         0     9006      61    0    0    0     0       0          0\n"
 
-	i := &InterfaceStatistics{}
+	i := &types.InterfaceStatistics{}
 
 	if err := scanInterfaceStats(data, "wlan0", i); err != nil {
 		t.Fatal(err)

--- a/sandbox.go
+++ b/sandbox.go
@@ -28,7 +28,7 @@ type Sandbox interface {
 	// Labels returns the sandbox's labels
 	Labels() map[string]interface{}
 	// Statistics retrieves the interfaces' statistics for the sandbox
-	Statistics() (map[string]*osl.InterfaceStatistics, error)
+	Statistics() (map[string]*types.InterfaceStatistics, error)
 	// Refresh leaves all the endpoints, resets and re-apply the options,
 	// re-joins all the endpoints without destroying the osl sandbox
 	Refresh(options ...SandboxOption) error
@@ -126,8 +126,8 @@ func (sb *sandbox) Labels() map[string]interface{} {
 	return sb.config.generic
 }
 
-func (sb *sandbox) Statistics() (map[string]*osl.InterfaceStatistics, error) {
-	m := make(map[string]*osl.InterfaceStatistics)
+func (sb *sandbox) Statistics() (map[string]*types.InterfaceStatistics, error) {
+	m := make(map[string]*types.InterfaceStatistics)
 
 	if sb.osSbox == nil {
 		return m, nil

--- a/types/types.go
+++ b/types/types.go
@@ -278,6 +278,23 @@ func (r *StaticRoute) GetCopy() *StaticRoute {
 	}
 }
 
+// InterfaceStatistics represents the interface's statistics
+type InterfaceStatistics struct {
+	RxBytes   uint64
+	RxPackets uint64
+	RxErrors  uint64
+	RxDropped uint64
+	TxBytes   uint64
+	TxPackets uint64
+	TxErrors  uint64
+	TxDropped uint64
+}
+
+func (is *InterfaceStatistics) String() string {
+	return fmt.Sprintf("\nRxBytes: %d, RxPackets: %d, RxErrors: %d, RxDropped: %d, TxBytes: %d, TxPackets: %d, TxErrors: %d, TxDropped: %d",
+		is.RxBytes, is.RxPackets, is.RxErrors, is.RxDropped, is.TxBytes, is.TxPackets, is.TxErrors, is.TxDropped)
+}
+
 /******************************
  * Well-known Error Interfaces
  ******************************/


### PR DESCRIPTION
Exposing osl package outside libnetwork is not neccessary and the
InterfaceStatistics anyways belong to the types package.

Signed-off-by: Madhu Venugopal <madhu@docker.com>