### PR TITLE
Skip defaultGw check if sandbox is being deleted

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -561,7 +561,7 @@ func (ep *endpoint) sbLeave(sbox Sandbox, options ...EndpointOption) error {
 
 	sb.deleteHostsEntries(n.getSvcRecords(ep))
 
-	if sb.needDefaultGW() {
+	if !sb.inDelete && sb.needDefaultGW() {
 		ep := sb.getEPwithoutGateway()
 		if ep == nil {
 			return fmt.Errorf("endpoint without GW expected, but not found")


### PR DESCRIPTION
- On Sandbox deletion, during Leave from each
  connected endpoint, avoid the default gw
  check, which may create an unnecessary
  connection to the default gateway network.

- Especially during sandbox cleanup on start
  after an ungraceful shutdown of the docker
  daemon, the unnecessary connection to the
  default gw network is likely to happen, if a 
  container was connected to multiple network.

Signed-off-by: Alessandro Boch <aboch@docker.com>