### PR TITLE
bitseq: fix race between CopyTo and set

### DIFF
--- a/bitseq/sequence.go
+++ b/bitseq/sequence.go
@@ -250,8 +250,12 @@ func (h *Handle) set(ordinal, start, end uint64, any bool, release bool) (uint64
 	)
 
 	for {
-		if h.store != nil {
-			if err := h.store.GetObject(datastore.Key(h.Key()...), h); err != nil && err != datastore.ErrKeyNotFound {
+		var store datastore.DataStore
+		h.Lock()
+		store = h.store
+		h.Unlock()
+		if store != nil {
+			if err := store.GetObject(datastore.Key(h.Key()...), h); err != nil && err != datastore.ErrKeyNotFound {
 				return ret, err
 			}
 		}


### PR DESCRIPTION
Race detector message:
```
WARNING: DATA RACE
Write by goroutine 269:
  github.com/docker/libnetwork/bitseq.(*Handle).CopyTo()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/bitseq/store.go:85 +0x2f6
  github.com/docker/libnetwork/datastore.(*cache).get()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/datastore/cache.go:135 +0x307
  github.com/docker/libnetwork/datastore.(*datastore).GetObject()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/datastore/datastore.go:438 +0x121
  github.com/docker/libnetwork/bitseq.(*Handle).set()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/bitseq/sequence.go:254 +0x1a5
  github.com/docker/libnetwork/bitseq.(*Handle).Unset()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/bitseq/sequence.go:227 +0xb0
  github.com/docker/libnetwork/ipam.(*Allocator).ReleaseAddress()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/ipam/allocator.go:446 +0x10bc
  github.com/docker/libnetwork.(*endpoint).releaseAddress()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/endpoint.go:830 +0x731
  github.com/docker/libnetwork.(*endpoint).Delete()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/endpoint.go:624 +0x8d8
  github.com/docker/libnetwork.(*sandbox).Delete()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/sandbox.go:191 +0x1047
  github.com/docker/docker/daemon.(*Daemon).releaseNetwork()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/container_unix.go:1180 +0x676
  github.com/docker/docker/daemon.(*Daemon).Cleanup()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/start.go:157 +0x5d
  github.com/docker/docker/daemon.(*containerMonitor).Close()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/monitor.go:111 +0xa4
  github.com/docker/docker/daemon.(*containerMonitor).Start.func1()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/monitor.go:142 +0x14b
  github.com/docker/docker/daemon.(*containerMonitor).Start()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/monitor.go:223 +0x1159
  github.com/docker/docker/daemon.(*containerMonitor).Start-fm()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/start.go:147 +0x3b
  github.com/docker/docker/pkg/promise.Go.func1()
      /home/moroz/project/workspace/src/github.com/docker/docker/pkg/promise/promise.go:8 +0x2a

Previous read by goroutine 340:
  github.com/docker/libnetwork/bitseq.(*Handle).set()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/bitseq/sequence.go:254 +0x133
  github.com/docker/libnetwork/bitseq.(*Handle).Unset()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/bitseq/sequence.go:227 +0xb0
  github.com/docker/libnetwork/ipam.(*Allocator).ReleaseAddress()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/ipam/allocator.go:446 +0x10bc
  github.com/docker/libnetwork.(*endpoint).releaseAddress()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/endpoint.go:830 +0x731
  github.com/docker/libnetwork.(*endpoint).Delete()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/endpoint.go:624 +0x8d8
  github.com/docker/libnetwork.(*sandbox).Delete()
      /home/moroz/project/workspace/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/sandbox.go:191 +0x1047
  github.com/docker/docker/daemon.(*Daemon).releaseNetwork()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/container_unix.go:1180 +0x676
  github.com/docker/docker/daemon.(*Daemon).Cleanup()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/start.go:157 +0x5d
  github.com/docker/docker/daemon.(*containerMonitor).Close()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/monitor.go:111 +0xa4
  github.com/docker/docker/daemon.(*containerMonitor).Start.func1()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/monitor.go:142 +0x14b
  github.com/docker/docker/daemon.(*containerMonitor).Start()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/monitor.go:223 +0x1159
  github.com/docker/docker/daemon.(*containerMonitor).Start-fm()
      /home/moroz/project/workspace/src/github.com/docker/docker/daemon/start.go:147 +0x3b
  github.com/docker/docker/pkg/promise.Go.func1()
      /home/moroz/project/workspace/src/github.com/docker/docker/pkg/promise/promise.go:8 +0x2a
```