### PR TITLE
Respect IPv6 gateway configuration when disabling gateway service

### DIFF
--- a/default_gateway.go
+++ b/default_gateway.go
@@ -109,12 +109,12 @@ func (sb *sandbox) needDefaultGW() bool {
 		if ep.joinInfo.disableGatewayService {
 			return false
 		}
-		// TODO v6 needs to be handled.
-		if len(ep.Gateway()) > 0 {
+		if len(ep.Gateway()) > 0 || len(ep.GatewayIPv6()) > 0 {
 			return false
 		}
 		for _, r := range ep.StaticRoutes() {
-			if r.Destination.String() == "0.0.0.0/0" {
+			if r.Destination.String() == "0.0.0.0/0" ||
+				r.Destination.String() == "::/0" {
 				return false
 			}
 		}


### PR DESCRIPTION
Treat an IPv6 gateway the same an IPv4 gateway is treated, disable
gateway services if a gateway has been configured by the driver.