### PR TITLE
Fix in handling aux addresses

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -412,9 +412,14 @@ func (a *Allocator) ReleaseAddress(poolID string, address net.IP) error {
 		return ipamapi.ErrBadPool
 	}
 
-	if address == nil || !p.Pool.Contains(address) {
+	if address == nil {
 		aSpace.Unlock()
 		return ipamapi.ErrInvalidRequest
+	}
+
+	if !p.Pool.Contains(address) {
+		aSpace.Unlock()
+		return ipamapi.ErrIPOutOfRange
 	}
 
 	c := p


### PR DESCRIPTION
- libnetwork should reserve only the auxiliary
  addresses which belong to the requested pool

Signed-off-by: Alessandro Boch <aboch@docker.com>