### PR TITLE
Fix in bitseq.NewHandle()

### DIFF
--- a/bitseq/sequence.go
+++ b/bitseq/sequence.go
@@ -65,6 +65,13 @@ func NewHandle(app string, ds datastore.DataStore, id string, numElements uint32
 		return nil, err
 	}
 
+	// If the handle is not in store, write it.
+	if !h.Exists() {
+		if err := h.writeToStore(); err != nil {
+			return nil, fmt.Errorf("failed to write bitsequence to store: %v", err)
+		}
+	}
+
 	return h, nil
 }
 


### PR DESCRIPTION
- When creating the handle, write it to store if not present. 
  Currently it is written to store only on first bit allocation, lazily. 
  

Signed-off-by: Alessandro Boch <aboch@docker.com>