### PR TITLE
Clean hosts entries on endpoint leave

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -512,6 +512,8 @@ func (ep *endpoint) sbLeave(sbox Sandbox, options ...EndpointOption) error {
 		return err
 	}
 
+	sb.deleteHostsEntries(n.getSvcRecords(ep))
+
 	if sb.needDefaultGW() {
 		ep := sb.getEPwithoutGateway()
 		if ep == nil {


### PR DESCRIPTION
- Currently when a sandbox disconnect from a network
  the network's services are not removed from the
  sandbox's /etc/hosts file

Signed-off-by: Alessandro Boch <aboch@docker.com>