### PR TITLE
Pass down store configs to driver

### DIFF
--- a/cmd/ovrouter/ovrouter.go
+++ b/cmd/ovrouter/ovrouter.go
@@ -105,10 +105,10 @@ func main() {
 		opt[netlabel.OverlayNeighborIP] = os.Args[2]
 	}
 	if len(os.Args) > 3 {
-		opt[netlabel.KVProvider] = os.Args[3]
+		opt[netlabel.GlobalKVProvider] = os.Args[3]
 	}
 	if len(os.Args) > 4 {
-		opt[netlabel.KVProviderURL] = os.Args[4]
+		opt[netlabel.GlobalKVProviderURL] = os.Args[4]
 	}
 
 	r := &router{}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -79,8 +79,8 @@ func (d *driver) configure() error {
 	}
 
 	d.once.Do(func() {
-		provider, provOk := d.config[netlabel.KVProvider]
-		provURL, urlOk := d.config[netlabel.KVProviderURL]
+		provider, provOk := d.config[netlabel.GlobalKVProvider]
+		provURL, urlOk := d.config[netlabel.GlobalKVProviderURL]
 
 		if provOk && urlOk {
 			cfg := &datastore.ScopeCfg{
@@ -89,7 +89,7 @@ func (d *driver) configure() error {
 					Address:  provURL.(string),
 				},
 			}
-			provConfig, confOk := d.config[netlabel.KVProviderConfig]
+			provConfig, confOk := d.config[netlabel.GlobalKVProviderConfig]
 			if confOk {
 				cfg.Client.Config = provConfig.(*store.Config)
 			}

--- a/netlabel/labels.go
+++ b/netlabel/labels.go
@@ -9,6 +9,10 @@ const (
 	// DriverPrefix constant marks the reserved label space for libnetwork drivers
 	DriverPrefix = Prefix + ".driver"
 
+	// DriverPrivatePrefix constant marks the reserved label space
+	// for internal libnetwork drivers
+	DriverPrivatePrefix = DriverPrefix + ".private"
+
 	// GenericData constant that helps to identify an option as a Generic constant
 	GenericData = Prefix + ".generic"
 
@@ -24,15 +28,6 @@ const (
 	//EnableIPv6 constant represents enabling IPV6 at network level
 	EnableIPv6 = Prefix + ".enable_ipv6"
 
-	// KVProvider constant represents the KV provider backend
-	KVProvider = DriverPrefix + ".kv_provider"
-
-	// KVProviderURL constant represents the KV provider URL
-	KVProviderURL = DriverPrefix + ".kv_provider_url"
-
-	// KVProviderConfig constant represents the KV provider Config
-	KVProviderConfig = DriverPrefix + ".kv_provider_config"
-
 	// OverlayBindInterface constant represents overlay driver bind interface
 	OverlayBindInterface = DriverPrefix + ".overlay.bind_interface"
 
@@ -42,6 +37,41 @@ const (
 	// Gateway represents the gateway for the network
 	Gateway = Prefix + ".gateway"
 )
+
+var (
+	// GlobalKVProvider constant represents the KV provider backend
+	GlobalKVProvider = MakeKVProvider("global")
+
+	// GlobalKVProviderURL constant represents the KV provider URL
+	GlobalKVProviderURL = MakeKVProviderURL("global")
+
+	// GlobalKVProviderConfig constant represents the KV provider Config
+	GlobalKVProviderConfig = MakeKVProviderConfig("global")
+
+	// LocalKVProvider constant represents the KV provider backend
+	LocalKVProvider = MakeKVProvider("local")
+
+	// LocalKVProviderURL constant represents the KV provider URL
+	LocalKVProviderURL = MakeKVProviderURL("local")
+
+	// LocalKVProviderConfig constant represents the KV provider Config
+	LocalKVProviderConfig = MakeKVProviderConfig("local")
+)
+
+// MakeKVProvider returns the kvprovider label for the scope
+func MakeKVProvider(scope string) string {
+	return DriverPrivatePrefix + scope + "kv_provider"
+}
+
+// MakeKVProviderURL returns the kvprovider url label for the scope
+func MakeKVProviderURL(scope string) string {
+	return DriverPrivatePrefix + scope + "kv_provider_url"
+}
+
+// MakeKVProviderConfig returns the kvprovider config label for the scope
+func MakeKVProviderConfig(scope string) string {
+	return DriverPrivatePrefix + scope + "kv_provider_config"
+}
 
 // Key extracts the key portion of the label
 func Key(label string) string {


### PR DESCRIPTION
     - Renamed netlabel prefixes to accomodate both global
       and local store configs.
     - Added a `private` marker.
     - Skipping the data store configs for remote driver
       so that external plugins don't get it as there is
       no secure and sane way to coordinate providing
       data store access to external plugins.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>