### PR TITLE
Allow remote ipam driver to return nil address

### DIFF
--- a/ipams/remote/remote.go
+++ b/ipams/remote/remote.go
@@ -78,7 +78,11 @@ func (a *allocator) ReleasePool(poolID string) error {
 
 // RequestAddress requests an address from the address pool
 func (a *allocator) RequestAddress(poolID string, address net.IP, options map[string]string) (*net.IPNet, map[string]string, error) {
-	var prefAddress string
+	var (
+		prefAddress string
+		retAddress  *net.IPNet
+		err         error
+	)
 	if address != nil {
 		prefAddress = address.String()
 	}
@@ -87,7 +91,9 @@ func (a *allocator) RequestAddress(poolID string, address net.IP, options map[st
 	if err := a.call("RequestAddress", req, res); err != nil {
 		return nil, nil, err
 	}
-	retAddress, err := types.ParseCIDR(res.Address)
+	if res.Address != "" {
+		retAddress, err = types.ParseCIDR(res.Address)
+	}
 	return retAddress, res.Data, err
 }
 


### PR DESCRIPTION
- This brings the remote ipam driver in pair with the local one. As of now remote driver package is assuming a valid address in CIDR form is always present in a nil error AddressRequestResponse,      which is no longer true as community has requested to remove this limitation.
- We are ok to remove it until we can provide a null ipam driver option in future releases.


Issue was pointed out by @pyakpyak in [comment](https://github.com/docker/libnetwork/issues/665#issuecomment-149788760)

Signed-off-by: Alessandro Boch <aboch@docker.com>