### PR TITLE
Fix race in getEndpointsFromStore

### DIFF
--- a/store.go
+++ b/store.go
@@ -176,7 +176,6 @@ func (n *network) getEndpointsFromStore() ([]*endpoint, error) {
 
 		for _, kvo := range kvol {
 			ep := kvo.(*endpoint)
-			ep.network = n
 			epl = append(epl, ep)
 		}
 	}


### PR DESCRIPTION
Race can occur between two getEndpointsFromStore or between it and
getNetwork.