### PR TITLE
Fix docker daemon failed to start with multiple cluster store address

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -188,7 +188,7 @@ func ParseKey(key string) ([]string, error) {
 }
 
 // newClient used to connect to KV Store
-func newClient(scope string, kv string, addrs string, config *store.Config, cached bool) (DataStore, error) {
+func newClient(scope string, kv string, addr string, config *store.Config, cached bool) (DataStore, error) {
 	if cached && scope != LocalScope {
 		return nil, fmt.Errorf("caching supported only for scope %s", LocalScope)
 	}
@@ -196,7 +196,10 @@ func newClient(scope string, kv string, addrs string, config *store.Config, cach
 	if config == nil {
 		config = &store.Config{}
 	}
-	store, err := libkv.NewStore(store.Backend(kv), []string{addrs}, config)
+
+	addrs := strings.Split(addr, ",")
+
+	store, err := libkv.NewStore(store.Backend(kv), addrs, config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>

fixes https://github.com/docker/docker/issues/17007

For HA, user always specify multiple store address.