### PR TITLE
Do not manipulate bitseq length to reserve broadcast address

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -250,11 +250,6 @@ func (a *Allocator) insertBitMask(key SubnetKey, pool *net.IPNet) error {
 	ones, bits := pool.Mask.Size()
 	numAddresses := uint64(1 << uint(bits-ones))
 
-	if ipVer == v4 {
-		// Do not let broadcast address be reserved
-		numAddresses--
-	}
-
 	// Allow /64 subnet
 	if ipVer == v6 && numAddresses == 0 {
 		numAddresses--
@@ -269,6 +264,11 @@ func (a *Allocator) insertBitMask(key SubnetKey, pool *net.IPNet) error {
 	// Do not let network identifier address be reserved
 	// Do the same for IPv6 so that bridge ip starts with XXXX...::1
 	h.Set(0)
+
+	// Do not let broadcast address be reserved
+	if ipVer == v4 {
+		h.Set(numAddresses - 1)
+	}
 
 	a.Lock()
 	a.addresses[key] = h

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -575,6 +575,23 @@ func TestGetSameAddress(t *testing.T) {
 	}
 }
 
+func TestGetAddressSubPoolEqualPool(t *testing.T) {
+	a, err := getAllocator()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Requesting a subpool of same size of the master pool should not cause any problem on ip allocation
+	pid, _, _, err := a.RequestPool(localAddressSpace, "172.18.0.0/16", "172.18.0.0/16", nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = a.RequestAddress(pid, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRequestReleaseAddressFromSubPool(t *testing.T) {
 	a, err := getAllocator()
 	if err != nil {


### PR DESCRIPTION
- Currently ipam allocator implicitly reserves the broadcast address for the ipv4 subnet reducing the length of the respective bitsequence of one during its creation.
This causes issue when somebody request a sub pool of the same size of the master pool: subsequent address requests will fail in bitsequence because range upper limit is greater than bitsequence upper limit.
- Fix: Create the bitsequence with the right size and explicitly reserve the last bit

Closes #698 

Signed-off-by: Alessandro Boch <aboch@docker.com>