### PR TITLE
Don't connect sbx to default gw nw if default static route is provided

### DIFF
--- a/default_gateway.go
+++ b/default_gateway.go
@@ -107,6 +107,11 @@ func (sb *sandbox) needDefaultGW() bool {
 		if len(ep.Gateway()) > 0 {
 			return false
 		}
+		for _, r := range ep.StaticRoutes() {
+			if r.Destination.String() == "0.0.0.0/0" {
+				return false
+			}
+		}
 		needGW = true
 	}
 	return needGW

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -222,6 +222,8 @@ The entries in `"StaticRoutes"` represent routes that should be added to an inte
 
 Routes are either given a `RouteType` of `0` and a value for `NextHop`; or, a `RouteType` of `1` and no value for `NextHop`, meaning a connected route.
 
+If no gateway and no default static route is set by the driver in the Join response, libnetwork will add an additional interface to the sandbox connecting to a default gateway network (a bridge network named *docker_gwbridge*) and program the default gateway into the sandbox accordingly, pointing to the interface address of the bridge *docker_gwbridge*.
+
 ### Leave
 
 If the proxy is asked to remove an endpoint from a sandbox, the remote process shall receive a POST to the URL `/NetworkDriver.Leave` of the form

--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -25,6 +25,10 @@ type EndpointInfo interface {
 	// This will only return a valid value if a container has joined the endpoint.
 	GatewayIPv6() net.IP
 
+	// StaticRoutes returns the list of static routes configured by the network
+	// driver when the container joins a network
+	StaticRoutes() []*types.StaticRoute
+
 	// Sandbox returns the attached sandbox if there, nil otherwise.
 	Sandbox() Sandbox
 }
@@ -293,6 +297,17 @@ func (ep *endpoint) Sandbox() Sandbox {
 		return nil
 	}
 	return cnt
+}
+
+func (ep *endpoint) StaticRoutes() []*types.StaticRoute {
+	ep.Lock()
+	defer ep.Unlock()
+
+	if ep.joinInfo == nil {
+		return nil
+	}
+
+	return ep.joinInfo.StaticRoutes
 }
 
 func (ep *endpoint) Gateway() net.IP {


### PR DESCRIPTION
Signed-off-by: Alessandro Boch <aboch@docker.com>