### PR TITLE
Fix in endpoint Info() method

### DIFF
--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -159,7 +159,11 @@ func (ep *endpoint) Info() EndpointInfo {
 		return ep
 	}
 
-	return sb.getEndpoint(ep.ID())
+	if epi := sb.getEndpoint(ep.ID()); epi != nil {
+		return epi
+	}
+
+	return nil
 }
 
 func (ep *endpoint) DriverInfo() (map[string]interface{}, error) {


### PR DESCRIPTION
- Make sure to return the proper value for the
  EndpointInfo interface in case of nil implementer

Related to https://github.com/docker/docker/issues/18009

Signed-off-by: Alessandro Boch <aboch@docker.com>