### PR TITLE
Allowing local joins to happen even when serf is not initialized

### DIFF
--- a/drivers/overlay/joinleave.go
+++ b/drivers/overlay/joinleave.go
@@ -75,11 +75,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 
 	d.peerDbAdd(nid, eid, ep.addr.IP, ep.mac,
 		net.ParseIP(d.bindAddress), true)
-	d.notifyCh <- ovNotify{
-		action: "join",
-		nid:    nid,
-		eid:    eid,
-	}
+	d.pushLocalEndpointEvent("join", nid, eid)
 
 	return nil
 }

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -174,6 +174,9 @@ func (d *driver) nodeJoin(node string, self bool) {
 		var err error
 		d.joinOnce.Do(func() {
 			err = d.serfJoin(neighIP)
+			if err == nil {
+				d.pushLocalDb()
+			}
 		})
 		if err != nil {
 			logrus.Errorf("joining serf neighbor %s failed: %v", node, err)
@@ -182,6 +185,17 @@ func (d *driver) nodeJoin(node string, self bool) {
 			d.Unlock()
 			return
 		}
+	}
+}
+
+func (d *driver) pushLocalEndpointEvent(action, nid, eid string) {
+	if !d.isSerfAlive() {
+		return
+	}
+	d.notifyCh <- ovNotify{
+		action: "join",
+		nid:    nid,
+		eid:    eid,
 	}
 }
 


### PR DESCRIPTION
With the new Discovery model, join can happen even before serf is
initliazed. It could also happen due to misconfiguration of
--cluster-advertise. The local endpoint join must succeed and later when
the serf initializes and joins the cluster, it will push the local db to
the cluster.

Signed-off-by: Madhu Venugopal <madhu@docker.com>