### PR TITLE
Allow endpoint delete if sandbox identifier is stale

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -584,7 +584,8 @@ func (ep *endpoint) Delete() error {
 	ep.Lock()
 	epid := ep.id
 	name := ep.name
-	if ep.sandboxID != "" {
+	sb, _ := n.getController().SandboxByID(ep.sandboxID)
+	if sb != nil {
 		ep.Unlock()
 		return &ActiveContainerError{name: name, id: epid}
 	}

--- a/test/integration/dnet/multi.bats
+++ b/test/integration/dnet/multi.bats
@@ -112,7 +112,7 @@ function is_network_exist() {
 
 	for j in `seq 1 3`;
 	do
-	    run dnet_cmd $(inst_id2port 2) service unpublish ${osvc}.${oname}
+	    run dnet_cmd $(inst_id2port $i) service unpublish ${osvc}.${oname}
 	    echo ${output}
 	    [ "$status" -ne 0 ]
 	    run dnet_cmd $(inst_id2port $j) network rm ${oname}


### PR DESCRIPTION
There are cases as seen in https://github.com/docker/docker/issues/17984
the sandbox could be stale in endpoint structure, when the actual
sandbox is removed during the cleanup phase. Hence instead of just
validating for sandboxID, make sure if it is actually present in the
sandboxes DB managed by the controller.

Signed-off-by: Madhu Venugopal <madhu@docker.com>