### PR TITLE
Remove watch on all libnetwork objects

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/libnetwork"
+	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/testutils"
@@ -88,11 +89,13 @@ func i2sbL(i interface{}) []*sandboxResource {
 }
 
 func createTestNetwork(t *testing.T, network string) (libnetwork.NetworkController, libnetwork.Network) {
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
+
 	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Stop()
 
 	netOption := options.Generic{
 		netlabel.GenericData: options.Generic{
@@ -175,6 +178,9 @@ func TestJson(t *testing.T) {
 func TestCreateDeleteNetwork(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
+
 	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
@@ -248,6 +254,9 @@ func TestCreateDeleteNetwork(t *testing.T) {
 
 func TestGetNetworksAndEndpoints(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
+
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
 
 	c, err := libnetwork.New()
 	if err != nil {
@@ -518,6 +527,9 @@ func TestGetNetworksAndEndpoints(t *testing.T) {
 func TestProcGetServices(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
+
 	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
@@ -686,6 +698,7 @@ func TestProcGetService(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
 	c, nw := createTestNetwork(t, "network")
+	defer c.Stop()
 	ep1, err := nw.CreateEndpoint("db")
 	if err != nil {
 		t.Fatal(err)
@@ -738,6 +751,8 @@ func TestProcPublishUnpublishService(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
 	c, _ := createTestNetwork(t, "network")
+	defer c.Stop()
+
 	vars := make(map[string]string)
 
 	vbad, err := json.Marshal("bad service create data")
@@ -870,6 +885,7 @@ func TestAttachDetachBackend(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
 	c, nw := createTestNetwork(t, "network")
+	defer c.Stop()
 	ep1, err := nw.CreateEndpoint("db")
 	if err != nil {
 		t.Fatal(err)
@@ -994,6 +1010,9 @@ func TestAttachDetachBackend(t *testing.T) {
 }
 
 func TestDetectGetNetworksInvalidQueryComposition(t *testing.T) {
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
+
 	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
@@ -1011,6 +1030,7 @@ func TestDetectGetEndpointsInvalidQueryComposition(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
 	c, _ := createTestNetwork(t, "network")
+	defer c.Stop()
 
 	vars := map[string]string{urlNwName: "network", urlEpName: "x", urlEpPID: "y"}
 	_, errRsp := procGetEndpoints(c, vars, nil)
@@ -1023,6 +1043,7 @@ func TestDetectGetServicesInvalidQueryComposition(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
 	c, _ := createTestNetwork(t, "network")
+	defer c.Stop()
 
 	vars := map[string]string{urlNwName: "network", urlEpName: "x", urlEpPID: "y"}
 	_, errRsp := procGetServices(c, vars, nil)
@@ -1040,6 +1061,8 @@ func TestFindNetworkUtil(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
 	c, nw := createTestNetwork(t, "network")
+	defer c.Stop()
+
 	nid := nw.ID()
 
 	_, errRsp := findNetwork(c, "", byName)
@@ -1101,6 +1124,9 @@ func TestFindNetworkUtil(t *testing.T) {
 
 func TestCreateDeleteEndpoints(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
+
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
 
 	c, err := libnetwork.New()
 	if err != nil {
@@ -1224,6 +1250,9 @@ func TestCreateDeleteEndpoints(t *testing.T) {
 
 func TestJoinLeave(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
+
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
 
 	c, err := libnetwork.New()
 	if err != nil {
@@ -1382,6 +1411,8 @@ func TestFindEndpointUtilPanic(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 	defer checkPanic(t)
 	c, nw := createTestNetwork(t, "network")
+	defer c.Stop()
+
 	nid := nw.ID()
 	findEndpoint(c, nid, "", byID, -1)
 }
@@ -1390,6 +1421,8 @@ func TestFindServiceUtilPanic(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 	defer checkPanic(t)
 	c, _ := createTestNetwork(t, "network")
+	defer c.Stop()
+
 	findService(c, "random_service", -1)
 }
 
@@ -1397,6 +1430,8 @@ func TestFindEndpointUtil(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
 	c, nw := createTestNetwork(t, "network")
+	defer c.Stop()
+
 	nid := nw.ID()
 
 	ep, err := nw.CreateEndpoint("secondEp", nil)
@@ -1443,7 +1478,8 @@ func TestFindEndpointUtil(t *testing.T) {
 		t.Fatalf("Unexepected failure: %v", errRsp)
 	}
 
-	if ep0 != ep1 || ep0 != ep2 || ep0 != ep3 || ep0 != ep4 || ep0 != ep5 {
+	if ep0.ID() != ep1.ID() || ep0.ID() != ep2.ID() ||
+		ep0.ID() != ep3.ID() || ep0.ID() != ep4.ID() || ep0.ID() != ep5.ID() {
 		t.Fatalf("Diffenrent queries returned different endpoints")
 	}
 
@@ -1665,6 +1701,9 @@ func TestwriteJSON(t *testing.T) {
 func TestHttpHandlerUninit(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
+
 	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
@@ -1732,6 +1771,9 @@ func TestHttpHandlerBadBody(t *testing.T) {
 
 	rsp := newWriter()
 
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
+
 	c, err := libnetwork.New()
 	if err != nil {
 		t.Fatal(err)
@@ -1764,6 +1806,9 @@ func TestEndToEnd(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
 	rsp := newWriter()
+
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
 
 	c, err := libnetwork.New()
 	if err != nil {
@@ -2212,6 +2257,9 @@ func TestEndToEndErrorMessage(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
 	rsp := newWriter()
+
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
 
 	c, err := libnetwork.New()
 	if err != nil {

--- a/bitseq/sequence.go
+++ b/bitseq/sequence.go
@@ -57,9 +57,6 @@ func NewHandle(app string, ds datastore.DataStore, id string, numElements uint32
 		return h, nil
 	}
 
-	// Register for status changes
-	h.watchForChanges()
-
 	// Get the initial status from the ds if present.
 	if err := h.store.GetObject(datastore.Key(h.Key()...), h); err != nil && err != datastore.ErrKeyNotFound {
 		return nil, err
@@ -252,6 +249,12 @@ func (h *Handle) set(ordinal, start, end uint32, any bool, release bool) (uint32
 	)
 
 	for {
+		if h.store != nil {
+			if err := h.store.GetObject(datastore.Key(h.Key()...), h); err != nil && err != datastore.ErrKeyNotFound {
+				return ret, err
+			}
+		}
+
 		h.Lock()
 		// Get position if available
 		if release {

--- a/datastore/cache.go
+++ b/datastore/cache.go
@@ -1,0 +1,153 @@
+package datastore
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/store/boltdb"
+)
+
+type kvMap map[string]KVObject
+
+type cache struct {
+	sync.Mutex
+	kmm map[string]kvMap
+	ds  *datastore
+}
+
+func newCache(ds *datastore) *cache {
+	return &cache{kmm: make(map[string]kvMap), ds: ds}
+}
+
+func (c *cache) kmap(kvObject KVObject) (kvMap, error) {
+	var err error
+
+	c.Lock()
+	keyPrefix := Key(kvObject.KeyPrefix()...)
+	kmap, ok := c.kmm[keyPrefix]
+	c.Unlock()
+
+	if ok {
+		return kmap, nil
+	}
+
+	kmap = kvMap{}
+
+	// Bail out right away if the kvObject does not implement KVConstructor
+	ctor, ok := kvObject.(KVConstructor)
+	if !ok {
+		return nil, fmt.Errorf("error while populating kmap, object does not implement KVConstructor interface")
+	}
+
+	kvList, err := c.ds.store.List(keyPrefix)
+	if err != nil {
+		// In case of BoltDB it may return ErrBoltBucketNotFound when no writes
+		// have ever happened on the db bucket. So check for both err codes
+		if err == store.ErrKeyNotFound || err == boltdb.ErrBoltBucketNotFound {
+			// If the store doesn't have anything then there is nothing to
+			// populate in the cache. Just bail out.
+			goto out
+		}
+
+		return nil, fmt.Errorf("error while populating kmap: %v", err)
+	}
+
+	for _, kvPair := range kvList {
+		// Ignore empty kvPair values
+		if len(kvPair.Value) == 0 {
+			continue
+		}
+
+		dstO := ctor.New()
+		err = dstO.SetValue(kvPair.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		// Make sure the object has a correct view of the DB index in
+		// case we need to modify it and update the DB.
+		dstO.SetIndex(kvPair.LastIndex)
+
+		kmap[Key(dstO.Key()...)] = dstO
+	}
+
+out:
+	// There may multiple go routines racing to fill the
+	// cache. The one which places the kmap in c.kmm first
+	// wins. The others should just use what the first populated.
+	c.Lock()
+	kmapNew, ok := c.kmm[keyPrefix]
+	if ok {
+		c.Unlock()
+		return kmapNew, nil
+	}
+
+	c.kmm[keyPrefix] = kmap
+	c.Unlock()
+
+	return kmap, nil
+}
+
+func (c *cache) add(kvObject KVObject) error {
+	kmap, err := c.kmap(kvObject)
+	if err != nil {
+		return err
+	}
+
+	c.Lock()
+	kmap[Key(kvObject.Key()...)] = kvObject
+	c.Unlock()
+	return nil
+}
+
+func (c *cache) del(kvObject KVObject) error {
+	kmap, err := c.kmap(kvObject)
+	if err != nil {
+		return err
+	}
+
+	c.Lock()
+	delete(kmap, Key(kvObject.Key()...))
+	c.Unlock()
+	return nil
+}
+
+func (c *cache) get(key string, kvObject KVObject) error {
+	kmap, err := c.kmap(kvObject)
+	if err != nil {
+		return err
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	o, ok := kmap[Key(kvObject.Key()...)]
+	if !ok {
+		return ErrKeyNotFound
+	}
+
+	ctor, ok := o.(KVConstructor)
+	if !ok {
+		return fmt.Errorf("kvobject does not implement KVConstructor interface. could not get object")
+	}
+
+	return ctor.CopyTo(kvObject)
+}
+
+func (c *cache) list(kvObject KVObject) ([]KVObject, error) {
+	kmap, err := c.kmap(kvObject)
+	if err != nil {
+		return nil, err
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	var kvol []KVObject
+	for _, v := range kmap {
+		kvol = append(kvol, v)
+	}
+
+	return kvol, nil
+}

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -1,8 +1,11 @@
 package datastore
 
 import (
+	"fmt"
+	"log"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
@@ -10,26 +13,37 @@ import (
 	"github.com/docker/libkv/store/consul"
 	"github.com/docker/libkv/store/etcd"
 	"github.com/docker/libkv/store/zookeeper"
-	"github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/types"
 )
 
 //DataStore exported
 type DataStore interface {
 	// GetObject gets data from datastore and unmarshals to the specified object
-	GetObject(key string, o KV) error
+	GetObject(key string, o KVObject) error
 	// PutObject adds a new Record based on an object into the datastore
-	PutObject(kvObject KV) error
+	PutObject(kvObject KVObject) error
 	// PutObjectAtomic provides an atomic add and update operation for a Record
-	PutObjectAtomic(kvObject KV) error
+	PutObjectAtomic(kvObject KVObject) error
 	// DeleteObject deletes a record
-	DeleteObject(kvObject KV) error
+	DeleteObject(kvObject KVObject) error
 	// DeleteObjectAtomic performs an atomic delete operation
-	DeleteObjectAtomic(kvObject KV) error
+	DeleteObjectAtomic(kvObject KVObject) error
 	// DeleteTree deletes a record
-	DeleteTree(kvObject KV) error
+	DeleteTree(kvObject KVObject) error
+	// Watchable returns whether the store is watchable are not
+	Watchable() bool
+	// Watch for changes on a KVObject
+	Watch(kvObject KVObject, stopCh <-chan struct{}) (<-chan KVObject, error)
+	// List returns of a list of KVObjects belonging to the parent
+	// key. The caller must pass a KVObject of the same type as
+	// the objects that need to be listed
+	List(string, KVObject) ([]KVObject, error)
+	// Scope returns the scope of the store
+	Scope() string
 	// KVStore returns access to the KV Store
 	KVStore() store.Store
+	// Close closes the data store
+	Close()
 }
 
 // ErrKeyModified is raised for an atomic update when the update is working on a stale state
@@ -39,11 +53,13 @@ var (
 )
 
 type datastore struct {
+	scope string
 	store store.Store
+	cache *cache
 }
 
-//KV Key Value interface used by objects to be part of the DataStore
-type KV interface {
+// KVObject is  Key/Value interface used by objects to be part of the DataStore
+type KVObject interface {
 	// Key method lets an object to provide the Key to be used in KV Store
 	Key() []string
 	// KeyPrefix method lets an object to return immediate parent key that can be used for tree walk
@@ -60,19 +76,40 @@ type KV interface {
 	// When SetIndex() is called, the object has been stored.
 	Exists() bool
 	// DataScope indicates the storage scope of the KV object
-	DataScope() DataScope
+	DataScope() string
 	// Skip provides a way for a KV Object to avoid persisting it in the KV Store
 	Skip() bool
 }
 
-// DataScope indicates the storage scope
-type DataScope int
+// KVConstructor interface defines methods which can construct a KVObject from another.
+type KVConstructor interface {
+	// New returns a new object which is created based on the
+	// source object
+	New() KVObject
+	// CopyTo deep copies the contents of the implementing object
+	// to the passed destination object
+	CopyTo(KVObject) error
+}
+
+// ScopeCfg represents Datastore configuration.
+type ScopeCfg struct {
+	Embedded bool
+	Client   ScopeClientCfg
+}
+
+// ScopeClientCfg represents Datastore Client-only mode configuration
+type ScopeClientCfg struct {
+	Provider string
+	Address  string
+	Config   *store.Config
+}
 
 const (
 	// LocalScope indicates to store the KV object in local datastore such as boltdb
-	LocalScope DataScope = iota
+	LocalScope = "local"
 	// GlobalScope indicates to store the KV object in global datastore such as consul/etcd/zookeeper
-	GlobalScope
+	GlobalScope   = "global"
+	defaultPrefix = "/var/lib/docker/network/files"
 )
 
 const (
@@ -82,6 +119,27 @@ const (
 	EndpointKeyPrefix = "endpoint"
 )
 
+var (
+	defaultScopes = makeDefaultScopes()
+)
+
+func makeDefaultScopes() map[string]*ScopeCfg {
+	def := make(map[string]*ScopeCfg)
+	def[LocalScope] = &ScopeCfg{
+		Embedded: true,
+		Client: ScopeClientCfg{
+			Provider: "boltdb",
+			Address:  defaultPrefix + "/boltdb.db",
+			Config: &store.Config{
+				Bucket:            "libnetwork",
+				ConnectionTimeout: 3 * time.Second,
+			},
+		},
+	}
+
+	return def
+}
+
 var rootChain = []string{"docker", "libnetwork"}
 
 func init() {
@@ -89,6 +147,28 @@ func init() {
 	zookeeper.Register()
 	etcd.Register()
 	boltdb.Register()
+}
+
+// DefaultScopes returns a map of default scopes and it's config for clients to use.
+func DefaultScopes(dataDir string) map[string]*ScopeCfg {
+	if dataDir != "" {
+		defaultScopes[LocalScope].Client.Address = dataDir + "/network/files/boltdb.db"
+		return defaultScopes
+	}
+
+	defaultScopes[LocalScope].Client.Address = defaultPrefix + "/boltdb.db"
+	return defaultScopes
+}
+
+// IsValid checks if the scope config has valid configuration.
+func (cfg *ScopeCfg) IsValid() bool {
+	if cfg == nil ||
+		strings.TrimSpace(cfg.Client.Provider) == "" ||
+		strings.TrimSpace(cfg.Client.Address) == "" {
+		return false
+	}
+
+	return true
 }
 
 //Key provides convenient method to create a Key
@@ -110,7 +190,11 @@ func ParseKey(key string) ([]string, error) {
 }
 
 // newClient used to connect to KV Store
-func newClient(kv string, addrs string, config *store.Config) (DataStore, error) {
+func newClient(scope string, kv string, addrs string, config *store.Config, cached bool) (DataStore, error) {
+	if cached && scope != LocalScope {
+		return nil, fmt.Errorf("caching supported only for scope %s", LocalScope)
+	}
+
 	if config == nil {
 		config = &store.Config{}
 	}
@@ -118,22 +202,82 @@ func newClient(kv string, addrs string, config *store.Config) (DataStore, error)
 	if err != nil {
 		return nil, err
 	}
-	ds := &datastore{store: store}
+
+	ds := &datastore{scope: scope, store: store}
+	if cached {
+		ds.cache = newCache(ds)
+	}
+
 	return ds, nil
 }
 
 // NewDataStore creates a new instance of LibKV data store
-func NewDataStore(cfg *config.DatastoreCfg) (DataStore, error) {
-	if cfg == nil {
-		return nil, types.BadRequestErrorf("invalid configuration passed to datastore")
+func NewDataStore(scope string, cfg *ScopeCfg) (DataStore, error) {
+	if cfg == nil || cfg.Client.Provider == "" || cfg.Client.Address == "" {
+		c, ok := defaultScopes[scope]
+		if !ok || c.Client.Provider == "" || c.Client.Address == "" {
+			return nil, fmt.Errorf("unexpected scope %s without configuration passed", scope)
+		}
+
+		cfg = c
 	}
-	// TODO : cfg.Embedded case
-	return newClient(cfg.Client.Provider, cfg.Client.Address, cfg.Client.Config)
+
+	var cached bool
+	if scope == LocalScope {
+		cached = true
+	}
+
+	return newClient(scope, cfg.Client.Provider, cfg.Client.Address, cfg.Client.Config, cached)
 }
 
-// NewCustomDataStore can be used by clients to plugin cusom datatore that adhers to store.Store
-func NewCustomDataStore(customStore store.Store) DataStore {
-	return &datastore{store: customStore}
+func (ds *datastore) Close() {
+	ds.store.Close()
+}
+
+func (ds *datastore) Scope() string {
+	return ds.scope
+}
+
+func (ds *datastore) Watchable() bool {
+	return ds.scope != LocalScope
+}
+
+func (ds *datastore) Watch(kvObject KVObject, stopCh <-chan struct{}) (<-chan KVObject, error) {
+	sCh := make(chan struct{})
+
+	ctor, ok := kvObject.(KVConstructor)
+	if !ok {
+		return nil, fmt.Errorf("error watching object type %T, object does not implement KVConstructor interface", kvObject)
+	}
+
+	kvpCh, err := ds.store.Watch(Key(kvObject.Key()...), sCh)
+	if err != nil {
+		return nil, err
+	}
+
+	kvoCh := make(chan KVObject)
+
+	go func() {
+		for {
+			select {
+			case <-stopCh:
+				close(sCh)
+				return
+			case kvPair := <-kvpCh:
+				dstO := ctor.New()
+
+				if err := dstO.SetValue(kvPair.Value); err != nil {
+					log.Printf("Could not unmarshal kvpair value = %s", string(kvPair.Value))
+					break
+				}
+
+				dstO.SetIndex(kvPair.LastIndex)
+				kvoCh <- dstO
+			}
+		}
+	}()
+
+	return kvoCh, nil
 }
 
 func (ds *datastore) KVStore() store.Store {
@@ -141,40 +285,71 @@ func (ds *datastore) KVStore() store.Store {
 }
 
 // PutObjectAtomic adds a new Record based on an object into the datastore
-func (ds *datastore) PutObjectAtomic(kvObject KV) error {
+func (ds *datastore) PutObjectAtomic(kvObject KVObject) error {
+	var (
+		previous *store.KVPair
+		pair     *store.KVPair
+		err      error
+	)
+
 	if kvObject == nil {
 		return types.BadRequestErrorf("invalid KV Object : nil")
 	}
+
 	kvObjValue := kvObject.Value()
 
 	if kvObjValue == nil {
 		return types.BadRequestErrorf("invalid KV Object with a nil Value for key %s", Key(kvObject.Key()...))
 	}
 
-	var previous *store.KVPair
+	if kvObject.Skip() {
+		goto add_cache
+	}
+
 	if kvObject.Exists() {
 		previous = &store.KVPair{Key: Key(kvObject.Key()...), LastIndex: kvObject.Index()}
 	} else {
 		previous = nil
 	}
-	_, pair, err := ds.store.AtomicPut(Key(kvObject.Key()...), kvObjValue, previous, nil)
+
+	_, pair, err = ds.store.AtomicPut(Key(kvObject.Key()...), kvObjValue, previous, nil)
 	if err != nil {
 		return err
 	}
 
 	kvObject.SetIndex(pair.LastIndex)
+
+add_cache:
+	if ds.cache != nil {
+		return ds.cache.add(kvObject)
+	}
+
 	return nil
 }
 
 // PutObject adds a new Record based on an object into the datastore
-func (ds *datastore) PutObject(kvObject KV) error {
+func (ds *datastore) PutObject(kvObject KVObject) error {
 	if kvObject == nil {
 		return types.BadRequestErrorf("invalid KV Object : nil")
 	}
-	return ds.putObjectWithKey(kvObject, kvObject.Key()...)
+
+	if kvObject.Skip() {
+		goto add_cache
+	}
+
+	if err := ds.putObjectWithKey(kvObject, kvObject.Key()...); err != nil {
+		return err
+	}
+
+add_cache:
+	if ds.cache != nil {
+		return ds.cache.add(kvObject)
+	}
+
+	return nil
 }
 
-func (ds *datastore) putObjectWithKey(kvObject KV, key ...string) error {
+func (ds *datastore) putObjectWithKey(kvObject KVObject, key ...string) error {
 	kvObjValue := kvObject.Value()
 
 	if kvObjValue == nil {
@@ -184,39 +359,128 @@ func (ds *datastore) putObjectWithKey(kvObject KV, key ...string) error {
 }
 
 // GetObject returns a record matching the key
-func (ds *datastore) GetObject(key string, o KV) error {
+func (ds *datastore) GetObject(key string, o KVObject) error {
+	if ds.cache != nil {
+		return ds.cache.get(key, o)
+	}
+
 	kvPair, err := ds.store.Get(key)
 	if err != nil {
 		return err
 	}
-	err = o.SetValue(kvPair.Value)
-	if err != nil {
+
+	if err := o.SetValue(kvPair.Value); err != nil {
 		return err
 	}
 
-	// Make sure the object has a correct view of the DB index in case we need to modify it
-	// and update the DB.
+	// Make sure the object has a correct view of the DB index in
+	// case we need to modify it and update the DB.
 	o.SetIndex(kvPair.LastIndex)
 	return nil
 }
 
+func (ds *datastore) ensureKey(key string) error {
+	exists, err := ds.store.Exists(key)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	return ds.store.Put(key, []byte{}, nil)
+}
+
+func (ds *datastore) List(key string, kvObject KVObject) ([]KVObject, error) {
+	if ds.cache != nil {
+		return ds.cache.list(kvObject)
+	}
+
+	// Bail out right away if the kvObject does not implement KVConstructor
+	ctor, ok := kvObject.(KVConstructor)
+	if !ok {
+		return nil, fmt.Errorf("error listing objects, object does not implement KVConstructor interface")
+	}
+
+	// Make sure the parent key exists
+	if err := ds.ensureKey(key); err != nil {
+		return nil, err
+	}
+
+	kvList, err := ds.store.List(key)
+	if err != nil {
+		return nil, err
+	}
+
+	var kvol []KVObject
+	for _, kvPair := range kvList {
+		if len(kvPair.Value) == 0 {
+			continue
+		}
+
+		dstO := ctor.New()
+		if err := dstO.SetValue(kvPair.Value); err != nil {
+			return nil, err
+		}
+
+		// Make sure the object has a correct view of the DB index in
+		// case we need to modify it and update the DB.
+		dstO.SetIndex(kvPair.LastIndex)
+
+		kvol = append(kvol, dstO)
+	}
+
+	return kvol, nil
+}
+
 // DeleteObject unconditionally deletes a record from the store
-func (ds *datastore) DeleteObject(kvObject KV) error {
+func (ds *datastore) DeleteObject(kvObject KVObject) error {
+	// cleaup the cache first
+	if ds.cache != nil {
+		ds.cache.del(kvObject)
+	}
+
+	if kvObject.Skip() {
+		return nil
+	}
+
 	return ds.store.Delete(Key(kvObject.Key()...))
 }
 
 // DeleteObjectAtomic performs atomic delete on a record
-func (ds *datastore) DeleteObjectAtomic(kvObject KV) error {
+func (ds *datastore) DeleteObjectAtomic(kvObject KVObject) error {
 	if kvObject == nil {
 		return types.BadRequestErrorf("invalid KV Object : nil")
 	}
 
 	previous := &store.KVPair{Key: Key(kvObject.Key()...), LastIndex: kvObject.Index()}
-	_, err := ds.store.AtomicDelete(Key(kvObject.Key()...), previous)
-	return err
+
+	if kvObject.Skip() {
+		goto del_cache
+	}
+
+	if _, err := ds.store.AtomicDelete(Key(kvObject.Key()...), previous); err != nil {
+		return err
+	}
+
+del_cache:
+	// cleanup the cache only if AtomicDelete went through successfully
+	if ds.cache != nil {
+		return ds.cache.del(kvObject)
+	}
+
+	return nil
 }
 
 // DeleteTree unconditionally deletes a record from the store
-func (ds *datastore) DeleteTree(kvObject KV) error {
+func (ds *datastore) DeleteTree(kvObject KVObject) error {
+	// cleaup the cache first
+	if ds.cache != nil {
+		ds.cache.del(kvObject)
+	}
+
+	if kvObject.Skip() {
+		return nil
+	}
+
 	return ds.store.DeleteTree(Key(kvObject.KeyPrefix()...))
 }

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/options"
 	_ "github.com/docker/libnetwork/testutils"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +14,7 @@ var dummyKey = "dummy"
 
 // NewCustomDataStore can be used by other Tests in order to use custom datastore
 func NewTestDataStore() DataStore {
-	return &datastore{store: NewMockStore()}
+	return &datastore{scope: LocalScope, store: NewMockStore()}
 }
 
 func TestKey(t *testing.T) {
@@ -38,11 +37,11 @@ func TestParseKey(t *testing.T) {
 }
 
 func TestInvalidDataStore(t *testing.T) {
-	config := &config.DatastoreCfg{}
+	config := &ScopeCfg{}
 	config.Embedded = false
 	config.Client.Provider = "invalid"
 	config.Client.Address = "localhost:8500"
-	_, err := NewDataStore(config)
+	_, err := NewDataStore(GlobalScope, config)
 	if err == nil {
 		t.Fatal("Invalid Datastore connection configuration must result in a failure")
 	}
@@ -167,7 +166,7 @@ func (n *dummyObject) Skip() bool {
 	return n.SkipSave
 }
 
-func (n *dummyObject) DataScope() DataScope {
+func (n *dummyObject) DataScope() string {
 	return LocalScope
 }
 

--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -1,10 +1,6 @@
 package driverapi
 
-import (
-	"net"
-
-	"github.com/docker/libnetwork/datastore"
-)
+import "net"
 
 // NetworkPluginEndpointType represents the Endpoint Type used by Plugin system
 const NetworkPluginEndpointType = "NetworkDriver"
@@ -105,7 +101,7 @@ type DriverCallback interface {
 
 // Capability represents the high level capabilities of the drivers which libnetwork can make use of
 type Capability struct {
-	DataScope datastore.DataScope
+	DataScope string
 }
 
 // DiscoveryType represents the type of discovery element the DiscoverNew function is invoked on

--- a/drivers.go
+++ b/drivers.go
@@ -3,6 +3,7 @@ package libnetwork
 import (
 	"strings"
 
+	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/ipamapi"
 	builtinIpam "github.com/docker/libnetwork/ipams/builtin"
@@ -32,9 +33,9 @@ func makeDriverConfig(c *controller, ntype string) map[string]interface{} {
 
 	config := make(map[string]interface{})
 
-	if c.validateGlobalStoreConfig() {
-		config[netlabel.KVProvider] = c.cfg.GlobalStore.Client.Provider
-		config[netlabel.KVProviderURL] = c.cfg.GlobalStore.Client.Address
+	if dcfg, ok := c.cfg.Scopes[datastore.GlobalScope]; ok && dcfg.IsValid() {
+		config[netlabel.KVProvider] = dcfg.Client.Provider
+		config[netlabel.KVProviderURL] = dcfg.Client.Address
 	}
 
 	for _, label := range c.cfg.Daemon.Labels {

--- a/drivers/overlay/ov_endpoint.go
+++ b/drivers/overlay/ov_endpoint.go
@@ -43,12 +43,16 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 		return err
 	}
 
+	// Since we perform lazy configuration make sure we try
+	// configuring the driver when we enter CreateEndpoint since
+	// CreateNetwork may not be called in every node.
+	if err := d.configure(); err != nil {
+		return err
+	}
+
 	n := d.network(nid)
 	if n == nil {
-		n, err = d.createNetworkfromStore(nid)
-		if err != nil {
-			return fmt.Errorf("network id %q not found", nid)
-		}
+		return fmt.Errorf("network id %q not found", nid)
 	}
 
 	ep := &endpoint{

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store"
-	"github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/idm"
@@ -84,8 +83,8 @@ func (d *driver) configure() error {
 		provURL, urlOk := d.config[netlabel.KVProviderURL]
 
 		if provOk && urlOk {
-			cfg := &config.DatastoreCfg{
-				Client: config.DatastoreClientCfg{
+			cfg := &datastore.ScopeCfg{
+				Client: datastore.ScopeClientCfg{
 					Provider: provider.(string),
 					Address:  provURL.(string),
 				},
@@ -94,7 +93,7 @@ func (d *driver) configure() error {
 			if confOk {
 				cfg.Client.Config = provConfig.(*store.Config)
 			}
-			d.store, err = datastore.NewDataStore(cfg)
+			d.store, err = datastore.NewDataStore(datastore.GlobalScope, cfg)
 			if err != nil {
 				err = fmt.Errorf("failed to initialize data store: %v", err)
 				return

--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/types"
@@ -30,11 +29,6 @@ func TestDriverRegistration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Test failed with an error %v", err)
 	}
-}
-
-func SetTestDataStore(c NetworkController, custom datastore.DataStore) {
-	con := c.(*controller)
-	con.globalStore = custom
 }
 
 func TestNetworkMarshalling(t *testing.T) {

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	libnetwork.SetTestDataStore(controller, datastore.NewCustomDataStore(datastore.NewMockStore()))
+	//libnetwork.SetTestDataStore(controller, datastore.NewCustomDataStore(datastore.NewMockStore()))
 
 	x := m.Run()
 	controller.Stop()
@@ -59,6 +59,9 @@ func TestMain(m *testing.M) {
 
 func createController() error {
 	var err error
+
+	// Cleanup local datastore file
+	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
 
 	option := options.Generic{
 		"EnableIPForwarding": true,
@@ -354,27 +357,6 @@ func TestNilRemoteDriver(t *testing.T) {
 	}
 
 	if _, ok := err.(types.NotFoundError); !ok {
-		t.Fatalf("Did not fail with expected error. Actual error: %v", err)
-	}
-}
-
-func TestDuplicateNetwork(t *testing.T) {
-	if !testutils.IsRunningInContainer() {
-		defer testutils.SetupTestOSContext(t)()
-	}
-
-	// Creating a default bridge name network (can't be removed)
-	_, err := controller.NewNetwork(bridgeNetType, "testdup")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = controller.NewNetwork(bridgeNetType, "testdup")
-	if err == nil {
-		t.Fatal("Expected to fail. But instead succeeded")
-	}
-
-	if _, ok := err.(libnetwork.NetworkNameError); !ok {
 		t.Fatalf("Did not fail with expected error. Actual error: %v", err)
 	}
 }
@@ -703,7 +685,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 	if netWanted == nil {
 		t.Fatal(err)
 	}
-	if net1 != netWanted {
+	if net1.ID() != netWanted.ID() {
 		t.Fatal(err)
 	}
 
@@ -712,7 +694,7 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 	if netWanted == nil {
 		t.Fatal(err)
 	}
-	if net2 != netWanted {
+	if net2.ID() != netWanted.ID() {
 		t.Fatal(err)
 	}
 }
@@ -843,7 +825,7 @@ func TestControllerQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected failure for NetworkByID(): %v", err)
 	}
-	if net1 != g {
+	if net1.ID() != g.ID() {
 		t.Fatalf("NetworkByID() returned unexpected element: %v", g)
 	}
 
@@ -863,7 +845,7 @@ func TestControllerQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected failure for NetworkByID(): %v", err)
 	}
-	if net2 != g {
+	if net2.ID() != g.ID() {
 		t.Fatalf("NetworkByID() returned unexpected element: %v", g)
 	}
 }
@@ -940,7 +922,7 @@ func TestNetworkQuery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ep12 != e {
+	if ep12.ID() != e.ID() {
 		t.Fatalf("EndpointByID() returned %v instead of %v", e, ep12)
 	}
 

--- a/sandbox_test.go
+++ b/sandbox_test.go
@@ -115,21 +115,21 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ctrlr.sandboxes[sid].endpoints[0] != ep3 {
+	if ctrlr.sandboxes[sid].endpoints[0].ID() != ep3.ID() {
 		t.Fatal("Expected ep3 to be at the top of the heap. But did not find ep3 at the top of the heap")
 	}
 
 	if err := ep3.Leave(sbx); err != nil {
 		t.Fatal(err)
 	}
-	if ctrlr.sandboxes[sid].endpoints[0] != ep2 {
+	if ctrlr.sandboxes[sid].endpoints[0].ID() != ep2.ID() {
 		t.Fatal("Expected ep2 to be at the top of the heap after removing ep3. But did not find ep2 at the top of the heap")
 	}
 
 	if err := ep2.Leave(sbx); err != nil {
 		t.Fatal(err)
 	}
-	if ctrlr.sandboxes[sid].endpoints[0] != ep1 {
+	if ctrlr.sandboxes[sid].endpoints[0].ID() != ep1.ID() {
 		t.Fatal("Expected ep1 to be at the top of the heap after removing ep2. But did not find ep1 at the top of the heap")
 	}
 
@@ -138,7 +138,7 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ctrlr.sandboxes[sid].endpoints[0] != ep3 {
+	if ctrlr.sandboxes[sid].endpoints[0].ID() != ep3.ID() {
 		t.Fatal("Expected ep3 to be at the top of the heap after adding ep3 back. But did not find ep3 at the top of the heap")
 	}
 
@@ -185,7 +185,7 @@ func TestSandboxAddSamePrio(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ctrlr.sandboxes[sid].endpoints[0] != ep1 {
+	if ctrlr.sandboxes[sid].endpoints[0].ID() != ep1.ID() {
 		t.Fatal("Expected ep1 to be at the top of the heap. But did not find ep1 at the top of the heap")
 	}
 
@@ -193,7 +193,7 @@ func TestSandboxAddSamePrio(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ctrlr.sandboxes[sid].endpoints[0] != ep2 {
+	if ctrlr.sandboxes[sid].endpoints[0].ID() != ep2.ID() {
 		t.Fatal("Expected ep2 to be at the top of the heap after removing ep3. But did not find ep2 at the top of the heap")
 	}
 

--- a/store.go
+++ b/store.go
@@ -1,408 +1,348 @@
 package libnetwork
 
 import (
-	"encoding/json"
 	"fmt"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/docker/libkv/store"
-	"github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/datastore"
 )
 
-var (
-	defaultBoltTimeout      = 3 * time.Second
-	defaultLocalStoreConfig = config.DatastoreCfg{
-		Embedded: true,
-		Client: config.DatastoreClientCfg{
-			Provider: "boltdb",
-			Address:  defaultPrefix + "/boltdb.db",
-			Config: &store.Config{
-				Bucket:            "libnetwork",
-				ConnectionTimeout: defaultBoltTimeout,
-			},
-		},
-	}
-)
-
-func (c *controller) validateGlobalStoreConfig() bool {
-	return c.cfg != nil && c.cfg.GlobalStore.Client.Provider != "" && c.cfg.GlobalStore.Client.Address != ""
-}
-
-func (c *controller) initGlobalStore() error {
+func (c *controller) initStores() error {
 	c.Lock()
-	cfg := c.cfg
-	c.Unlock()
-	if !c.validateGlobalStoreConfig() {
-		return fmt.Errorf("globalstore initialization requires a valid configuration")
-	}
-
-	store, err := datastore.NewDataStore(&cfg.GlobalStore)
-	if err != nil {
-		return err
-	}
-	c.Lock()
-	c.globalStore = store
-	c.Unlock()
-	return nil
-}
-
-func (c *controller) initLocalStore() error {
-	c.Lock()
-	cfg := c.cfg
-	c.Unlock()
-	localStore, err := datastore.NewDataStore(c.getLocalStoreConfig(cfg))
-	if err != nil {
-		return err
-	}
-	c.Lock()
-	c.localStore = localStore
-	c.Unlock()
-	return nil
-}
-
-func (c *controller) restoreFromGlobalStore() error {
-	c.Lock()
-	s := c.globalStore
-	c.Unlock()
-	if s == nil {
-		return nil
-	}
-	c.restore("global")
-	return c.watchNetworks()
-}
-
-func (c *controller) restoreFromLocalStore() error {
-	c.Lock()
-	s := c.localStore
-	c.Unlock()
-	if s != nil {
-		c.restore("local")
-	}
-	return nil
-}
-
-func (c *controller) restore(store string) {
-	nws, err := c.getNetworksFromStore(store == "global")
-	if err == nil {
-		c.processNetworkUpdate(nws, nil)
-	} else if err != datastore.ErrKeyNotFound {
-		log.Warnf("failed to read networks from %s store during init : %v", store, err)
-	}
-}
-
-func (c *controller) getNetworksFromStore(global bool) ([]*store.KVPair, error) {
-	var cs datastore.DataStore
-	c.Lock()
-	if global {
-		cs = c.globalStore
-	} else {
-		cs = c.localStore
-	}
-	c.Unlock()
-	return cs.KVStore().List(datastore.Key(datastore.NetworkKeyPrefix))
-}
-
-func (c *controller) newNetworkFromStore(n *network) error {
-	n.Lock()
-	n.ctrlr = c
-	n.endpoints = endpointTable{}
-	n.Unlock()
-
-	return c.addNetwork(n)
-}
-
-func (c *controller) newEndpointFromStore(key string, ep *endpoint) error {
-	ep.Lock()
-	n := ep.network
-	id := ep.id
-	ep.Unlock()
-
-	_, err := n.EndpointByID(id)
-	if err != nil {
-		if _, ok := err.(ErrNoSuchEndpoint); ok {
-			return n.addEndpoint(ep)
-		}
-	}
-	return err
-}
-
-func (c *controller) updateToStore(kvObject datastore.KV) error {
-	if kvObject.Skip() {
-		return nil
-	}
-	cs := c.getDataStore(kvObject.DataScope())
-	if cs == nil {
-		log.Debugf("datastore not initialized. kv object %s is not added to the store", datastore.Key(kvObject.Key()...))
-		return nil
-	}
-
-	return cs.PutObjectAtomic(kvObject)
-}
-
-func (c *controller) deleteFromStore(kvObject datastore.KV) error {
-	if kvObject.Skip() {
-		return nil
-	}
-	cs := c.getDataStore(kvObject.DataScope())
-	if cs == nil {
-		log.Debugf("datastore not initialized. kv object %s is not deleted from datastore", datastore.Key(kvObject.Key()...))
-		return nil
-	}
-
-	if err := cs.DeleteObjectAtomic(kvObject); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (c *controller) watchNetworks() error {
-	if !c.validateGlobalStoreConfig() {
-		return nil
-	}
-
-	c.Lock()
-	cs := c.globalStore
-	c.Unlock()
-
-	networkKey := datastore.Key(datastore.NetworkKeyPrefix)
-	if err := ensureKeys(networkKey, cs); err != nil {
-		return fmt.Errorf("failed to ensure if the network keys are valid and present in store: %v", err)
-	}
-	nwPairs, err := cs.KVStore().WatchTree(networkKey, nil)
-	if err != nil {
-		return err
-	}
-	go func() {
-		for {
-			select {
-			case nws := <-nwPairs:
-				c.Lock()
-				tmpview := networkTable{}
-				lview := c.networks
-				c.Unlock()
-				for k, v := range lview {
-					if v.isGlobalScoped() {
-						tmpview[k] = v
-					}
-				}
-				c.processNetworkUpdate(nws, &tmpview)
-
-				// Delete processing
-				for k := range tmpview {
-					c.Lock()
-					existing, ok := c.networks[k]
-					c.Unlock()
-					if !ok {
-						continue
-					}
-					tmp := network{}
-					if err := c.globalStore.GetObject(datastore.Key(existing.Key()...), &tmp); err != datastore.ErrKeyNotFound {
-						continue
-					}
-					if err := existing.deleteNetwork(); err != nil {
-						log.Debugf("Delete failed %s: %s", existing.name, err)
-					}
-				}
-			}
-		}
-	}()
-	return nil
-}
-
-func (n *network) watchEndpoints() error {
-	if n.Skip() || !n.ctrlr.validateGlobalStoreConfig() {
-		return nil
-	}
-
-	n.Lock()
-	cs := n.ctrlr.globalStore
-	tmp := endpoint{network: n}
-	n.stopWatchCh = make(chan struct{})
-	stopCh := n.stopWatchCh
-	n.Unlock()
-
-	endpointKey := datastore.Key(tmp.KeyPrefix()...)
-	if err := ensureKeys(endpointKey, cs); err != nil {
-		return fmt.Errorf("failed to ensure if the endpoint keys are valid and present in store: %v", err)
-	}
-	epPairs, err := cs.KVStore().WatchTree(endpointKey, stopCh)
-	if err != nil {
-		return err
-	}
-	go func() {
-		for {
-			select {
-			case <-stopCh:
-				return
-			case eps := <-epPairs:
-				n.Lock()
-				tmpview := endpointTable{}
-				lview := n.endpoints
-				n.Unlock()
-				for k, v := range lview {
-					if v.network.isGlobalScoped() {
-						tmpview[k] = v
-					}
-				}
-				n.ctrlr.processEndpointsUpdate(eps, &tmpview)
-				// Delete processing
-				for k := range tmpview {
-					n.Lock()
-					existing, ok := n.endpoints[k]
-					n.Unlock()
-					if !ok {
-						continue
-					}
-					tmp := endpoint{}
-					if err := cs.GetObject(datastore.Key(existing.Key()...), &tmp); err != datastore.ErrKeyNotFound {
-						continue
-					}
-					if err := existing.deleteEndpoint(); err != nil {
-						log.Debugf("Delete failed %s: %s", existing.name, err)
-					}
-				}
-			}
-		}
-	}()
-	return nil
-}
-
-func (n *network) stopWatch() {
-	n.Lock()
-	if n.stopWatchCh != nil {
-		close(n.stopWatchCh)
-		n.stopWatchCh = nil
-	}
-	n.Unlock()
-}
-
-func (c *controller) processNetworkUpdate(nws []*store.KVPair, prune *networkTable) {
-	for _, kve := range nws {
-		var n network
-		err := json.Unmarshal(kve.Value, &n)
-		if err != nil {
-			log.Error(err)
-			continue
-		}
-		if prune != nil {
-			delete(*prune, n.id)
-		}
-		n.SetIndex(kve.LastIndex)
-		c.Lock()
-		existing, ok := c.networks[n.id]
+	if c.cfg == nil {
 		c.Unlock()
-		if ok {
-			existing.Lock()
-			// Skip existing network update
-			if existing.dbIndex != n.Index() {
-				// Can't use SetIndex() since existing is locked.
-				existing.dbIndex = n.Index()
-				existing.dbExists = true
-				existing.endpointCnt = n.endpointCnt
-			}
-			existing.Unlock()
-			continue
-		}
-
-		if err = c.newNetworkFromStore(&n); err != nil {
-			log.Error(err)
-		}
-	}
-}
-
-func (c *controller) processEndpointUpdate(ep *endpoint) bool {
-	nw := ep.network
-	if nw == nil {
-		return true
-	}
-	nw.Lock()
-	id := nw.id
-	nw.Unlock()
-
-	c.Lock()
-	n, ok := c.networks[id]
-	c.Unlock()
-	if !ok {
-		return true
-	}
-	existing, _ := n.EndpointByID(ep.id)
-	if existing == nil {
-		return true
-	}
-
-	ee := existing.(*endpoint)
-	ee.Lock()
-	if ee.dbIndex != ep.Index() {
-		// Can't use SetIndex() because ee is locked.
-		ee.dbIndex = ep.Index()
-		ee.dbExists = true
-		ee.sandboxID = ep.sandboxID
-	}
-	ee.Unlock()
-
-	return false
-}
-
-func ensureKeys(key string, cs datastore.DataStore) error {
-	exists, err := cs.KVStore().Exists(key)
-	if err != nil {
-		return err
-	}
-	if exists {
 		return nil
 	}
-	return cs.KVStore().Put(key, []byte{}, nil)
-}
+	scopeConfigs := c.cfg.Scopes
+	c.Unlock()
 
-func (c *controller) getLocalStoreConfig(cfg *config.Config) *config.DatastoreCfg {
-	if cfg != nil && cfg.LocalStore.Client.Provider != "" && cfg.LocalStore.Client.Address != "" {
-		return &cfg.LocalStore
+	for scope, scfg := range scopeConfigs {
+		store, err := datastore.NewDataStore(scope, scfg)
+		if err != nil {
+			return err
+		}
+		c.Lock()
+		c.stores = append(c.stores, store)
+		c.Unlock()
 	}
-	return &defaultLocalStoreConfig
+
+	c.startWatch()
+	return nil
 }
 
-func (c *controller) getDataStore(dataScope datastore.DataScope) (dataStore datastore.DataStore) {
+func (c *controller) closeStores() {
+	for _, store := range c.getStores() {
+		store.Close()
+	}
+}
+
+func (c *controller) getStore(scope string) datastore.DataStore {
 	c.Lock()
-	if dataScope == datastore.GlobalScope {
-		dataStore = c.globalStore
-	} else if dataScope == datastore.LocalScope {
-		dataStore = c.localStore
+	defer c.Unlock()
+
+	for _, store := range c.stores {
+		if store.Scope() == scope {
+			return store
+		}
+	}
+
+	return nil
+}
+
+func (c *controller) getStores() []datastore.DataStore {
+	c.Lock()
+	defer c.Unlock()
+
+	return c.stores
+}
+
+func (c *controller) getNetworkFromStore(nid string) (*network, error) {
+	for _, store := range c.getStores() {
+		n := &network{id: nid, ctrlr: c}
+		err := store.GetObject(datastore.Key(n.Key()...), n)
+		if err != nil && err != datastore.ErrKeyNotFound {
+			return nil, fmt.Errorf("could not find network %s: %v", nid, err)
+		}
+
+		// Continue searching in the next store if the key is not found in this store
+		if err == datastore.ErrKeyNotFound {
+			continue
+		}
+
+		return n, nil
+	}
+
+	return nil, fmt.Errorf("network %s not found", nid)
+}
+
+func (c *controller) getNetworksFromStore() ([]*network, error) {
+	var nl []*network
+
+	for _, store := range c.getStores() {
+		kvol, err := store.List(datastore.Key(datastore.NetworkKeyPrefix),
+			&network{ctrlr: c})
+		if err != nil && err != datastore.ErrKeyNotFound {
+			return nil, fmt.Errorf("failed to get networks for scope %s: %v",
+				store.Scope(), err)
+		}
+
+		// Continue searching in the next store if no keys found in this store
+		if err == datastore.ErrKeyNotFound {
+			continue
+		}
+
+		for _, kvo := range kvol {
+			n := kvo.(*network)
+			n.ctrlr = c
+			nl = append(nl, n)
+		}
+	}
+
+	return nl, nil
+}
+
+func (n *network) getEndpointFromStore(eid string) (*endpoint, error) {
+	for _, store := range n.ctrlr.getStores() {
+		ep := &endpoint{id: eid, network: n}
+		err := store.GetObject(datastore.Key(ep.Key()...), ep)
+		if err != nil && err != datastore.ErrKeyNotFound {
+			return nil, fmt.Errorf("could not find endpoint %s: %v", eid, err)
+		}
+
+		// Continue searching in the next store if the key is not found in this store
+		if err == datastore.ErrKeyNotFound {
+			continue
+		}
+
+		return ep, nil
+	}
+
+	return nil, fmt.Errorf("endpoint %s not found", eid)
+}
+
+func (n *network) getEndpointsFromStore() ([]*endpoint, error) {
+	var epl []*endpoint
+
+	tmp := endpoint{network: n}
+	for _, store := range n.getController().getStores() {
+		kvol, err := store.List(datastore.Key(tmp.KeyPrefix()...), &endpoint{network: n})
+		if err != nil && err != datastore.ErrKeyNotFound {
+			return nil,
+				fmt.Errorf("failed to get endpoints for network %s scope %s: %v",
+					n.Name(), store.Scope(), err)
+		}
+
+		// Continue searching in the next store if no keys found in this store
+		if err == datastore.ErrKeyNotFound {
+			continue
+		}
+
+		for _, kvo := range kvol {
+			ep := kvo.(*endpoint)
+			ep.network = n
+			epl = append(epl, ep)
+		}
+	}
+
+	return epl, nil
+}
+
+func (c *controller) updateToStore(kvObject datastore.KVObject) error {
+	cs := c.getStore(kvObject.DataScope())
+	if cs == nil {
+		log.Warnf("datastore for scope %s not initialized. kv object %s is not added to the store", kvObject.DataScope(), datastore.Key(kvObject.Key()...))
+		return nil
+	}
+
+	if err := cs.PutObjectAtomic(kvObject); err != nil {
+		return fmt.Errorf("failed to update store for object type %T: %v", kvObject, err)
+	}
+
+	return nil
+}
+
+func (c *controller) deleteFromStore(kvObject datastore.KVObject) error {
+	cs := c.getStore(kvObject.DataScope())
+	if cs == nil {
+		log.Debugf("datastore for scope %s not initialized. kv object %s is not deleted from datastore", kvObject.DataScope(), datastore.Key(kvObject.Key()...))
+		return nil
+	}
+
+retry:
+	if err := cs.DeleteObjectAtomic(kvObject); err != nil {
+		if err == datastore.ErrKeyModified {
+			if err := cs.GetObject(datastore.Key(kvObject.Key()...), kvObject); err != nil {
+				return fmt.Errorf("could not update the kvobject to latest when trying to delete: %v", err)
+			}
+			goto retry
+		}
+		return err
+	}
+
+	return nil
+}
+
+type netWatch struct {
+	localEps  map[string]*endpoint
+	remoteEps map[string]*endpoint
+	stopCh    chan struct{}
+}
+
+func (c *controller) getLocalEps(nw *netWatch) []*endpoint {
+	c.Lock()
+	defer c.Unlock()
+
+	var epl []*endpoint
+	for _, ep := range nw.localEps {
+		epl = append(epl, ep)
+	}
+
+	return epl
+}
+
+func (c *controller) watchSvcRecord(ep *endpoint) {
+	c.watchCh <- ep
+}
+
+func (c *controller) unWatchSvcRecord(ep *endpoint) {
+	c.unWatchCh <- ep
+}
+
+func (c *controller) networkWatchLoop(nw *netWatch, ep *endpoint, nCh <-chan datastore.KVObject) {
+	for {
+		select {
+		case <-nw.stopCh:
+			return
+		case o := <-nCh:
+			n := o.(*network)
+
+			epl, err := n.getEndpointsFromStore()
+			if err != nil {
+				break
+			}
+
+			c.Lock()
+			var addEp []*endpoint
+
+			delEpMap := make(map[string]*endpoint)
+			for k, v := range nw.remoteEps {
+				delEpMap[k] = v
+			}
+
+			for _, lEp := range epl {
+				if _, ok := nw.localEps[lEp.ID()]; ok {
+					continue
+				}
+
+				if _, ok := nw.remoteEps[lEp.ID()]; ok {
+					delete(delEpMap, lEp.ID())
+					continue
+				}
+
+				nw.remoteEps[lEp.ID()] = lEp
+				addEp = append(addEp, lEp)
+
+			}
+			c.Unlock()
+
+			for _, lEp := range addEp {
+				ep.getNetwork().updateSvcRecord(lEp, c.getLocalEps(nw), true)
+			}
+
+			for _, lEp := range delEpMap {
+				ep.getNetwork().updateSvcRecord(lEp, c.getLocalEps(nw), false)
+
+			}
+		}
+	}
+}
+
+func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoint) {
+	c.Lock()
+	nw, ok := nmap[ep.getNetwork().ID()]
+	c.Unlock()
+
+	if ok {
+		// Update the svc db for the local endpoint join right away
+		ep.getNetwork().updateSvcRecord(ep, c.getLocalEps(nw), true)
+
+		c.Lock()
+		nw.localEps[ep.ID()] = ep
+		c.Unlock()
+		return
+	}
+
+	nw = &netWatch{
+		localEps:  make(map[string]*endpoint),
+		remoteEps: make(map[string]*endpoint),
+	}
+
+	// Update the svc db for the local endpoint join right away
+	// Do this before adding this ep to localEps so that we don't
+	// try to update this ep's container's svc records
+	ep.getNetwork().updateSvcRecord(ep, c.getLocalEps(nw), true)
+
+	c.Lock()
+	nw.localEps[ep.ID()] = ep
+	nmap[ep.getNetwork().ID()] = nw
+	nw.stopCh = make(chan struct{})
+	c.Unlock()
+
+	store := c.getStore(ep.getNetwork().DataScope())
+	if store == nil {
+		return
+	}
+
+	if !store.Watchable() {
+		return
+	}
+
+	ch, err := store.Watch(ep.getNetwork(), nw.stopCh)
+	if err != nil {
+		log.Warnf("Error creating watch for network: %v", err)
+		return
+	}
+
+	go c.networkWatchLoop(nw, ep, ch)
+}
+
+func (c *controller) processEndpointDelete(nmap map[string]*netWatch, ep *endpoint) {
+	c.Lock()
+	nw, ok := nmap[ep.getNetwork().ID()]
+
+	if ok {
+		delete(nw.localEps, ep.ID())
+		c.Unlock()
+
+		// Update the svc db about local endpoint leave right away
+		// Do this after we remove this ep from localEps so that we
+		// don't try to remove this svc record from this ep's container.
+		ep.getNetwork().updateSvcRecord(ep, c.getLocalEps(nw), false)
+
+		c.Lock()
+		if len(nw.localEps) == 0 {
+			close(nw.stopCh)
+			delete(nmap, ep.getNetwork().ID())
+		}
 	}
 	c.Unlock()
-	return
 }
 
-func (c *controller) processEndpointsUpdate(eps []*store.KVPair, prune *endpointTable) {
-	for _, epe := range eps {
-		var ep endpoint
-		err := json.Unmarshal(epe.Value, &ep)
-		if err != nil {
-			log.Error(err)
-			continue
-		}
-		if prune != nil {
-			delete(*prune, ep.id)
-		}
-		ep.SetIndex(epe.LastIndex)
-		if nid, err := ep.networkIDFromKey(epe.Key); err != nil {
-			log.Error(err)
-			continue
-		} else {
-			if n, err := c.NetworkByID(nid); err != nil {
-				log.Error(err)
-				continue
-			} else {
-				ep.network = n.(*network)
-			}
-		}
-		if c.processEndpointUpdate(&ep) {
-			err = c.newEndpointFromStore(epe.Key, &ep)
-			if err != nil {
-				log.Error(err)
-			}
+func (c *controller) watchLoop(nmap map[string]*netWatch) {
+	for {
+		select {
+		case ep := <-c.watchCh:
+			c.processEndpointCreate(nmap, ep)
+		case ep := <-c.unWatchCh:
+			c.processEndpointDelete(nmap, ep)
 		}
 	}
+}
+
+func (c *controller) startWatch() {
+	c.watchCh = make(chan *endpoint)
+	c.unWatchCh = make(chan *endpoint)
+	nmap := make(map[string]*netWatch)
+
+	go c.watchLoop(nmap)
 }

--- a/test/integration/dnet/bridge.bats
+++ b/test/integration/dnet/bridge.bats
@@ -1,0 +1,157 @@
+# -*- mode: sh -*-
+#!/usr/bin/env bats
+
+load helpers
+
+function test_single_network_connectivity() {
+    local nw_name start end
+
+    nw_name=${1}
+    start=1
+    end=${2}
+
+    # Create containers and connect them to the network
+    for i in `seq ${start} ${end}`;
+    do
+	dnet_cmd $(inst_id2port 1) container create container_${i}
+	net_connect 1 container_${i} ${nw_name}
+    done
+
+    # Now test connectivity between all the containers using service names
+    for i in `seq ${start} ${end}`;
+    do
+	for j in `seq ${start} ${end}`;
+	do
+	    if [ "$i" -eq "$j" ]; then
+		continue
+	    fi
+	    runc $(dnet_container_name 1 bridge) $(get_sbox_id 1 container_${i}) \
+		 "ping -c 1 container_${j}"
+	done
+    done
+
+    # Teardown the container connections and the network
+    for i in `seq ${start} ${end}`;
+    do
+	net_disconnect 1 container_${i} ${nw_name}
+	dnet_cmd $(inst_id2port 1) container rm container_${i}
+    done
+}
+
+@test "Test default bridge network" {
+    skip_for_circleci
+
+    echo $(docker ps)
+    test_single_network_connectivity bridge 3
+}
+
+@test "Test bridge network" {
+    skip_for_circleci
+
+    echo $(docker ps)
+    dnet_cmd $(inst_id2port 1) network create -d bridge singlehost
+    test_single_network_connectivity singlehost 3
+    dnet_cmd $(inst_id2port 1) network rm singlehost
+}
+
+@test "Test bridge network dnet restart" {
+    skip_for_circleci
+
+    echo $(docker ps)
+    dnet_cmd $(inst_id2port 1) network create -d bridge singlehost
+
+    for iter in `seq 1 2`;
+    do
+	test_single_network_connectivity singlehost 3
+	docker restart dnet-1-bridge
+	sleep 2
+    done
+
+    dnet_cmd $(inst_id2port 1) network rm singlehost
+}
+
+@test "Test multiple bridge networks" {
+    skip_for_circleci
+
+    echo $(docker ps)
+
+    start=1
+    end=3
+
+    for i in `seq ${start} ${end}`;
+    do
+	dnet_cmd $(inst_id2port 1) container create container_${i}
+	for j in `seq ${start} ${end}`;
+	do
+	    if [ "$i" -eq "$j" ]; then
+		continue
+	    fi
+
+	    if [ "$i" -lt "$j" ]; then
+		dnet_cmd $(inst_id2port 1) network create -d bridge sh${i}${j}
+		nw=sh${i}${j}
+	    else
+		nw=sh${j}${i}
+	    fi
+
+	    osvc="svc${i}${j}"
+	    dnet_cmd $(inst_id2port 1) service publish ${osvc}.${nw}
+	    dnet_cmd $(inst_id2port 1) service attach container_${i} ${osvc}.${nw}
+	done
+    done
+
+    for i in `seq ${start} ${end}`;
+    do
+	echo ${i1}
+	for j in `seq ${start} ${end}`;
+	do
+	    echo ${j1}
+	    if [ "$i" -eq "$j" ]; then
+		continue
+	    fi
+
+	    osvc="svc${j}${i}"
+	    echo "pinging ${osvc}"
+	    dnet_cmd $(inst_id2port 1) service ls
+	    runc $(dnet_container_name 1 bridge) $(get_sbox_id 1 container_${i}) "cat /etc/hosts"
+	    runc $(dnet_container_name 1 bridge) $(get_sbox_id 1 container_${i}) "ping -c 1 ${osvc}"
+	done
+    done
+
+    for i in `seq ${start} ${end}`;
+    do
+	for j in `seq ${start} ${end}`;
+	do
+	    if [ "$i" -eq "$j" ]; then
+		continue
+	    fi
+
+	    if [ "$i" -lt "$j" ]; then
+		nw=sh${i}${j}
+	    else
+		nw=sh${j}${i}
+	    fi
+
+	    osvc="svc${i}${j}"
+	    dnet_cmd $(inst_id2port 1) service detach container_${i} ${osvc}.${nw}
+	    dnet_cmd $(inst_id2port 1) service unpublish ${osvc}.${nw}
+
+	done
+	dnet_cmd $(inst_id2port 1) container rm container_${i}
+    done
+
+    for i in `seq ${start} ${end}`;
+    do
+	for j in `seq ${start} ${end}`;
+	do
+	    if [ "$i" -eq "$j" ]; then
+		continue
+	    fi
+
+	    if [ "$i" -lt "$j" ]; then
+		dnet_cmd $(inst_id2port 1) network rm sh${i}${j}
+	    fi
+	done
+    done
+
+}

--- a/test/integration/dnet/overlay.bats
+++ b/test/integration/dnet/overlay.bats
@@ -14,35 +14,28 @@ load helpers
     dnet_cmd $(inst_id2port 1) network create -d overlay multihost
     for i in `seq ${start} ${end}`;
     do
-	osvc="svc$i"
-	dnet_cmd $(inst_id2port $i) service publish ${osvc}.multihost
 	dnet_cmd $(inst_id2port $i) container create container_${i}
-	dnet_cmd $(inst_id2port $i) service attach container_${i} ${osvc}.multihost
+	net_connect ${i} container_${i} multihost
     done
 
     # Now test connectivity between all the containers using service names
     for i in `seq ${start} ${end}`;
     do
-	src="svc$i"
-	line=$(dnet_cmd $(inst_id2port $i) service ls | grep ${src})
-	echo ${line}
-	sbid=$(echo ${line} | cut -d" " -f5)
 	for j in `seq ${start} ${end}`;
 	do
 	    if [ "$i" -eq "$j" ]; then
 		continue
 	    fi
-	    runc $(dnet_container_name $i overlay) ${sbid} "ping -c 1 svc$j"
+	    runc $(dnet_container_name $i overlay) $(get_sbox_id ${i} container_${i}) \
+		 "ping -c 1 container_$j"
 	done
     done
 
     # Teardown the container connections and the network
     for i in `seq ${start} ${end}`;
     do
-	osvc="svc$i"
-	dnet_cmd $(inst_id2port $i) service detach container_${i} ${osvc}.multihost
+	net_disconnect ${i} container_${i} multihost
 	dnet_cmd $(inst_id2port $i) container rm container_${i}
-	dnet_cmd $(inst_id2port $i) service unpublish ${osvc}.multihost
     done
 
     run dnet_cmd $(inst_id2port 2) network rm multihost

--- a/test/integration/dnet/run-integration-tests.sh
+++ b/test/integration/dnet/run-integration-tests.sh
@@ -79,6 +79,18 @@ stop_dnet 3 multi 1>>${INTEGRATION_ROOT}/test.log 2>&1
 unset cmap[dnet-3-multi]
 
 ## Setup
+start_dnet 1 bridge 1>>${INTEGRATION_ROOT}/test.log 2>&1
+cmap[dnet-1-bridge]=dnet-1-bridge
+
+## Run the test cases
+./integration-tmp/bin/bats ./test/integration/dnet/bridge.bats
+#docker logs dnet-1-bridge
+
+## Teardown
+stop_dnet 1 bridge 1>>${INTEGRATION_ROOT}/test.log 2>&1
+unset cmap[dnet-1-bridge]
+
+## Setup
 start_dnet 1 overlay 1>>${INTEGRATION_ROOT}/test.log 2>&1
 cmap[dnet-1-overlay]=dnet-1-overlay
 start_dnet 2 overlay 1>>${INTEGRATION_ROOT}/test.log 2>&1

--- a/test/integration/dnet/simple.bats
+++ b/test/integration/dnet/simple.bats
@@ -7,6 +7,8 @@ load helpers
     run dnet_cmd $(inst_id2port 1) network create -d test mh1
     echo ${output}
     [ "$status" -eq 0 ]
+    run dnet_cmd $(inst_id2port 1) network ls
+    echo ${output}
     line=$(dnet_cmd $(inst_id2port 1) network ls | grep mh1)
     echo ${line}
     name=$(echo ${line} | cut -d" " -f2)
@@ -32,9 +34,9 @@ load helpers
     echo ${output}
     [ "$status" -eq 0 ]
     run dnet_cmd $(inst_id2port 1) service ls
-    [ "$status" -eq 0 ]
     echo ${output}
     echo ${lines[1]}
+    [ "$status" -eq 0 ]
     svc=$(echo ${lines[1]} | cut -d" " -f2)
     network=$(echo ${lines[1]} | cut -d" " -f3)
     echo ${svc} ${network}


### PR DESCRIPTION
This PR addresses the following:
- Remove the local network and endpoint table and always reach out to the store.
- For local store maintain a in-memory cache
- Change datastore apis to better manage scope and the related configs
- Remove watches for networks and endpoints and only add watch to participating nodes
- Make IPAM and bitseq watch free
- Organize IPAM allocator around address spaces
- Add bridge network integration tests