### PR TITLE
Do not refresh the bitmasks on all operations in IPAM

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -84,10 +84,6 @@ func (a *Allocator) refresh(as string) error {
 		return nil
 	}
 
-	if err := a.updateBitMasks(aSpace); err != nil {
-		return fmt.Errorf("error updating bit masks during init: %v", err)
-	}
-
 	a.Lock()
 	a.addrSpaces[as] = aSpace
 	a.Unlock()


### PR DESCRIPTION
- Currently allocator pulls all the bitmasks from datastore
  before processing each public API. This is not needed as
  the APIs already selectively pull the interested bitmask
  when needed.

Signed-off-by: Alessandro Boch <aboch@docker.com>