### PR TITLE
Clean unused variables

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -128,14 +128,11 @@ type ipamData struct {
 
 type driverTable map[string]*driverData
 
-//type networkTable map[string]*network
-//type endpointTable map[string]*endpoint
 type ipamTable map[string]*ipamData
 type sandboxTable map[string]*sandbox
 
 type controller struct {
-	id string
-	//networks       networkTable
+	id             string
 	drivers        driverTable
 	ipamDrivers    ipamTable
 	sandboxes      sandboxTable


### PR DESCRIPTION
Clean some unused variables and format code.

also fix typo: change `RegisterOpamDriver()` into `RegisterIpamDriver()`

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>