### PR TITLE
Bridge driver should return maskable error

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -989,7 +989,7 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 	d.Unlock()
 
 	if !ok {
-		return types.NotFoundErrorf("network %s does not exist", nid)
+		return types.InternalMaskableErrorf("network %s does not exist", nid)
 	}
 	if n == nil {
 		return driverapi.ErrNoNetwork(nid)
@@ -1145,7 +1145,7 @@ func (d *driver) Leave(nid, eid string) error {
 
 	network, err := d.getNetwork(nid)
 	if err != nil {
-		return err
+		return types.InternalMaskableErrorf("%s", err)
 	}
 
 	endpoint, err := network.getEndpoint(eid)


### PR DESCRIPTION
Bridge driver should return maskable error during Leave
or DeleteEndpoint since this can be an expected sceanrio
when libnetwork tries to leave and delete default bridge
endpoints and bridge driver does not persist with the default
bridge. This is only expected during an ungraceful exit of
the daemon but will cause confusion to the user if it shows
up as failures on a deamon restart after an ungraceful exit.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>