### PR TITLE
Handle maskable error during endpoint delete

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -536,7 +536,10 @@ func (ep *endpoint) deleteEndpoint() error {
 		if _, ok := err.(types.ForbiddenError); ok {
 			return err
 		}
-		log.Warnf("driver error deleting endpoint %s : %v", name, err)
+
+		if _, ok := err.(types.MaskableError); !ok {
+			log.Warnf("driver error deleting endpoint %s : %v", name, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Do not log unncessary warning messages when you get
maskable error from driver during an endpoint delete.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>