### PR TITLE
Change in bridge/setup_ip_tables.go

### DIFF
--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/iptables"
-	"github.com/docker/libnetwork/netutils"
 )
 
 // DockerChain: DOCKER iptable chain name
@@ -60,6 +59,8 @@ func setupIPChains(config *configuration) (*iptables.ChainInfo, *iptables.ChainI
 }
 
 func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInterface) error {
+	var err error
+
 	d := n.driver
 	d.Lock()
 	driverConfig := d.config
@@ -73,14 +74,9 @@ func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInt
 	// Pickup this configuraton option from driver
 	hairpinMode := !driverConfig.EnableUserlandProxy
 
-	addrv4, _, err := netutils.GetIfaceAddr(config.BridgeName)
-	if err != nil {
-		return fmt.Errorf("Failed to setup IP tables, cannot acquire Interface address: %s", err.Error())
-	}
-	ipnet := addrv4.(*net.IPNet)
 	maskedAddrv4 := &net.IPNet{
-		IP:   ipnet.IP.Mask(ipnet.Mask),
-		Mask: ipnet.Mask,
+		IP:   i.bridgeIPv4.IP.Mask(i.bridgeIPv4.Mask),
+		Mask: i.bridgeIPv4.Mask,
 	}
 	if config.Internal {
 		if err = setupInternalNetworkRules(config.BridgeName, maskedAddrv4, true); err != nil {


### PR DESCRIPTION
- With the transition to ipam, bridge ip address stored
  in `bridgeInterface` is guaranteed to be the ip of the
  OS bridge by the `setupBridgeIPv4` step function.
  Therefore the `setupIPTables()` step function no
  longer needs to fetch the address from the OS.

This removes unnecessary syscalls to the OS
and removes the code which may cause confusion.

Signed-off-by: Alessandro Boch <aboch@docker.com>