### PR TITLE
Purge remote endpoints from watch if it is local

### DIFF
--- a/store.go
+++ b/store.go
@@ -308,6 +308,11 @@ func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoi
 
 		c.Lock()
 		nw.localEps[ep.ID()] = ep
+
+		// If we had learned that from the kv store remove it
+		// from remote ep list now that we know that this is
+		// indeed a local endpoint
+		delete(nw.remoteEps, ep.ID())
 		c.Unlock()
 		return
 	}

--- a/test/integration/dnet/helpers.bash
+++ b/test/integration/dnet/helpers.bash
@@ -291,3 +291,42 @@ function test_overlay() {
 
     dnet_cmd $(inst_id2port 2) network rm multihost
 }
+
+function test_overlay_singlehost() {
+    dnet_suffix=$1
+    shift
+
+    echo $(docker ps)
+
+    start=1
+    end=3
+    # Setup overlay network and connect containers ot it
+    dnet_cmd $(inst_id2port 1) network create -d overlay multihost
+    for i in `seq ${start} ${end}`;
+    do
+	dnet_cmd $(inst_id2port 1) container create container_${i}
+	net_connect 1 container_${i} multihost
+    done
+
+    # Now test connectivity between all the containers using service names
+    for i in `seq ${start} ${end}`;
+    do
+	for j in `seq ${start} ${end}`;
+	do
+	    if [ "$i" -eq "$j" ]; then
+		continue
+	    fi
+	    runc $(dnet_container_name 1 $dnet_suffix) $(get_sbox_id 1 container_${i}) \
+		 "ping -c 1 container_$j"
+	done
+    done
+
+    # Teardown the container connections and the network
+    for i in `seq ${start} ${end}`;
+    do
+	net_disconnect 1 container_${i} multihost
+	dnet_cmd $(inst_id2port 1) container rm container_${i}
+    done
+
+    dnet_cmd $(inst_id2port 1) network rm multihost
+}

--- a/test/integration/dnet/overlay-consul.bats
+++ b/test/integration/dnet/overlay-consul.bats
@@ -7,3 +7,8 @@ load helpers
     skip_for_circleci
     test_overlay consul
 }
+
+@test "Test overlay network singlehost with consul" {
+    skip_for_circleci
+    test_overlay_singlehost consul
+}


### PR DESCRIPTION
A local endpoint is known to the watch database only
during Join. But the same endpoint can be known to the
watch database as remote endpoint well before the Join
because a CreateEndpoint updates the endpoint to the store.
So on Join when you come to know that this is indeed a
local endpoint remove it from remote endpoint list and add it
to local endpoint list.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>