### PR TITLE
Dont notify the leave if the serf is not inited

### DIFF
--- a/drivers/overlay/joinleave.go
+++ b/drivers/overlay/joinleave.go
@@ -118,10 +118,12 @@ func (d *driver) Leave(nid, eid string) error {
 		return fmt.Errorf("could not find network with id %s", nid)
 	}
 
-	d.notifyCh <- ovNotify{
-		action: "leave",
-		nid:    nid,
-		eid:    eid,
+	if d.notifyCh != nil {
+		d.notifyCh <- ovNotify{
+			action: "leave",
+			nid:    nid,
+			eid:    eid,
+		}
 	}
 
 	n.leaveSandbox()


### PR DESCRIPTION
Overlay driver allows local containers to communicate in overly network
even when the serf is not fully inited. But when the container leaves an
overlay network, it gets stuck waiting on a nil notifyCh, when the serf
is not fully initialized.

Signed-off-by: Madhu Venugopal <madhu@docker.com>