### PR TITLE
Fix race in host sandbox creation

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -507,13 +507,14 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 		return nil, err
 	}
 
+	c.Lock()
 	if sb.osSbox == nil && !sb.config.useExternalKey {
 		if sb.osSbox, err = osl.NewSandbox(sb.Key(), !sb.config.useDefaultSandBox); err != nil {
+			c.Unlock()
 			return nil, fmt.Errorf("failed to create new osl sandbox: %v", err)
 		}
 	}
 
-	c.Lock()
 	c.sandboxes[sb.id] = sb
 	c.Unlock()
 	defer func() {


### PR DESCRIPTION
Since we share the host sandbox with many containers we
need to serialize creation of the sandbox. Otherwise
container starts may see the namespace path in inconsistent
state.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>