### PR TITLE
Improve name gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all all-local build build-local check check-code check-format run-tests check-local integration-tests install-deps coveralls circle-ci start-services clean
 SHELL=/bin/bash
-build_image=libnetwork-build
+build_image=libnetworkbuild
 dockerargs = --privileged -v $(shell pwd):/go/src/github.com/docker/libnetwork -w /go/src/github.com/docker/libnetwork
 container_env = -e "INSIDECONTAINER=-incontainer=true"
 docker = docker run --rm -it ${dockerargs} ${container_env} ${build_image}

--- a/netutils/utils.go
+++ b/netutils/utils.go
@@ -161,8 +161,8 @@ func GenerateIfaceName(prefix string, len int) (string, error) {
 		if err != nil {
 			continue
 		}
-		if _, err := net.InterfaceByName(name); err != nil {
-			if strings.Contains(err.Error(), "no such") {
+		if _, err := netlink.LinkByName(name); err != nil {
+			if strings.Contains(err.Error(), "not found") {
 				return name, nil
 			}
 			return "", err


### PR DESCRIPTION
Use `netlink.LinkByName` instead of `net.InterfaceByName`, it improved container starting speed in docker tremendously.
Also I fixed image name in `Makefile`.