### PR TITLE
serfJoin doesnt happen if self notification comes later

### DIFF
--- a/drivers/overlay/ov_serf.go
+++ b/drivers/overlay/ov_serf.go
@@ -68,13 +68,13 @@ func (d *driver) serfInit() error {
 	return nil
 }
 
-func (d *driver) serfJoin() error {
-	if d.neighIP == "" {
+func (d *driver) serfJoin(neighIP string) error {
+	if neighIP == "" {
 		return fmt.Errorf("no neighbor to join")
 	}
-	if _, err := d.serfInstance.Join([]string{d.neighIP}, false); err != nil {
+	if _, err := d.serfInstance.Join([]string{neighIP}, false); err != nil {
 		return fmt.Errorf("Failed to join the cluster at neigh IP %s: %v",
-			d.neighIP, err)
+			neighIP, err)
 	}
 	return nil
 }


### PR DESCRIPTION
With the recently introduced docker discovery, the self node discovery
notification can reach the overlay driver after the remote node
discovery notification.  In scenarios such as 2 node setup, it seems more
likely. In those scenarios, the serfJoin is not triggered and hence the
neighborship is not formed between the 2 nodes.

The fix is to retain the knowledge of the neighbor and reuse it
immediately after the serfInit is done. Since we do the serfJoin just
once, there is no harm in changing the neighIP to a new value even if it
is not used.

Signed-off-by: Madhu Venugopal <madhu@docker.com>