### PR TITLE
Fix mutex copy

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -51,7 +51,7 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 	d := &driver{
 		networks: networkTable{},
 		peerDb: peerNetworkMap{
-			mp: map[string]peerMap{},
+			mp: map[string]*peerMap{},
 		},
 		config: config,
 	}

--- a/drivers/overlay/peerdb.go
+++ b/drivers/overlay/peerdb.go
@@ -26,7 +26,7 @@ type peerMap struct {
 }
 
 type peerNetworkMap struct {
-	mp map[string]peerMap
+	mp map[string]*peerMap
 	sync.Mutex
 }
 
@@ -138,7 +138,7 @@ func (d *driver) peerDbAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask
 	d.peerDb.Lock()
 	pMap, ok := d.peerDb.mp[nid]
 	if !ok {
-		d.peerDb.mp[nid] = peerMap{
+		d.peerDb.mp[nid] = &peerMap{
 			mp: make(map[string]peerEntry),
 		}
 


### PR DESCRIPTION
If we use peerMap as value, then we copy its mutex on
`pMap = d.peerDb.mp[nid]` and lock entirely different mutexes every
time.