### PR TITLE
Fix a couple of edge cases in service discovery

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -386,6 +386,9 @@ func (ep *endpoint) sbJoin(sbox Sandbox, options ...EndpointOption) error {
 		}
 	}()
 
+	// Watch for service records
+	network.getController().watchSvcRecord(ep)
+
 	address := ""
 	if ip := ep.getFirstInterfaceAddress(); ip != nil {
 		address = ip.String()
@@ -393,9 +396,6 @@ func (ep *endpoint) sbJoin(sbox Sandbox, options ...EndpointOption) error {
 	if err = sb.updateHostsFile(address, network.getSvcRecords(ep)); err != nil {
 		return err
 	}
-
-	// Watch for service records
-	network.getController().watchSvcRecord(ep)
 
 	if err = sb.updateDNS(network.enableIPv6); err != nil {
 		return err


### PR DESCRIPTION
The first issue is an ordering problem where sandbox
attached version of endpoint object should be pushed
to the watch database first so that any other create endpoint
which is in progress can make use of it immediately to update
the container hosts file. And only after that the current
container should try to retrieve the service records from the
service data base and upate it's hosts file. With the previous
order there is a small time window, when another endpoint create
will find this endpoint but it doesn't have the sandbox context
while the svc record population from svc db has already happened
so that container will totally miss to populate the service record
of the newly created endpoint.

The second issue is trying to rebuild the /etc/hosts file from scratch
during endpoint join and this may sometimes happen after the service
record add for another endpoint  has happened on the container
file. Obviously this rebuilding will wipe out that service record which
was just added. Removed the rebuilding of /etc/hosts file during
endpoint join. The initial population of /etc/hosts file should only
happen during sandbox creation time. In the endpoint join just added
the backward-compatible self ip -> hostname entry as just another
record.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>