### PR TITLE
update maintainers file for parsing

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,52 @@
-Alessandro Boch <aboch@docker.com> (@aboch)
-Alexandr Morozov <lk4d4@docker.com> (@LK4D4)
-Arnaud Porterie <arnaud@docker.com> (@icecrime)
-Jana Radhakrishnan <mrjana@docker.com> (@mrjana)
-Madhu Venugopal <madhu@docker.com> (@mavenugo)
+# Libnetwork maintainers file
+#
+# This file describes who runs the docker/libnetwork project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"aboch",
+			"LK4D4",
+			"icecrime",
+			"mrjana",
+			"mavenugo",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+
+	[people.aboch]
+	Name = "Alessandro Boch"
+	Email = "aboch@docker.com"
+	GitHub = "aboch"
+
+	[people.LK4D4]
+	Name = "Alexandr Morozov"
+	Email = "lk4d4@docker.com"
+	GitHub = "LK4D4"
+
+	[people.icecrime]
+	Name = "Arnaud Porterie"
+	Email = "arnaud@docker.com"
+	GitHub = "icecrime"
+
+	[people.mrjana]
+	Name = "Jana Radhakrishnan"
+	Email = "mrjana@docker.com"
+	GitHub = "mrjana"
+
+	[people.mavenugo]
+	Name = "Madhu Venugopal"
+	Email = "madhu@docker.com"
+	GitHub = "mavenugo"


### PR DESCRIPTION
this updates the MAINTAINERS file to the new toml format,
so that it can be parsed and collected in the docker/opensource
repository.

see docker/opensource#35 and docker/docker#18321