### PR TITLE
Explicitly set namepsace for ipamutils.ElectInterface

### DIFF
--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -218,6 +218,9 @@ func TestCreateMultipleNetworks(t *testing.T) {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
+	// Verify the network isolation rules are installed, each network subnet should appear 2 times
+	verifyV4INCEntries(d.networks, 2, t)
+
 	config3 := &networkConfiguration{BridgeName: "net_test_3"}
 	genericOption[netlabel.GenericData] = config3
 	if err := d.CreateNetwork("3", genericOption, getIPv4Data(t), nil); err != nil {

--- a/ipamutils/utils_linux.go
+++ b/ipamutils/utils_linux.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/docker/libnetwork/netutils"
+	"github.com/docker/libnetwork/osl"
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/vishvananda/netlink"
 )
@@ -20,6 +21,8 @@ func ElectInterfaceAddresses(name string) (*net.IPNet, []*net.IPNet, error) {
 		v6Nets []*net.IPNet
 		err    error
 	)
+
+	defer osl.InitOSContext()()
 
 	link, _ := netlink.LinkByName(name)
 	if link != nil {


### PR DESCRIPTION
During the run of `TestCreateMultipleNetworks()` (which runs in  a netns) occasionally `ipamutils.ElectInterfaceAddresses()` returns a network which is already being used, causing the test to fail. While debugging the test failure it turned out  the root cause was netutils.CheckRouteOverlaps() returning host routes during the failure. This looks the same issue that was fixed by #476. 

Now that the address pool election is moved away from bridge code into ipamutils via #588 , its execution is no longer tied to the netns by the fix introduced in #476.

In fact the random `TestCreateMultipleNetworks()` failures in circle ci started after #588.

Closes #652 

Signed-off-by: Alessandro Boch <aboch@docker.com>