### PR TITLE
fix the regexp for matching an ip address

### DIFF
--- a/resolvconf/dns/resolvconf.go
+++ b/resolvconf/dns/resolvconf.go
@@ -5,7 +5,7 @@ import (
 )
 
 // IPLocalhost is a regex patter for localhost IP address range.
-const IPLocalhost = `((127\.([0-9]{1,3}.){2}[0-9]{1,3})|(::1))`
+const IPLocalhost = `((127\.([0-9]{1,3}\.){2}[0-9]{1,3})|(::1))`
 
 var localhostIPRegexp = regexp.MustCompile(IPLocalhost)
 


### PR DESCRIPTION
this is a minor error that could cause some unexpected results;
and actually this following form would be more compact:

```go
+const IPLocalhost = `((127(\.[0-9]{1,3}){3})|(::1))`
```

Let me know if you need unit test cases I can write some.