### PR TITLE
ipamutils package

### DIFF
--- a/ipam/utils.go
+++ b/ipam/utils.go
@@ -36,33 +36,6 @@ func getAddressRange(pool string) (*AddressRange, error) {
 	return &AddressRange{nw, ipToUint32(types.GetMinimalIP(lIP)), ipToUint32(types.GetMinimalIP(hIP))}, nil
 }
 
-func initLocalPredefinedPools() []*net.IPNet {
-	pl := make([]*net.IPNet, 0, 274)
-	mask := []byte{255, 255, 0, 0}
-	for i := 17; i < 32; i++ {
-		pl = append(pl, &net.IPNet{IP: []byte{172, byte(i), 0, 0}, Mask: mask})
-	}
-	for i := 0; i < 256; i++ {
-		pl = append(pl, &net.IPNet{IP: []byte{10, byte(i), 0, 0}, Mask: mask})
-	}
-	mask24 := []byte{255, 255, 255, 0}
-	for i := 42; i < 45; i++ {
-		pl = append(pl, &net.IPNet{IP: []byte{192, 168, byte(i), 0}, Mask: mask24})
-	}
-	return pl
-}
-
-func initGlobalPredefinedPools() []*net.IPNet {
-	pl := make([]*net.IPNet, 0, 256*256)
-	mask := []byte{255, 255, 255, 0}
-	for i := 0; i < 256; i++ {
-		for j := 0; j < 256; j++ {
-			pl = append(pl, &net.IPNet{IP: []byte{10, byte(i), byte(j), 0}, Mask: mask})
-		}
-	}
-	return pl
-}
-
 // Check subnets size. In case configured subnet is v6 and host size is
 // greater than 32 bits, adjust subnet to /96.
 func adjustAndCheckSubnetSize(subnet *net.IPNet) (*net.IPNet, error) {

--- a/ipamutils/utils.go
+++ b/ipamutils/utils.go
@@ -1,0 +1,106 @@
+// Package ipamutils provides utililty functions for ipam management
+package ipamutils
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/docker/libnetwork/netutils"
+	"github.com/docker/libnetwork/resolvconf"
+	"github.com/vishvananda/netlink"
+)
+
+var (
+	// PredefinedBroadNetworks contains a list of 31 IPv4 private networks with host size 16 and 12
+	// (172.17-31.x.x/16, 192.168.x.x/20) which do not overlap with the networks in `PredefinedGranularNetworks`
+	PredefinedBroadNetworks []*net.IPNet
+	// PredefinedGranularNetworks contains a list of 64K IPv4 private networks with host size 8
+	// (10.x.x.x/24) which do not overlap with the networks in `PredefinedBroadNetworks`
+	PredefinedGranularNetworks []*net.IPNet
+)
+
+func init() {
+	PredefinedBroadNetworks = initBroadPredefinedNetworks()
+	PredefinedGranularNetworks = initGranularPredefinedNetworks()
+}
+
+// ElectInterfaceAddresses looks for an interface on the OS with the specified name
+// and returns its IPv4 and IPv6 addresses in CIDR form. If the interface does not exist,
+// it chooses from a predifined list the first IPv4 address which does not conflict
+// with other interfaces on the system.
+func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
+	var v4Nets, v6Nets []*net.IPNet
+
+	link, _ := netlink.LinkByName(name)
+	if link != nil {
+		v4addr, err := netlink.AddrList(link, netlink.FAMILY_V4)
+		if err != nil {
+			return nil, nil, err
+		}
+		v6addr, err := netlink.AddrList(link, netlink.FAMILY_V6)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, nlAddr := range v4addr {
+			v4Nets = append(v4Nets, nlAddr.IPNet)
+		}
+		for _, nlAddr := range v6addr {
+			v6Nets = append(v6Nets, nlAddr.IPNet)
+		}
+	}
+
+	if link == nil || len(v4Nets) == 0 {
+		// Choose from predifined broad networks
+		v4Net, err := FindAvailableNetwork(PredefinedBroadNetworks)
+		if err != nil {
+			return nil, nil, err
+		}
+		v4Nets = append(v4Nets, v4Net)
+	}
+
+	return v4Nets, v6Nets, nil
+}
+
+// FindAvailableNetwork returns a network from the passed list which does not
+// overlap with existing interfaces in the system
+func FindAvailableNetwork(list []*net.IPNet) (*net.IPNet, error) {
+	// We don't check for an error here, because we don't really care if we
+	// can't read /etc/resolv.conf. So instead we skip the append if resolvConf
+	// is nil. It either doesn't exist, or we can't read it for some reason.
+	var nameservers []string
+	if rc, err := resolvconf.Get(); err == nil {
+		nameservers = resolvconf.GetNameserversAsCIDR(rc.Content)
+	}
+	for _, nw := range list {
+		if err := netutils.CheckNameserverOverlaps(nameservers, nw); err == nil {
+			if err := netutils.CheckRouteOverlaps(nw); err == nil {
+				return nw, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no available network")
+}
+
+func initBroadPredefinedNetworks() []*net.IPNet {
+	pl := make([]*net.IPNet, 0, 31)
+	mask := []byte{255, 255, 0, 0}
+	for i := 17; i < 32; i++ {
+		pl = append(pl, &net.IPNet{IP: []byte{172, byte(i), 0, 0}, Mask: mask})
+	}
+	mask20 := []byte{255, 255, 240, 0}
+	for i := 0; i < 16; i++ {
+		pl = append(pl, &net.IPNet{IP: []byte{192, 168, byte(i << 4), 0}, Mask: mask20})
+	}
+	return pl
+}
+
+func initGranularPredefinedNetworks() []*net.IPNet {
+	pl := make([]*net.IPNet, 0, 256*256)
+	mask := []byte{255, 255, 255, 0}
+	for i := 0; i < 256; i++ {
+		for j := 0; j < 256; j++ {
+			pl = append(pl, &net.IPNet{IP: []byte{10, byte(i), byte(j), 0}, Mask: mask})
+		}
+	}
+	return pl
+}

--- a/ipamutils/utils_test.go
+++ b/ipamutils/utils_test.go
@@ -1,0 +1,113 @@
+package ipamutils
+
+import (
+	"net"
+	"testing"
+
+	"github.com/docker/libnetwork/testutils"
+	"github.com/docker/libnetwork/types"
+	"github.com/vishvananda/netlink"
+)
+
+func TestGranularPredefined(t *testing.T) {
+	for _, nw := range PredefinedGranularNetworks {
+		if ones, bits := nw.Mask.Size(); bits != 32 || ones != 24 {
+			t.Fatalf("Unexpected size for network in granular list: %v", nw)
+		}
+	}
+
+	for _, nw := range PredefinedBroadNetworks {
+		if ones, bits := nw.Mask.Size(); bits != 32 || (ones != 20 && ones != 16) {
+			t.Fatalf("Unexpected size for network in broad list: %v", nw)
+		}
+	}
+
+}
+
+func TestNetworkRequest(t *testing.T) {
+	defer testutils.SetupTestOSContext(t)()
+	_, exp, err := net.ParseCIDR("172.17.0.0/16")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nw, err := FindAvailableNetwork(PredefinedBroadNetworks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !types.CompareIPNet(exp, nw) {
+		t.Fatalf("exected %s. got %s", exp, nw)
+	}
+
+	_, exp, err = net.ParseCIDR("10.0.0.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nw, err = FindAvailableNetwork(PredefinedGranularNetworks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !types.CompareIPNet(exp, nw) {
+		t.Fatalf("exected %s. got %s", exp, nw)
+	}
+
+	// Add iface and ssert returned address on request
+	createInterface(t, "test", "172.17.42.1/16")
+
+	_, exp, err = net.ParseCIDR("172.18.0.0/16")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nw, err = FindAvailableNetwork(PredefinedBroadNetworks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !types.CompareIPNet(exp, nw) {
+		t.Fatalf("exected %s. got %s", exp, nw)
+	}
+}
+
+func TestElectInterfaceAddress(t *testing.T) {
+	defer testutils.SetupTestOSContext(t)()
+	nws := "172.101.202.254/16"
+	createInterface(t, "test", nws)
+
+	ipv4Nw, ipv6Nw, err := ElectInterfaceAddresses("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ipv4Nw) == 0 {
+		t.Fatalf("unexpected empty ipv4 network addresses")
+	}
+
+	if len(ipv6Nw) == 0 {
+		t.Fatalf("unexpected empty ipv4 network addresses")
+	}
+
+	if nws != ipv4Nw[0].String() {
+		t.Fatalf("expected %s. got %s", nws, ipv4Nw[0])
+	}
+}
+
+func createInterface(t *testing.T, name, nw string) {
+	// Add interface
+	link := &netlink.Bridge{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: "test",
+		},
+	}
+	bip, err := types.ParseCIDR(nw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = netlink.LinkAdd(link); err != nil {
+		t.Fatalf("Failed to create interface via netlink: %v", err)
+	}
+	if err := netlink.AddrAdd(link, &netlink.Addr{IPNet: bip}); err != nil {
+		t.Fatal(err)
+	}
+	if err = netlink.LinkSetUp(link); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/ipamutils/utils_test.go
+++ b/ipamutils/utils_test.go
@@ -77,7 +77,7 @@ func TestElectInterfaceAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(ipv4Nw) == 0 {
+	if ipv4Nw == nil {
 		t.Fatalf("unexpected empty ipv4 network addresses")
 	}
 
@@ -85,8 +85,8 @@ func TestElectInterfaceAddress(t *testing.T) {
 		t.Fatalf("unexpected empty ipv4 network addresses")
 	}
 
-	if nws != ipv4Nw[0].String() {
-		t.Fatalf("expected %s. got %s", nws, ipv4Nw[0])
+	if nws != ipv4Nw.String() {
+		t.Fatalf("expected %s. got %s", nws, ipv4Nw)
 	}
 }
 


### PR DESCRIPTION
+ Now that IPAM driver is part of CNM (therefore IP allocation is no longer part of bridge driver), libnetwork will provide this ipam utility pkg for docker daemon code to retrieve the network/address to pass on to libnetwork in the form of `IpamConfig` for the default `docker0` bridge network, in order to maintains existing behavior for end user.

+ Have default ipam driver reuse this package