### PR TITLE
Skip non-persistent endpoints in sandbox store

### DIFF
--- a/sandbox_store.go
+++ b/sandbox_store.go
@@ -128,6 +128,12 @@ func (sb *sandbox) storeUpdate() error {
 retry:
 	sbs.Eps = nil
 	for _, ep := range sb.getConnectedEndpoints() {
+		// If the endpoint is not persisted then do not add it to
+		// the sandbox checkpoint
+		if ep.Skip() {
+			continue
+		}
+
 		eps := epState{
 			Nid: ep.getNetwork().ID(),
 			Eid: ep.ID(),


### PR DESCRIPTION
If the endpoint and the corresponding network is
not persistent then skip adding it into sandbox
store.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>