### PR TITLE
Do not attempt serf query when not initialized

### DIFF
--- a/drivers/overlay/ov_serf.go
+++ b/drivers/overlay/ov_serf.go
@@ -151,6 +151,10 @@ func (d *driver) processQuery(q *serf.Query) {
 }
 
 func (d *driver) resolvePeer(nid string, peerIP net.IP) (net.HardwareAddr, net.IPMask, net.IP, error) {
+	if d.serfInstance == nil {
+		return nil, nil, nil, fmt.Errorf("could not resolve peer: serf instance not initialized")
+	}
+
 	qPayload := fmt.Sprintf("%s %s", string(nid), peerIP.String())
 	resp, err := d.serfInstance.Query("peerlookup", []byte(qPayload), nil)
 	if err != nil {


### PR DESCRIPTION
Sometimes, the vxlan kernel code may generate miss
notifications for vxlan bound packets when serf is
not initliazed. In such cases we should not try
doing a query as it will create a panic. We should
error out which will generate a log message.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>