### PR TITLE
Fixed a few issues identified during docker integration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -152,7 +152,7 @@ func (c *Config) ProcessOptions(options ...Option) {
 
 // IsValidName validates configuration objects supported by libnetwork
 func IsValidName(name string) bool {
-	if strings.TrimSpace(name) == "" || strings.Contains(name, ".") {
+	if strings.TrimSpace(name) == "" {
 		return false
 	}
 	return true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -52,7 +52,4 @@ func TestValidName(t *testing.T) {
 	if IsValidName("   ") {
 		t.Fatal("Name validation succeeds for a case when it is expected to fail")
 	}
-	if IsValidName("name.with.dots") {
-		t.Fatal("Name validation succeeds for a case when it is expected to fail")
-	}
 }

--- a/network.go
+++ b/network.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/etchosts"
+	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/types"
@@ -359,16 +360,24 @@ func (n *network) UnmarshalJSON(b []byte) (err error) {
 	}
 	n.name = netMap["name"].(string)
 	n.id = netMap["id"].(string)
-	n.ipamType = netMap["ipamType"].(string)
-	n.addrSpace = netMap["addrSpace"].(string)
 	n.networkType = netMap["networkType"].(string)
 	n.endpointCnt = uint64(netMap["endpointCnt"].(float64))
 	n.enableIPv6 = netMap["enableIPv6"].(bool)
+
 	if v, ok := netMap["generic"]; ok {
 		n.generic = v.(map[string]interface{})
 	}
 	if v, ok := netMap["persist"]; ok {
 		n.persist = v.(bool)
+	}
+	if v, ok := netMap["ipamType"]; ok {
+		n.ipamType = v.(string)
+	} else {
+		n.ipamType = ipamapi.DefaultIPAM
+	}
+
+	if v, ok := netMap["addrSpace"]; ok {
+		n.addrSpace = v.(string)
 	}
 	if v, ok := netMap["ipamV4Config"]; ok {
 		if err := json.Unmarshal([]byte(v.(string)), &n.ipamV4Config); err != nil {


### PR DESCRIPTION
* endpoint names can contain `.`
* any newly added variables must be checked for nil before type assertion in unmarshal
   (due to existing data in the store) 