### PR TITLE
Remove num bit limitation in bitsequence

### DIFF
--- a/bitseq/sequence.go
+++ b/bitseq/sequence.go
@@ -17,10 +17,10 @@ import (
 // If needed we can think of making these configurable
 const (
 	blockLen      = uint32(32)
-	blockBytes    = blockLen / 8
+	blockBytes    = uint64(blockLen / 8)
 	blockMAX      = uint32(1<<blockLen - 1)
 	blockFirstBit = uint32(1) << (blockLen - 1)
-	invalidPos    = blockMAX
+	invalidPos    = uint64(0xFFFFFFFFFFFFFFFF)
 )
 
 var (
@@ -29,8 +29,8 @@ var (
 
 // Handle contains the sequece representing the bitmask and its identifier
 type Handle struct {
-	bits       uint32
-	unselected uint32
+	bits       uint64
+	unselected uint64
 	head       *sequence
 	app        string
 	id         string
@@ -41,7 +41,7 @@ type Handle struct {
 }
 
 // NewHandle returns a thread-safe instance of the bitmask handler
-func NewHandle(app string, ds datastore.DataStore, id string, numElements uint32) (*Handle, error) {
+func NewHandle(app string, ds datastore.DataStore, id string, numElements uint64) (*Handle, error) {
 	h := &Handle{
 		app:        app,
 		id:         id,
@@ -76,7 +76,7 @@ func NewHandle(app string, ds datastore.DataStore, id string, numElements uint32
 // sequence represents a recurring sequence of 32 bits long bitmasks
 type sequence struct {
 	block uint32    // block is a symbol representing 4 byte long allocation bitmask
-	count uint32    // number of consecutive blocks (symbols)
+	count uint64    // number of consecutive blocks (symbols)
 	next  *sequence // next sequence
 }
 
@@ -92,7 +92,7 @@ func (s *sequence) toString() string {
 }
 
 // GetAvailableBit returns the position of the first unset bit in the bitmask represented by this sequence
-func (s *sequence) getAvailableBit(from uint32) (uint32, uint32, error) {
+func (s *sequence) getAvailableBit(from uint64) (uint64, uint64, error) {
 	if s.block == blockMAX || s.count == 0 {
 		return invalidPos, invalidPos, errNoBitAvailable
 	}
@@ -145,9 +145,9 @@ func (s *sequence) toByteArray() ([]byte, error) {
 
 	p := s
 	for p != nil {
-		b := make([]byte, 8)
+		b := make([]byte, 12)
 		binary.BigEndian.PutUint32(b[0:], p.block)
-		binary.BigEndian.PutUint32(b[4:], p.count)
+		binary.BigEndian.PutUint64(b[4:], p.count)
 		bb = append(bb, b...)
 		p = p.next
 	}
@@ -158,7 +158,7 @@ func (s *sequence) toByteArray() ([]byte, error) {
 // fromByteArray construct the sequence from the byte array
 func (s *sequence) fromByteArray(data []byte) error {
 	l := len(data)
-	if l%8 != 0 {
+	if l%12 != 0 {
 		return fmt.Errorf("cannot deserialize byte sequence of lenght %d (%v)", l, data)
 	}
 
@@ -166,8 +166,8 @@ func (s *sequence) fromByteArray(data []byte) error {
 	i := 0
 	for {
 		p.block = binary.BigEndian.Uint32(data[i : i+4])
-		p.count = binary.BigEndian.Uint32(data[i+4 : i+8])
-		i += 8
+		p.count = binary.BigEndian.Uint64(data[i+4 : i+12])
+		i += 12
 		if i == l {
 			break
 		}
@@ -192,7 +192,7 @@ func (h *Handle) getCopy() *Handle {
 }
 
 // SetAnyInRange atomically sets the first unset bit in the specified range in the sequence and returns the corresponding ordinal
-func (h *Handle) SetAnyInRange(start, end uint32) (uint32, error) {
+func (h *Handle) SetAnyInRange(start, end uint64) (uint64, error) {
 	if end-start <= 0 || end >= h.bits {
 		return invalidPos, fmt.Errorf("invalid bit range [%d, %d]", start, end)
 	}
@@ -203,7 +203,7 @@ func (h *Handle) SetAnyInRange(start, end uint32) (uint32, error) {
 }
 
 // SetAny atomically sets the first unset bit in the sequence and returns the corresponding ordinal
-func (h *Handle) SetAny() (uint32, error) {
+func (h *Handle) SetAny() (uint64, error) {
 	if h.Unselected() == 0 {
 		return invalidPos, errNoBitAvailable
 	}
@@ -211,7 +211,7 @@ func (h *Handle) SetAny() (uint32, error) {
 }
 
 // Set atomically sets the corresponding bit in the sequence
-func (h *Handle) Set(ordinal uint32) error {
+func (h *Handle) Set(ordinal uint64) error {
 	if err := h.validateOrdinal(ordinal); err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (h *Handle) Set(ordinal uint32) error {
 }
 
 // Unset atomically unsets the corresponding bit in the sequence
-func (h *Handle) Unset(ordinal uint32) error {
+func (h *Handle) Unset(ordinal uint64) error {
 	if err := h.validateOrdinal(ordinal); err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func (h *Handle) Unset(ordinal uint32) error {
 
 // IsSet atomically checks if the ordinal bit is set. In case ordinal
 // is outside of the bit sequence limits, false is returned.
-func (h *Handle) IsSet(ordinal uint32) bool {
+func (h *Handle) IsSet(ordinal uint64) bool {
 	if err := h.validateOrdinal(ordinal); err != nil {
 		return false
 	}
@@ -241,11 +241,11 @@ func (h *Handle) IsSet(ordinal uint32) bool {
 }
 
 // set/reset the bit
-func (h *Handle) set(ordinal, start, end uint32, any bool, release bool) (uint32, error) {
+func (h *Handle) set(ordinal, start, end uint64, any bool, release bool) (uint64, error) {
 	var (
-		bitPos  uint32
-		bytePos uint32
-		ret     uint32
+		bitPos  uint64
+		bytePos uint64
+		ret     uint64
 		err     error
 	)
 
@@ -309,7 +309,7 @@ func (h *Handle) set(ordinal, start, end uint32, any bool, release bool) (uint32
 }
 
 // checks is needed because to cover the case where the number of bits is not a multiple of blockLen
-func (h *Handle) validateOrdinal(ordinal uint32) error {
+func (h *Handle) validateOrdinal(ordinal uint64) error {
 	if ordinal >= h.bits {
 		return fmt.Errorf("bit does not belong to the sequence")
 	}
@@ -341,9 +341,9 @@ func (h *Handle) ToByteArray() ([]byte, error) {
 
 	h.Lock()
 	defer h.Unlock()
-	ba := make([]byte, 8)
-	binary.BigEndian.PutUint32(ba[0:], h.bits)
-	binary.BigEndian.PutUint32(ba[4:], h.unselected)
+	ba := make([]byte, 16)
+	binary.BigEndian.PutUint64(ba[0:], h.bits)
+	binary.BigEndian.PutUint64(ba[8:], h.unselected)
 	bm, err := h.head.toByteArray()
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize head: %s", err.Error())
@@ -360,27 +360,27 @@ func (h *Handle) FromByteArray(ba []byte) error {
 	}
 
 	nh := &sequence{}
-	err := nh.fromByteArray(ba[8:])
+	err := nh.fromByteArray(ba[16:])
 	if err != nil {
 		return fmt.Errorf("failed to deserialize head: %s", err.Error())
 	}
 
 	h.Lock()
 	h.head = nh
-	h.bits = binary.BigEndian.Uint32(ba[0:4])
-	h.unselected = binary.BigEndian.Uint32(ba[4:8])
+	h.bits = binary.BigEndian.Uint64(ba[0:8])
+	h.unselected = binary.BigEndian.Uint64(ba[8:16])
 	h.Unlock()
 
 	return nil
 }
 
 // Bits returns the length of the bit sequence
-func (h *Handle) Bits() uint32 {
+func (h *Handle) Bits() uint64 {
 	return h.bits
 }
 
 // Unselected returns the number of bits which are not selected
-func (h *Handle) Unselected() uint32 {
+func (h *Handle) Unselected() uint64 {
 	h.Lock()
 	defer h.Unlock()
 	return h.unselected
@@ -426,7 +426,7 @@ func (h *Handle) UnmarshalJSON(data []byte) error {
 }
 
 // getFirstAvailable looks for the first unset bit in passed mask starting from start
-func getFirstAvailable(head *sequence, start uint32) (uint32, uint32, error) {
+func getFirstAvailable(head *sequence, start uint64) (uint64, uint64, error) {
 	// Find sequence which contains the start bit
 	byteStart, bitStart := ordinalToPos(start)
 	current, _, _, inBlockBytePos := findSequence(head, byteStart)
@@ -450,7 +450,7 @@ func getFirstAvailable(head *sequence, start uint32) (uint32, uint32, error) {
 
 // checkIfAvailable checks if the bit correspondent to the specified ordinal is unset
 // If the ordinal is beyond the sequence limits, a negative response is returned
-func checkIfAvailable(head *sequence, ordinal uint32) (uint32, uint32, error) {
+func checkIfAvailable(head *sequence, ordinal uint64) (uint64, uint64, error) {
 	bytePos, bitPos := ordinalToPos(ordinal)
 
 	// Find the sequence containing this byte
@@ -470,7 +470,7 @@ func checkIfAvailable(head *sequence, ordinal uint32) (uint32, uint32, error) {
 // sequence containing the byte (current), the pointer to the previous sequence,
 // the number of blocks preceding the block containing the byte inside the current sequence.
 // If bytePos is outside of the list, function will return (nil, nil, 0, invalidPos)
-func findSequence(head *sequence, bytePos uint32) (*sequence, *sequence, uint32, uint32) {
+func findSequence(head *sequence, bytePos uint64) (*sequence, *sequence, uint64, uint64) {
 	// Find the sequence containing this byte
 	previous := head
 	current := head
@@ -511,7 +511,7 @@ func findSequence(head *sequence, bytePos uint32) (*sequence, *sequence, uint32,
 // A) block is first in current:         [prev seq] [new] [modified current seq] [next seq]
 // B) block is last in current:          [prev seq] [modified current seq] [new] [next seq]
 // C) block is in the middle of current: [prev seq] [curr pre] [new] [curr post] [next seq]
-func pushReservation(bytePos, bitPos uint32, head *sequence, release bool) *sequence {
+func pushReservation(bytePos, bitPos uint64, head *sequence, release bool) *sequence {
 	// Store list's head
 	newHead := head
 
@@ -599,18 +599,18 @@ func mergeSequences(seq *sequence) {
 	}
 }
 
-func getNumBlocks(numBits uint32) uint32 {
-	numBlocks := numBits / blockLen
-	if numBits%blockLen != 0 {
+func getNumBlocks(numBits uint64) uint64 {
+	numBlocks := numBits / uint64(blockLen)
+	if numBits%uint64(blockLen) != 0 {
 		numBlocks++
 	}
 	return numBlocks
 }
 
-func ordinalToPos(ordinal uint32) (uint32, uint32) {
+func ordinalToPos(ordinal uint64) (uint64, uint64) {
 	return ordinal / 8, ordinal % 8
 }
 
-func posToOrdinal(bytePos, bitPos uint32) uint32 {
+func posToOrdinal(bytePos, bitPos uint64) uint64 {
 	return bytePos*8 + bitPos
 }

--- a/bitseq/sequence_test.go
+++ b/bitseq/sequence_test.go
@@ -9,9 +9,9 @@ import (
 func TestSequenceGetAvailableBit(t *testing.T) {
 	input := []struct {
 		head    *sequence
-		from    uint32
-		bytePos uint32
-		bitPos  uint32
+		from    uint64
+		bytePos uint64
+		bitPos  uint64
 	}{
 		{&sequence{block: 0x0, count: 0}, 0, invalidPos, invalidPos},
 		{&sequence{block: 0x0, count: 1}, 0, 0, 0},
@@ -120,8 +120,8 @@ func TestSequenceCopy(t *testing.T) {
 func TestGetFirstAvailable(t *testing.T) {
 	input := []struct {
 		mask    *sequence
-		bytePos uint32
-		bitPos  uint32
+		bytePos uint64
+		bitPos  uint64
 	}{
 		{&sequence{block: 0xffffffff, count: 2048}, invalidPos, invalidPos},
 		{&sequence{block: 0x0, count: 8}, 0, 0},
@@ -167,9 +167,9 @@ func TestGetFirstAvailable(t *testing.T) {
 func TestFindSequence(t *testing.T) {
 	input := []struct {
 		head           *sequence
-		bytePos        uint32
-		precBlocks     uint32
-		inBlockBytePos uint32
+		bytePos        uint64
+		precBlocks     uint64
+		inBlockBytePos uint64
 	}{
 		{&sequence{block: 0xffffffff, count: 0}, 0, 0, invalidPos},
 		{&sequence{block: 0xffffffff, count: 0}, 31, 0, invalidPos},
@@ -202,9 +202,9 @@ func TestFindSequence(t *testing.T) {
 func TestCheckIfAvailable(t *testing.T) {
 	input := []struct {
 		head    *sequence
-		ordinal uint32
-		bytePos uint32
-		bitPos  uint32
+		ordinal uint64
+		bytePos uint64
+		bitPos  uint64
 	}{
 		{&sequence{block: 0xffffffff, count: 0}, 0, invalidPos, invalidPos},
 		{&sequence{block: 0xffffffff, count: 0}, 31, invalidPos, invalidPos},
@@ -274,8 +274,8 @@ func TestMergeSequences(t *testing.T) {
 func TestPushReservation(t *testing.T) {
 	input := []struct {
 		mask    *sequence
-		bytePos uint32
-		bitPos  uint32
+		bytePos uint64
+		bitPos  uint64
 		newMask *sequence
 	}{
 		// Create first sequence and fill in 8 addresses starting from address 0
@@ -445,8 +445,8 @@ func TestSet(t *testing.T) {
 	}
 	hnd.head = getTestSequence()
 
-	firstAv := uint32(32*100 + 31)
-	last := uint32(1024*32 - 1)
+	firstAv := uint64(32*100 + 31)
+	last := uint64(1024*32 - 1)
 
 	if hnd.IsSet(100000) {
 		t.Fatal("IsSet() returned wrong result")
@@ -497,7 +497,7 @@ func TestSet(t *testing.T) {
 }
 
 func TestSetUnset(t *testing.T) {
-	numBits := uint32(64 * 1024)
+	numBits := uint64(64 * 1024)
 	hnd, err := NewHandle("", nil, "", numBits)
 	if err != nil {
 		t.Fatal(err)
@@ -508,7 +508,7 @@ func TestSetUnset(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	i := uint32(0)
+	i := uint64(0)
 	for hnd.Unselected() < numBits {
 		if err := hnd.Unset(i); err != nil {
 			t.Fatal(err)
@@ -518,14 +518,14 @@ func TestSetUnset(t *testing.T) {
 }
 
 func TestSetInRange(t *testing.T) {
-	numBits := uint32(1024 * blockLen)
+	numBits := uint64(1024 * blockLen)
 	hnd, err := NewHandle("", nil, "", numBits)
 	if err != nil {
 		t.Fatal(err)
 	}
 	hnd.head = getTestSequence()
 
-	firstAv := uint32(100*blockLen + blockLen - 1)
+	firstAv := uint64(100*blockLen + blockLen - 1)
 
 	if o, err := hnd.SetAnyInRange(4, 3); err == nil {
 		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
@@ -539,7 +539,7 @@ func TestSetInRange(t *testing.T) {
 		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
 	}
 
-	o, err := hnd.SetAnyInRange(100*blockLen, 101*blockLen)
+	o, err := hnd.SetAnyInRange(100*uint64(blockLen), 101*uint64(blockLen))
 	if err != nil {
 		t.Fatalf("Unexpected failure: (%d, %v)", o, err)
 	}
@@ -547,7 +547,7 @@ func TestSetInRange(t *testing.T) {
 		t.Fatalf("Unexpected ordinal: %d", o)
 	}
 
-	if o, err := hnd.SetAnyInRange(0, blockLen); err == nil {
+	if o, err := hnd.SetAnyInRange(0, uint64(blockLen)); err == nil {
 		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
 	}
 
@@ -555,27 +555,27 @@ func TestSetInRange(t *testing.T) {
 		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
 	}
 
-	if o, err := hnd.SetAnyInRange(111*blockLen, 161*blockLen); err == nil {
+	if o, err := hnd.SetAnyInRange(111*uint64(blockLen), 161*uint64(blockLen)); err == nil {
 		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
 	}
 
-	o, err = hnd.SetAnyInRange(161*blockLen, 162*blockLen)
+	o, err = hnd.SetAnyInRange(161*uint64(blockLen), 162*uint64(blockLen))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if o != 161*blockLen+30 {
+	if o != 161*uint64(blockLen)+30 {
 		t.Fatalf("Unexpected ordinal: %d", o)
 	}
 
-	o, err = hnd.SetAnyInRange(161*blockLen, 162*blockLen)
+	o, err = hnd.SetAnyInRange(161*uint64(blockLen), 162*uint64(blockLen))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if o != 161*blockLen+31 {
+	if o != 161*uint64(blockLen)+31 {
 		t.Fatalf("Unexpected ordinal: %d", o)
 	}
 
-	o, err = hnd.SetAnyInRange(161*blockLen, 162*blockLen)
+	o, err = hnd.SetAnyInRange(161*uint64(blockLen), 162*uint64(blockLen))
 	if err == nil {
 		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
 	}

--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -475,7 +475,7 @@ func (n *network) releaseVxlanID() error {
 	}
 
 	for _, s := range n.subnets {
-		n.driver.vxlanIdm.Release(n.vxlanID(s))
+		n.driver.vxlanIdm.Release(uint64(n.vxlanID(s)))
 		n.setVxlanID(s, 0)
 	}
 	return nil
@@ -502,9 +502,9 @@ func (n *network) obtainVxlanID(s *subnet) error {
 				return fmt.Errorf("failed to allocate vxlan id: %v", err)
 			}
 
-			n.setVxlanID(s, vxlanID)
+			n.setVxlanID(s, uint32(vxlanID))
 			if err := n.writeToStore(); err != nil {
-				n.driver.vxlanIdm.Release(n.vxlanID(s))
+				n.driver.vxlanIdm.Release(uint64(n.vxlanID(s)))
 				n.setVxlanID(s, 0)
 				if err == datastore.ErrKeyModified {
 					continue

--- a/idm/idm.go
+++ b/idm/idm.go
@@ -10,13 +10,13 @@ import (
 
 // Idm manages the reservation/release of numerical ids from a contiguos set
 type Idm struct {
-	start  uint32
-	end    uint32
+	start  uint64
+	end    uint64
 	handle *bitseq.Handle
 }
 
 // New returns an instance of id manager for a set of [start-end] numerical ids
-func New(ds datastore.DataStore, id string, start, end uint32) (*Idm, error) {
+func New(ds datastore.DataStore, id string, start, end uint64) (*Idm, error) {
 	if id == "" {
 		return nil, fmt.Errorf("Invalid id")
 	}
@@ -33,7 +33,7 @@ func New(ds datastore.DataStore, id string, start, end uint32) (*Idm, error) {
 }
 
 // GetID returns the first available id in the set
-func (i *Idm) GetID() (uint32, error) {
+func (i *Idm) GetID() (uint64, error) {
 	if i.handle == nil {
 		return 0, fmt.Errorf("ID set is not initialized")
 	}
@@ -42,7 +42,7 @@ func (i *Idm) GetID() (uint32, error) {
 }
 
 // GetSpecificID tries to reserve the specified id
-func (i *Idm) GetSpecificID(id uint32) error {
+func (i *Idm) GetSpecificID(id uint64) error {
 	if i.handle == nil {
 		return fmt.Errorf("ID set is not initialized")
 	}
@@ -55,6 +55,6 @@ func (i *Idm) GetSpecificID(id uint32) error {
 }
 
 // Release releases the specified id
-func (i *Idm) Release(id uint32) {
+func (i *Idm) Release(id uint64) {
 	i.handle.Unset(id - i.start)
 }

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -239,7 +239,7 @@ func (a *Allocator) parsePoolRequest(addressSpace, pool, subPool string, v6 bool
 }
 
 func (a *Allocator) insertBitMask(key SubnetKey, pool *net.IPNet) error {
-	log.Debugf("Inserting bitmask (%s, %s)", key.String(), pool.String())
+	//log.Debugf("Inserting bitmask (%s, %s)", key.String(), pool.String())
 
 	store := a.getStore(key.AddressSpace)
 	if store == nil {

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -66,10 +66,10 @@ func getAllocator() (*Allocator, error) {
 }
 
 func TestInt2IP2IntConversion(t *testing.T) {
-	for i := uint32(0); i < 256*256*256; i++ {
+	for i := uint64(0); i < 256*256*256; i++ {
 		var array [4]byte // new array at each cycle
 		addIntToIP(array[:], i)
-		j := ipToUint32(array[:])
+		j := ipToUint64(array[:])
 		if j != i {
 			t.Fatalf("Failed to convert ordinal %d to IP % x and back to ordinal. Got %d", i, array, j)
 		}
@@ -502,31 +502,6 @@ func TestPredefinedPool(t *testing.T) {
 	}
 }
 
-func TestAdjustAndCheckSubnet(t *testing.T) {
-	_, sub6, _ := net.ParseCIDR("1003:1:2:300::/63")
-	_, err := adjustAndCheckSubnetSize(sub6)
-	if err == nil {
-		t.Fatalf("Failed detect too big v6 subnet")
-	}
-
-	_, sub, _ := net.ParseCIDR("192.0.0.0/7")
-	_, err = adjustAndCheckSubnetSize(sub)
-	if err == nil {
-		t.Fatalf("Failed detect too big v4 subnet")
-	}
-
-	subnet := "1004:1:2:6::/64"
-	_, sub6, _ = net.ParseCIDR(subnet)
-	subnetToSplit, err := adjustAndCheckSubnetSize(sub6)
-	if err != nil {
-		t.Fatalf("Unexpected error returned by adjustAndCheckSubnetSize()")
-	}
-	ones, _ := subnetToSplit.Mask.Size()
-	if ones < minNetSizeV6Eff {
-		t.Fatalf("Wrong effective network size for %s. Expected: %d. Got: %d", subnet, minNetSizeV6Eff, ones)
-	}
-}
-
 func TestRemoveSubnet(t *testing.T) {
 	a, err := getAllocator()
 	if err != nil {
@@ -757,7 +732,7 @@ func TestRequestSyntaxCheck(t *testing.T) {
 
 	err = a.ReleaseAddress(pid, ip)
 	if err != nil {
-		t.Fatalf("Unexpected failure: %v", err)
+		t.Fatalf("Unexpected failure: %v: %s, %s", err, pid, ip)
 	}
 }
 
@@ -873,7 +848,7 @@ func assertGetAddress(t *testing.T, subnet string) {
 	zeroes := bits - ones
 	numAddresses := 1 << uint(zeroes)
 
-	bm, err := bitseq.NewHandle("ipam_test", nil, "default/"+subnet, uint32(numAddresses))
+	bm, err := bitseq.NewHandle("ipam_test", nil, "default/"+subnet, uint64(numAddresses))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ipam/structures.go
+++ b/ipam/structures.go
@@ -43,7 +43,7 @@ type addrSpace struct {
 // identify a range in a a pool of addresses
 type AddressRange struct {
 	Sub        *net.IPNet
-	Start, End uint32
+	Start, End uint64
 }
 
 // String returns the string form of the AddressRange object
@@ -71,8 +71,8 @@ func (r *AddressRange) UnmarshalJSON(data []byte) error {
 	if r.Sub, err = types.ParseCIDR(m["Sub"].(string)); err != nil {
 		return err
 	}
-	r.Start = uint32(m["Start"].(float64))
-	r.End = uint32(m["End"].(float64))
+	r.Start = uint64(m["Start"].(float64))
+	r.End = uint64(m["End"].(float64))
 	return nil
 }
 

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -276,7 +276,7 @@ func TestBridge(t *testing.T) {
 		},
 	}
 	ipamV4ConfList := []*libnetwork.IpamConf{&libnetwork.IpamConf{PreferredPool: "192.168.100.0/24", Gateway: "192.168.100.1"}}
-	ipamV6ConfList := []*libnetwork.IpamConf{&libnetwork.IpamConf{PreferredPool: "fe90::/98", Gateway: "fe90::22"}}
+	ipamV6ConfList := []*libnetwork.IpamConf{&libnetwork.IpamConf{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
 
 	network, err := createTestNetwork(bridgeNetType, "testnetwork", netOption, ipamV4ConfList, ipamV6ConfList)
 	if err != nil {
@@ -1641,7 +1641,7 @@ func TestEnableIPv6(t *testing.T) {
 			"BridgeName": "testnetwork",
 		},
 	}
-	ipamV6ConfList := []*libnetwork.IpamConf{&libnetwork.IpamConf{PreferredPool: "fe80::/98"}}
+	ipamV6ConfList := []*libnetwork.IpamConf{&libnetwork.IpamConf{PreferredPool: "fe80::/64"}}
 
 	n, err := createTestNetwork("bridge", "testnetwork", netOption, nil, ipamV6ConfList)
 	if err != nil {

--- a/sandbox_store.go
+++ b/sandbox_store.go
@@ -168,7 +168,6 @@ func (c *controller) sandboxCleanup() {
 	for _, kvo := range kvol {
 		sbs := kvo.(*sbState)
 
-		logrus.Printf("sandboxcleanup sbs = %+v", sbs)
 		sb := &sandbox{
 			id:          sbs.ID,
 			controller:  sbs.c,


### PR DESCRIPTION
- Removed 2^32-1 bit number limitation in bitsequence
  This simplify IPv6 subnet management in IPAM
- Reduced log verbosity in IPAM and sandbox store