### PR TITLE
Moved the default local and global store to new root

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,7 +68,7 @@ type Option func(c *Config)
 // OptionDefaultNetwork function returns an option setter for a default network
 func OptionDefaultNetwork(dn string) Option {
 	return func(c *Config) {
-		log.Infof("Option DefaultNetwork: %s", dn)
+		log.Debugf("Option DefaultNetwork: %s", dn)
 		c.Daemon.DefaultNetwork = strings.TrimSpace(dn)
 	}
 }
@@ -76,7 +76,7 @@ func OptionDefaultNetwork(dn string) Option {
 // OptionDefaultDriver function returns an option setter for default driver
 func OptionDefaultDriver(dd string) Option {
 	return func(c *Config) {
-		log.Infof("Option DefaultDriver: %s", dd)
+		log.Debugf("Option DefaultDriver: %s", dd)
 		c.Daemon.DefaultDriver = strings.TrimSpace(dd)
 	}
 }
@@ -102,7 +102,7 @@ func OptionLabels(labels []string) Option {
 // OptionKVProvider function returns an option setter for kvstore provider
 func OptionKVProvider(provider string) Option {
 	return func(c *Config) {
-		log.Infof("Option OptionKVProvider: %s", provider)
+		log.Debugf("Option OptionKVProvider: %s", provider)
 		if _, ok := c.Scopes[datastore.GlobalScope]; !ok {
 			c.Scopes[datastore.GlobalScope] = &datastore.ScopeCfg{}
 		}
@@ -113,7 +113,7 @@ func OptionKVProvider(provider string) Option {
 // OptionKVProviderURL function returns an option setter for kvstore url
 func OptionKVProviderURL(url string) Option {
 	return func(c *Config) {
-		log.Infof("Option OptionKVProviderURL: %s", url)
+		log.Debugf("Option OptionKVProviderURL: %s", url)
 		if _, ok := c.Scopes[datastore.GlobalScope]; !ok {
 			c.Scopes[datastore.GlobalScope] = &datastore.ScopeCfg{}
 		}
@@ -196,7 +196,7 @@ func IsValidName(name string) bool {
 // OptionLocalKVProvider function returns an option setter for kvstore provider
 func OptionLocalKVProvider(provider string) Option {
 	return func(c *Config) {
-		log.Infof("Option OptionLocalKVProvider: %s", provider)
+		log.Debugf("Option OptionLocalKVProvider: %s", provider)
 		if _, ok := c.Scopes[datastore.LocalScope]; !ok {
 			c.Scopes[datastore.LocalScope] = &datastore.ScopeCfg{}
 		}
@@ -207,7 +207,7 @@ func OptionLocalKVProvider(provider string) Option {
 // OptionLocalKVProviderURL function returns an option setter for kvstore url
 func OptionLocalKVProviderURL(url string) Option {
 	return func(c *Config) {
-		log.Infof("Option OptionLocalKVProviderURL: %s", url)
+		log.Debugf("Option OptionLocalKVProviderURL: %s", url)
 		if _, ok := c.Scopes[datastore.LocalScope]; !ok {
 			c.Scopes[datastore.LocalScope] = &datastore.ScopeCfg{}
 		}
@@ -218,7 +218,7 @@ func OptionLocalKVProviderURL(url string) Option {
 // OptionLocalKVProviderConfig function returns an option setter for kvstore config
 func OptionLocalKVProviderConfig(config *store.Config) Option {
 	return func(c *Config) {
-		log.Infof("Option OptionLocalKVProviderConfig: %v", config)
+		log.Debugf("Option OptionLocalKVProviderConfig: %v", config)
 		if _, ok := c.Scopes[datastore.LocalScope]; !ok {
 			c.Scopes[datastore.LocalScope] = &datastore.ScopeCfg{}
 		}

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -126,7 +126,7 @@ func makeDefaultScopes() map[string]*ScopeCfg {
 	def[LocalScope] = &ScopeCfg{
 		Client: ScopeClientCfg{
 			Provider: "boltdb",
-			Address:  defaultPrefix + "/boltdb.db",
+			Address:  defaultPrefix + "/local-kv.db",
 			Config: &store.Config{
 				Bucket: "libnetwork",
 			},
@@ -136,7 +136,7 @@ func makeDefaultScopes() map[string]*ScopeCfg {
 	return def
 }
 
-var rootChain = []string{"docker", "libnetwork"}
+var rootChain = []string{"docker", "network", "v1.0"}
 
 func init() {
 	consul.Register()
@@ -148,11 +148,11 @@ func init() {
 // DefaultScopes returns a map of default scopes and it's config for clients to use.
 func DefaultScopes(dataDir string) map[string]*ScopeCfg {
 	if dataDir != "" {
-		defaultScopes[LocalScope].Client.Address = dataDir + "/network/files/boltdb.db"
+		defaultScopes[LocalScope].Client.Address = dataDir + "/network/files/local-kv.db"
 		return defaultScopes
 	}
 
-	defaultScopes[LocalScope].Client.Address = defaultPrefix + "/boltdb.db"
+	defaultScopes[LocalScope].Client.Address = defaultPrefix + "/local-kv.db"
 	return defaultScopes
 }
 

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -20,13 +20,13 @@ func NewTestDataStore() DataStore {
 func TestKey(t *testing.T) {
 	eKey := []string{"hello", "world"}
 	sKey := Key(eKey...)
-	if sKey != "docker/libnetwork/hello/world/" {
+	if sKey != "docker/network/v1.0/hello/world/" {
 		t.Fatalf("unexpected key : %s", sKey)
 	}
 }
 
 func TestParseKey(t *testing.T) {
-	keySlice, err := ParseKey("/docker/libnetwork/hello/world/")
+	keySlice, err := ParseKey("/docker/network/v1.0/hello/world/")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is required in order to provide a clean switchover.

Signed-off-by: Madhu Venugopal <madhu@docker.com>