### PR TITLE
Allow toggling service registration on a network

### DIFF
--- a/netlabel/labels.go
+++ b/netlabel/labels.go
@@ -27,8 +27,11 @@ const (
 	// ExposedPorts constant represents the container's Exposed Ports
 	ExposedPorts = Prefix + ".endpoint.exposedports"
 
-	//EnableIPv6 constant represents enabling IPV6 at network level
+	// EnableIPv6 constant represents enabling IPV6 at network level
 	EnableIPv6 = Prefix + ".enable_ipv6"
+
+	// IgnoreSvcs represents ignoring service registration at network level
+	IgnoreSvcs = Prefix + ".ignore_svcs"
 
 	// DriverMTU constant represents the MTU size for the network driver
 	DriverMTU = DriverPrefix + ".mtu"


### PR DESCRIPTION
The end goal is to allow you to run:
```
$ docker network modify newbridge com.docker.network.ignore_svcs=true
$ docker network modify newbridge com.docker.network.ignore_svcs=false
```
to permit toggling of services on a network (you can try it out be cloning and building https://github.com/aidanhs/docker/tree/aphs-service-discovery-toggle, which has the libnetwork changes as well as Docker changes on the branch).

I want to focus on the libnetwork stuff before opening PRs on Docker.

The first commit is useful in itself, allowing you you create networks without service registration enabled. The second commit is the interesting one for me, allowing toggling.

One question: when 'disabling services', would you expect it to 1) disable all services on the network immediately or 2) just not register any new services started after that point? Currently this PR works based on 2. If it should be changed to 1, I'll probably change `ignore_svcs` to `disable_svcs`.