### PR TITLE
Use documentation IPv6 addresses (RFC 3849) in tests

### DIFF
--- a/driverapi/driverapi_test.go
+++ b/driverapi/driverapi_test.go
@@ -69,7 +69,7 @@ func TestValidateAndIsV6(t *testing.T) {
 		t.Fatalf("incorrect ip version returned")
 	}
 	orig := i.Pool
-	if i.Pool, err = types.ParseCIDR("2003::33/64"); err != nil {
+	if i.Pool, err = types.ParseCIDR("2001:db8::33/64"); err != nil {
 		t.Fatal(err)
 	}
 	if !i.IsV6() {
@@ -83,7 +83,7 @@ func TestValidateAndIsV6(t *testing.T) {
 	}
 
 	// incongruent gw ver
-	if i.Gateway, err = types.ParseCIDR("2001::45/65"); err != nil {
+	if i.Gateway, err = types.ParseCIDR("2001:db8::45/65"); err != nil {
 		t.Fatal(err)
 	}
 	if err = i.Validate(); err == nil {
@@ -92,7 +92,7 @@ func TestValidateAndIsV6(t *testing.T) {
 	i.Gateway = nil
 
 	// incongruent secondary ip ver
-	if i.AuxAddresses["ip2"], err = types.ParseCIDR("2002::44/80"); err != nil {
+	if i.AuxAddresses["ip2"], err = types.ParseCIDR("2001:db8::44/80"); err != nil {
 		t.Fatal(err)
 	}
 	if err = i.Validate(); err == nil {

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -112,8 +112,8 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 	}
 
 	bndIPs := "127.0.0.1"
-	nwV6s := "2100:2400:2600:2700:2800::/80"
-	gwV6s := "2100:2400:2600:2700:2800::25/80"
+	nwV6s := "2001:db8:2600:2700:2800::/80"
+	gwV6s := "2001:db8:2600:2700:2800::25/80"
 	nwV6, _ := types.ParseCIDR(nwV6s)
 	gwV6, _ := types.ParseCIDR(gwV6s)
 
@@ -191,7 +191,7 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 	if !nwV6.Contains(te.Interface().AddressIPv6().IP) {
 		t.Fatalf("endpoint got assigned address outside of container network(%s): %s", nwV6.String(), te.Interface().AddressIPv6())
 	}
-	if te.Interface().AddressIPv6().IP.String() != "2100:2400:2600:2700:2800:aabb:ccdd:eeff" {
+	if te.Interface().AddressIPv6().IP.String() != "2001:db8:2600:2700:2800:aabb:ccdd:eeff" {
 		t.Fatalf("Unexpected endpoint IPv6 address: %v", te.Interface().AddressIPv6().IP)
 	}
 }
@@ -724,18 +724,18 @@ func TestValidateConfig(t *testing.T) {
 	}
 
 	// Test v6 gw
-	_, v6nw, _ := net.ParseCIDR("2001:1234:ae:b004::/64")
+	_, v6nw, _ := net.ParseCIDR("2001:db8:ae:b004::/64")
 	c = networkConfiguration{
 		EnableIPv6:         true,
 		AddressIPv6:        v6nw,
-		DefaultGatewayIPv6: net.ParseIP("2001:1234:ac:b004::bad:a55"),
+		DefaultGatewayIPv6: net.ParseIP("2001:db8:ac:b004::bad:a55"),
 	}
 	err = c.Validate()
 	if err == nil {
 		t.Fatalf("Failed to detect invalid v6 default gateway")
 	}
 
-	c.DefaultGatewayIPv6 = net.ParseIP("2001:1234:ae:b004::bad:a55")
+	c.DefaultGatewayIPv6 = net.ParseIP("2001:db8:ae:b004::bad:a55")
 	err = c.Validate()
 	if err != nil {
 		t.Fatalf("Unexpected validation error on v6 default gateway")

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -86,7 +86,7 @@ func TestGetAddressVersion(t *testing.T) {
 	if v6 != getAddressVersion(net.ParseIP("ff01::1")) {
 		t.Fatalf("Failed to detect IPv6 version")
 	}
-	if v6 != getAddressVersion(net.ParseIP("2001:56::76:51")) {
+	if v6 != getAddressVersion(net.ParseIP("2001:db8::76:51")) {
 		t.Fatalf("Failed to detect IPv6 version")
 	}
 }
@@ -523,11 +523,11 @@ func TestRemoveSubnet(t *testing.T) {
 		{localAddressSpace, "192.168.0.0/16", false},
 		{localAddressSpace, "172.17.0.0/16", false},
 		{localAddressSpace, "10.0.0.0/8", false},
-		{localAddressSpace, "2002:1:2:3:4:5:ffff::/112", false},
+		{localAddressSpace, "2001:db8:1:2:3:4:ffff::/112", false},
 		{"splane", "172.17.0.0/16", false},
 		{"splane", "10.0.0.0/8", false},
-		{"splane", "2002:1:2:3:4:5:6::/112", true},
-		{"splane", "2002:1:2:3:4:5:ffff::/112", true},
+		{"splane", "2001:db8:1:2:3:4:5::/112", true},
+		{"splane", "2001:db8:1:2:3:4:ffff::/112", true},
 	}
 
 	poolIDs := make([]string, len(input))

--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -179,7 +179,7 @@ func printIpamInfo(list []*IpamInfo) string {
 }
 
 func TestEndpointMarshalling(t *testing.T) {
-	ip, nw6, err := net.ParseCIDR("2001:3002:4003::122/64")
+	ip, nw6, err := net.ParseCIDR("2001:db8:4003::122/64")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -180,13 +180,13 @@ func TestCompareIPMask(t *testing.T) {
 			ms:   0,
 		},
 		{ // ip and mask as v6
-			ip:   net.ParseIP("2005:2004:2002:2001:FFFF:ABCD:EEAB:00CD"),
+			ip:   net.ParseIP("2001:DB8:2002:2001:FFFF:ABCD:EEAB:00CD"),
 			mask: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0},
 			is:   0,
 			ms:   0,
 		},
 		{
-			ip:    net.ParseIP("2005:2004:2002:2001:FFFF:ABCD:EEAB:00CD"),
+			ip:    net.ParseIP("2001:DB8:2002:2001:FFFF:ABCD:EEAB:00CD"),
 			mask:  []byte{0xff, 0xff, 0xff, 0},
 			isErr: true,
 		},
@@ -244,7 +244,7 @@ func TestUtilGetHostPortionIP(t *testing.T) {
 			host: net.IPv4(0, 0, 0, 4)[12:],
 		},
 		{ // ip and mask as v6
-			ip:   net.ParseIP("2005:2004:2002:2001:FFFF:ABCD:EEAB:00CD"),
+			ip:   net.ParseIP("2001:DB8:2002:2001:FFFF:ABCD:EEAB:00CD"),
 			mask: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0},
 			host: net.ParseIP("0::AB:00CD"),
 		},
@@ -261,7 +261,7 @@ func TestUtilGetHostPortionIP(t *testing.T) {
 	}
 
 	// ip as v6 and mask as v4 are not compatible
-	if _, err := GetHostPartIP(net.ParseIP("2005:2004:2002:2001:FFFF:ABCD:EEAB:00CD"), []byte{0xff, 0xff, 0xff, 0}); err == nil {
+	if _, err := GetHostPartIP(net.ParseIP("2001:DB8:2002:2001:FFFF:ABCD:EEAB:00CD"), []byte{0xff, 0xff, 0xff, 0}); err == nil {
 		t.Fatalf("Unexpected success")
 	}
 	// ip as v4 and non conventional mask
@@ -326,9 +326,9 @@ func TestUtilGetBroadcastIP(t *testing.T) {
 			bcast: net.IPv4(172, 28, 255, 255)[12:],
 		},
 		{ // ip and mask as v6
-			ip:    net.ParseIP("2005:2004:2002:2001:FFFF:ABCD:EEAB:00CD"),
+			ip:    net.ParseIP("2001:DB8:2002:2001:FFFF:ABCD:EEAB:00CD"),
 			mask:  []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0},
-			bcast: net.ParseIP("2005:2004:2002:2001:FFFF:ABCD:EEFF:FFFF"),
+			bcast: net.ParseIP("2001:DB8:2002:2001:FFFF:ABCD:EEFF:FFFF"),
 		},
 	}
 
@@ -343,7 +343,7 @@ func TestUtilGetBroadcastIP(t *testing.T) {
 	}
 
 	// ip as v6 and mask as v4 are not compatible
-	if _, err := GetBroadcastIP(net.ParseIP("2005:2004:2002:2001:FFFF:ABCD:EEAB:00CD"), []byte{0xff, 0xff, 0xff, 0}); err == nil {
+	if _, err := GetBroadcastIP(net.ParseIP("2001:DB8:2002:2001:FFFF:ABCD:EEAB:00CD"), []byte{0xff, 0xff, 0xff, 0}); err == nil {
 		t.Fatalf("Unexpected success")
 	}
 	// ip as v4 and non conventional mask


### PR DESCRIPTION
As discussed here: https://github.com/docker/libnetwork/pull/741/files#r44872866

I searched for potentially affected files with: `grep  -ER '200.:' . |grep -iv '2001:db8'`, so maybe some places slipped through.

Tests still seem to pass, but I am not entirely sure whether I ran them correctly on my local box.

You also might want to take a look at these lines: https://github.com/docker/libnetwork/blob/e8ebc0bf6510343c88d162db08b3d855cbbe75b9/libnetwork_test.go#L1839-L1843
The IPv6 is Google Public DNS, so this might be correct. The IPv4 addresses belong to some Chinese Company and the domain is currently unassigned. You might want to replace the domain by `example.com` and the IPv4 addresses by addresses in some private network.

/cc @aboch 