### PR TITLE
Change in ipamutils.ElectInterfaceAddresses

### DIFF
--- a/ipamutils/utils_linux.go
+++ b/ipamutils/utils_linux.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/docker/libnetwork/netutils"
 	"github.com/docker/libnetwork/resolvconf"
+	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 )
+
+const defaultInterface = "docker0"
 
 // ElectInterfaceAddresses looks for an interface on the OS with the specified name
 // and returns its IPv4 and IPv6 addresses in CIDR form. If the interface does not exist,
@@ -45,6 +48,8 @@ func ElectInterfaceAddresses(name string) (*net.IPNet, []*net.IPNet, error) {
 		if err != nil {
 			return nil, nil, err
 		}
+		// Make sure docker behaviour for default bridge is preserved
+		v4Net = adjustIfDefaultInterface(name, v4Net)
 	}
 
 	return v4Net, v6Nets, nil
@@ -68,4 +73,12 @@ func FindAvailableNetwork(list []*net.IPNet) (*net.IPNet, error) {
 		}
 	}
 	return nil, fmt.Errorf("no available network")
+}
+
+func adjustIfDefaultInterface(name string, nw *net.IPNet) *net.IPNet {
+	if name == defaultInterface && nw.String() == "172.17.0.0/16" {
+		dw, _ := types.ParseCIDR("172.17.42.1/16")
+		return dw
+	}
+	return nw
 }


### PR DESCRIPTION
- To preserve docker0 addressing behaviour, only for the default docker0 bridge restore the address to "172.17.42.1" instead of "172.17.0.1". 
- People should not hard-code IP addresses into their script, but there is no functionality risk in restoring the old address.

Signed-off-by: Alessandro Boch <aboch@docker.com>