### PR TITLE
Release address pool before removing the network from store

### DIFF
--- a/network.go
+++ b/network.go
@@ -603,11 +603,12 @@ func (n *network) Delete() error {
 	if err = n.getController().deleteFromStore(n.getEpCnt()); err != nil {
 		return fmt.Errorf("error deleting network endpoint count from store: %v", err)
 	}
+
+	n.ipamRelease()
+
 	if err = n.getController().deleteFromStore(n); err != nil {
 		return fmt.Errorf("error deleting network from store: %v", err)
 	}
-
-	n.ipamRelease()
 
 	return nil
 }


### PR DESCRIPTION
- On network delete it is preferable to release the gateway address
  and address pool before removing the network from the datastore,
  given ipam data is a child of network data.

Signed-off-by: Alessandro Boch <aboch@docker.com>