### PR TITLE
Assigning Address driver options

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -60,6 +60,8 @@ type endpoint struct {
 	anonymous     bool
 	generic       map[string]interface{}
 	joinLeaveDone chan struct{}
+	prefAddress   net.IP
+	ipamOptions   map[string]string
 	dbIndex       uint64
 	dbExists      bool
 	sync.Mutex
@@ -685,6 +687,14 @@ func EndpointOptionGeneric(generic map[string]interface{}) EndpointOption {
 	}
 }
 
+// CreateOptionIpam function returns an option setter for the ipam configuration for this endpoint
+func CreateOptionIpam(prefAddress net.IP, ipamOptions map[string]string) EndpointOption {
+	return func(ep *endpoint) {
+		ep.prefAddress = prefAddress
+		ep.ipamOptions = ipamOptions
+	}
+}
+
 // CreateOptionExposedPorts function returns an option setter for the container exposed
 // ports option to be passed to network.CreateEndpoint() method.
 func CreateOptionExposedPorts(exposedPorts []types.TransportPort) EndpointOption {
@@ -799,7 +809,7 @@ func (ep *endpoint) assignAddressVersion(ipVer int, ipam ipamapi.Ipam) error {
 		if *address != nil {
 			prefIP = (*address).IP
 		}
-		addr, _, err := ipam.RequestAddress(d.PoolID, prefIP, nil)
+		addr, _, err := ipam.RequestAddress(d.PoolID, prefIP, ep.ipamOptions)
 		if err == nil {
 			ep.Lock()
 			*address = addr

--- a/ipamapi/contract.go
+++ b/ipamapi/contract.go
@@ -16,6 +16,8 @@ const (
 	DefaultIPAM = "default"
 	// PluginEndpointType represents the Endpoint Type used by Plugin system
 	PluginEndpointType = "IpamDriver"
+	// RequestAddressType represents the Address Type used when requesting an address
+	RequestAddressType = "RequestAddressType"
 )
 
 // Callback provides a Callback interface for registering an IPAM instance into LibNetwork

--- a/network.go
+++ b/network.go
@@ -971,7 +971,10 @@ func (n *network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {
 		// irrespective of whether ipam driver returned a gateway already.
 		// If none of the above is true, libnetwork will allocate one.
 		if cfg.Gateway != "" || d.Gateway == nil {
-			if d.Gateway, _, err = ipam.RequestAddress(d.PoolID, net.ParseIP(cfg.Gateway), nil); err != nil {
+			var gatewayOpts = map[string]string{
+				ipamapi.RequestAddressType: netlabel.Gateway,
+			}
+			if d.Gateway, _, err = ipam.RequestAddress(d.PoolID, net.ParseIP(cfg.Gateway), gatewayOpts); err != nil {
 				return types.InternalErrorf("failed to allocate gateway (%v): %v", cfg.Gateway, err)
 			}
 		}


### PR DESCRIPTION
Adds the ability to give driver options when assigning an address.

Also when assigning the ipam gateway address pass the options bellow
```
{
  "gateway": "true"
}
```
This will allow ipam drivers to detect whether an address belongs to a gateway or not. 

Currently under CreateEndpoint options are set to nil. This should be changed once EndpointOptions contains driver options for the endpoint it self and driver options for its address.
 
Signed-off-by: Ryan Belgrave <rmb1993@gmail.com>