### PR TITLE
libnetwork to honor explicit mac-address for all drivers

### DIFF
--- a/network.go
+++ b/network.go
@@ -671,6 +671,12 @@ func (n *network) CreateEndpoint(name string, options ...EndpointOption) (Endpoi
 
 	ep.processOptions(options...)
 
+	if opt, ok := ep.generic[netlabel.MacAddress]; ok {
+		if mac, ok := opt.(net.HardwareAddr); ok {
+			ep.iface.mac = mac
+		}
+	}
+
 	if err = ep.assignAddress(true, !n.postIPv6); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Currently endpoint interface mac address is
  not being set in network.go when user specified
  the mac address for the container.
 Similarly to IP address, MAC address is no longer
 a driver specific option only. So libnetwork to parse it and set it into endpoint interface mac.
- Overlay driver expects to get the user defined mac-address
  from InterfaceInfo.

Fixes #753 

Signed-off-by: Alessandro Boch <aboch@docker.com>