### PR TITLE
Make boltDB connection persistent by default.

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
@@ -136,7 +137,9 @@ func makeDefaultScopes() map[string]*ScopeCfg {
 			Provider: string(store.BOLTDB),
 			Address:  defaultPrefix + "/local-kv.db",
 			Config: &store.Config{
-				Bucket: "libnetwork",
+				Bucket:            "libnetwork",
+				PersistConnection: true,
+				ConnectionTimeout: 30 * time.Second,
 			},
 		},
 	}
@@ -210,6 +213,8 @@ func newClient(scope string, kv string, addr string, config *store.Config, cache
 	if kv == string(store.BOLTDB) {
 		// Parse file path
 		addrs = strings.Split(addr, ",")
+		config.PersistConnection = true
+		config.ConnectionTimeout = 30 * time.Second
 	} else {
 		// Parse URI
 		parts := strings.SplitN(addr, "/", 2)

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -55,6 +55,7 @@ func TestCreateFullOptions(t *testing.T) {
 	if err := d.configure(genericOption); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	netOption := make(map[string]interface{})
 	netOption[netlabel.GenericData] = netConfig
@@ -110,6 +111,7 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 	if err := d.configure(genericOption); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	bndIPs := "127.0.0.1"
 	nwV6s := "2100:2400:2600:2700:2800::/80"
@@ -203,6 +205,7 @@ func TestCreate(t *testing.T) {
 	if err := d.configure(nil); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	netconfig := &networkConfiguration{BridgeName: DefaultBridgeName}
 	genericOption := make(map[string]interface{})
@@ -228,6 +231,7 @@ func TestCreateFail(t *testing.T) {
 	if err := d.configure(nil); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	netconfig := &networkConfiguration{BridgeName: "dummy0", DefaultBridge: true}
 	genericOption := make(map[string]interface{})
@@ -251,6 +255,7 @@ func TestCreateMultipleNetworks(t *testing.T) {
 	if err := d.configure(genericOption); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	config1 := &networkConfiguration{BridgeName: "net_test_1"}
 	genericOption = make(map[string]interface{})
@@ -440,6 +445,7 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 	if err := d.configure(genericOption); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	netconfig := &networkConfiguration{
 		BridgeName: DefaultBridgeName,
@@ -504,6 +510,7 @@ func TestCreateLinkWithOptions(t *testing.T) {
 	if err := d.configure(nil); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	netconfig := &networkConfiguration{BridgeName: DefaultBridgeName}
 	netOptions := make(map[string]interface{})
@@ -571,6 +578,7 @@ func TestLinkContainers(t *testing.T) {
 	if err := d.configure(genericOption); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	netconfig := &networkConfiguration{
 		BridgeName: DefaultBridgeName,
@@ -763,6 +771,7 @@ func TestSetDefaultGw(t *testing.T) {
 	if err := d.configure(nil); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	_, subnetv6, _ := net.ParseCIDR("2001:db8:ea9:9abc:b0c4::/80")
 

--- a/drivers/bridge/network_test.go
+++ b/drivers/bridge/network_test.go
@@ -16,6 +16,7 @@ func TestLinkCreate(t *testing.T) {
 	if err := d.configure(nil); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	mtu := 1490
 	config := &networkConfiguration{
@@ -111,6 +112,7 @@ func TestLinkCreateTwo(t *testing.T) {
 	if err := d.configure(nil); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	config := &networkConfiguration{
 		BridgeName: DefaultBridgeName,
@@ -148,6 +150,7 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 	if err := d.configure(nil); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	config := &networkConfiguration{
 		BridgeName: DefaultBridgeName}
@@ -182,6 +185,7 @@ func TestLinkDelete(t *testing.T) {
 	if err := d.configure(nil); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	config := &networkConfiguration{
 		BridgeName: DefaultBridgeName,

--- a/drivers/bridge/port_mapping_test.go
+++ b/drivers/bridge/port_mapping_test.go
@@ -30,6 +30,7 @@ func TestPortMappingConfig(t *testing.T) {
 	if err := d.configure(genericOption); err != nil {
 		t.Fatalf("Failed to setup driver config: %v", err)
 	}
+	defer d.store.Close()
 
 	binding1 := types.PortBinding{Proto: types.UDP, Port: uint16(400), HostPort: uint16(54000)}
 	binding2 := types.PortBinding{Proto: types.TCP, Port: uint16(500), HostPort: uint16(65000)}

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -25,6 +25,7 @@ func setupDriver(t *testing.T) *driverTester {
 	if err := dt.d.configure(); err != nil {
 		t.Fatal(err)
 	}
+	defer dt.d.store.Close()
 
 	iface, err := net.InterfaceByName("eth0")
 	if err != nil {
@@ -96,6 +97,7 @@ func TestOverlayNilConfig(t *testing.T) {
 	if err := dt.d.configure(); err != nil {
 		t.Fatal(err)
 	}
+	defer dt.d.store.Close()
 
 	cleanupDriver(t, dt)
 }


### PR DESCRIPTION
The local storage is designed to be used by a sigle local application.
Reusing connections will make any operation faster, since we don't
have to reconnect all the time from the same local application.

By doing this, Docker won't need to reconnect every time libnetwork uses the local storage.

Signed-off-by: David Calavera <david.calavera@gmail.com>