### PR TITLE
Fix the issue for the --cluster-store URL with path

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -133,7 +133,7 @@ func makeDefaultScopes() map[string]*ScopeCfg {
 	def := make(map[string]*ScopeCfg)
 	def[LocalScope] = &ScopeCfg{
 		Client: ScopeClientCfg{
-			Provider: "boltdb",
+			Provider: string(store.BOLTDB),
 			Address:  defaultPrefix + "/local-kv.db",
 			Config: &store.Config{
 				Bucket: "libnetwork",
@@ -196,10 +196,6 @@ func ParseKey(key string) ([]string, error) {
 
 // newClient used to connect to KV Store
 func newClient(scope string, kv string, addr string, config *store.Config, cached bool) (DataStore, error) {
-	var (
-		parts = strings.SplitN(addr, "/", 2)
-		addrs = strings.Split(parts[0], ",")
-	)
 
 	if cached && scope != LocalScope {
 		return nil, fmt.Errorf("caching supported only for scope %s", LocalScope)
@@ -209,16 +205,26 @@ func newClient(scope string, kv string, addr string, config *store.Config, cache
 		config = &store.Config{}
 	}
 
-	// Add the custom prefix to the root chain
-	if len(parts) == 2 {
-		rootChain = append([]string{parts[1]}, defaultRootChain...)
+	var addrs []string
+
+	if kv == string(store.BOLTDB) {
+		// Parse file path
+		addrs = strings.Split(addr, ",")
+	} else {
+		// Parse URI
+		parts := strings.SplitN(addr, "/", 2)
+		addrs = strings.Split(parts[0], ",")
+
+		// Add the custom prefix to the root chain
+		if len(parts) == 2 {
+			rootChain = append([]string{parts[1]}, defaultRootChain...)
+		}
 	}
 
 	store, err := libkv.NewStore(store.Backend(kv), addrs, config)
 	if err != nil {
 		return nil, err
 	}
-
 	ds := &datastore{scope: scope, store: store, active: true, watchCh: make(chan struct{})}
 	if cached {
 		ds.cache = newCache(ds)

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -225,6 +225,7 @@ func newClient(scope string, kv string, addr string, config *store.Config, cache
 	if err != nil {
 		return nil, err
 	}
+
 	ds := &datastore{scope: scope, store: store, active: true, watchCh: make(chan struct{})}
 	if cached {
 		ds.cache = newCache(ds)

--- a/store_test.go
+++ b/store_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestZooKeeperBackend(t *testing.T) {
-	c, err := testNewController(t, "zk", "127.0.0.1:2181")
+	c, err := testNewController(t, "zk", "127.0.0.1:2181/custom_prefix")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/dnet/helpers.bash
+++ b/test/integration/dnet/helpers.bash
@@ -134,12 +134,13 @@ function start_dnet() {
     mkdir -p /tmp/dnet/${name}
     tomlfile="/tmp/dnet/${name}/libnetwork.toml"
 
+    # Try discovery URLs with or without path
     if [ "$store" = "zookeeper" ]; then
 	read discovery provider address < <(parse_discovery_str zk://${bridge_ip}:2182)
     elif [ "$store" = "etcd" ]; then
-	read discovery provider address < <(parse_discovery_str etcd://${bridge_ip}:42000)
+	read discovery provider address < <(parse_discovery_str etcd://${bridge_ip}:42000/custom_prefix)
     else
-	read discovery provider address < <(parse_discovery_str consul://${bridge_ip}:8500)
+	read discovery provider address < <(parse_discovery_str consul://${bridge_ip}:8500/custom_prefix)
     fi
 
     cat > ${tomlfile} <<EOF


### PR DESCRIPTION
In the [Dicovery/README.md](https://github.com/docker/docker/blob/3a24eb2de468c34195dc9fc6b036492a0095bbf1/pkg/discovery/README.md), Docker support the etcd based backend with following format 
```
$ docker daemon -H=<node_ip:2376> --cluster-advertise=<node_ip:2376> --cluster-store etcd://<etcd_ip1>,<etcd_ip2>/<path>
``` 

But I found there will be issue with Docker 1.9 RC1. More details in docker/docker#17298

In the datastore.go, it has the different logic to create Libkv store than docker discovery. 

Signed-off-by: Li Yi <denverdino@gmail.com>

