### PR TITLE
Network ep count increment/decrement needs retry

### DIFF
--- a/store.go
+++ b/store.go
@@ -155,6 +155,9 @@ func (c *controller) updateToStore(kvObject datastore.KVObject) error {
 	}
 
 	if err := cs.PutObjectAtomic(kvObject); err != nil {
+		if err == datastore.ErrKeyModified {
+			return err
+		}
 		return fmt.Errorf("failed to update store for object type %T: %v", kvObject, err)
 	}
 


### PR DESCRIPTION
Today we try to increment/decrement endpoint count
only once even if it is a key modified error. In case
of key modified error we should retry it to allow it to
succeed.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>