### PR TITLE
Allow libnetwork to compile on freebsd

### DIFF
--- a/ipamutils/utils_freebsd.go
+++ b/ipamutils/utils_freebsd.go
@@ -1,0 +1,22 @@
+// Package ipamutils provides utililty functions for ipam management
+package ipamutils
+
+import (
+	"net"
+
+	"github.com/docker/libnetwork/types"
+)
+
+// ElectInterfaceAddresses looks for an interface on the OS with the specified name
+// and returns its IPv4 and IPv6 addresses in CIDR form. If the interface does not exist,
+// it chooses from a predifined list the first IPv4 address which does not conflict
+// with other interfaces on the system.
+func ElectInterfaceAddresses(name string) (*net.IPNet, []*net.IPNet, error) {
+	return nil, nil, types.NotImplementedErrorf("not supported on freebsd")
+}
+
+// FindAvailableNetwork returns a network from the passed list which does not
+// overlap with existing interfaces in the system
+func FindAvailableNetwork(list []*net.IPNet) (*net.IPNet, error) {
+	return nil, types.NotImplementedErrorf("not supported on freebsd")
+}

--- a/osl/sandbox_freebsd.go
+++ b/osl/sandbox_freebsd.go
@@ -19,6 +19,11 @@ func NewSandbox(key string, osCreate bool) (Sandbox, error) {
 	return nil, nil
 }
 
+// GetSandboxForExternalKey returns sandbox object for the supplied path
+func GetSandboxForExternalKey(path string, key string) (Sandbox, error) {
+	return nil, nil
+}
+
 // GC triggers garbage collection of namespace path right away
 // and waits for it.
 func GC() {


### PR DESCRIPTION
libnetwork should be able to compile on freebsd after #186 is merged with this changes.