### PR TITLE
Synchronize /etc/hosts updates at file level

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -182,6 +182,10 @@ func (sb *sandbox) Delete() error {
 		}
 	}
 
+	// Container is going away. Path cache in etchosts is most
+	// likely not required any more. Drop it.
+	etchosts.Drop(sb.config.hostsPath)
+
 	if sb.osSbox != nil {
 		sb.osSbox.Destroy()
 	}


### PR DESCRIPTION
Introduced a path level lock to synchronize updates
to /etc/hosts writes. A path level cache is maintained
to only synchronize only at the file level.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>