### PR TITLE
Don't filter out localhost entries in resolv.conf in default sandbox

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -747,8 +747,8 @@ func (sb *sandbox) updateDNS(ipv6Enabled bool) error {
 	var (
 		currHash string
 		hashFile = sb.config.resolvConfHashFile
+		newRC    *resolvconf.File
 	)
-	var newRC *resolvconf.File
 
 	if len(sb.config.dnsList) > 0 || len(sb.config.dnsSearchList) > 0 || len(sb.config.dnsOptionsList) > 0 {
 		return nil

--- a/sandbox_test.go
+++ b/sandbox_test.go
@@ -211,3 +211,25 @@ func TestSandboxAddSamePrio(t *testing.T) {
 
 	osl.GC()
 }
+
+func TestDefaultSandboxAddEmpty(t *testing.T) {
+	ctrlr := createEmptyCtrlr()
+
+	var sboxOptions []SandboxOption
+	sboxOptions = append(sboxOptions, OptionUseDefaultSandbox())
+
+	sbx, err := ctrlr.NewSandbox("sandbox0", sboxOptions...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sbx.Delete(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ctrlr.sandboxes) != 0 {
+		t.Fatalf("controller sandboxes is not empty. len = %d", len(ctrlr.sandboxes))
+	}
+
+	osl.GC()
+}


### PR DESCRIPTION
(i.e. when host networking is used in the sandbox, --net=host).

In docker 1.9.0, a localhost DNS address is removed from resolv.conf when using --net=host.  This worked fine in 1.8.2, and this patch restores that behaviour.  Fixes docker/docker#15819.
