### PR TITLE
Handling container rename in libnetwork

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -143,6 +143,7 @@ type controller struct {
 	watchCh        chan *endpoint
 	unWatchCh      chan *endpoint
 	svcDb          map[string]svcMap
+	nmap           map[string]*netWatch
 	sync.Mutex
 }
 

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -1134,6 +1134,10 @@ func (f *fakeSandbox) Delete() error {
 	return nil
 }
 
+func (f *fakeSandbox) Rename(name string) error {
+	return nil
+}
+
 func (f *fakeSandbox) SetKey(key string) error {
 	return nil
 }

--- a/sandbox.go
+++ b/sandbox.go
@@ -34,6 +34,8 @@ type Sandbox interface {
 	Refresh(options ...SandboxOption) error
 	// SetKey updates the Sandbox Key
 	SetKey(key string) error
+	// Rename changes the name of all attached Endpoints
+	Rename(name string) error
 	// Delete destroys this container after detaching it from all connected endpoints.
 	Delete() error
 }
@@ -199,6 +201,35 @@ func (sb *sandbox) Delete() error {
 	c.Unlock()
 
 	return nil
+}
+
+func (sb *sandbox) Rename(name string) error {
+	var err error
+	undo := []func(){}
+
+	for _, ep := range sb.getConnectedEndpoints() {
+		if ep.endpointInGWNetwork() {
+			continue
+		}
+
+		oldName := ep.Name()
+		lEp := ep
+		if err = ep.rename(name); err != nil {
+			break
+		}
+		undo = append(undo,
+			func() {
+				// Ignore the error while undoing
+				_ = lEp.rename(oldName)
+			})
+	}
+
+	if err != nil {
+		for _, f := range undo {
+			f()
+		}
+	}
+	return err
 }
 
 func (sb *sandbox) Refresh(options ...SandboxOption) error {


### PR DESCRIPTION
Added a handler in libnetwork for container rename. Loops through all the end-points, changes the name and updates the service records. For global scope networks the KV store will get updated as well to fix the service record in the peers.

Fixes 
https://github.com/docker/docker/issues/15727
https://github.com/docker/docker/issues/16485

Signed-off-by: Santhosh Manohar <santhosh@docker.com>