### PR TITLE
CherryPick: Add overlay network support < 3.16 kernels

### DIFF
--- a/drivers/overlay/filter.go
+++ b/drivers/overlay/filter.go
@@ -1,0 +1,119 @@
+package overlay
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/libnetwork/iptables"
+)
+
+const globalChain = "DOCKER-OVERLAY"
+
+var filterOnce sync.Once
+
+func rawIPTables(args ...string) error {
+	if output, err := iptables.Raw(args...); err != nil {
+		return fmt.Errorf("unable to add overlay filter: %v", err)
+	} else if len(output) != 0 {
+		return fmt.Errorf("unable to add overlay filter: %s", string(output))
+	}
+
+	return nil
+}
+
+func setupGlobalChain() {
+	if err := rawIPTables("-N", globalChain); err != nil {
+		logrus.Errorf("could not create global overlay chain: %v", err)
+		return
+	}
+
+	if err := rawIPTables("-A", globalChain, "-j", "RETURN"); err != nil {
+		logrus.Errorf("could not install default return chain in the overlay global chain: %v", err)
+		return
+	}
+}
+
+func setNetworkChain(cname string, remove bool) error {
+	// Initialize the onetime global overlay chain
+	filterOnce.Do(setupGlobalChain)
+
+	opt := "-N"
+	// In case of remove, make sure to flush the rules in the chain
+	if remove {
+		if err := rawIPTables("-F", cname); err != nil {
+			return fmt.Errorf("failed to flush overlay network chain %s rules: %v", cname, err)
+		}
+		opt = "-X"
+	}
+
+	if err := rawIPTables(opt, cname); err != nil {
+		return fmt.Errorf("failed network chain operation %q for chain %s: %v", opt, cname, err)
+	}
+
+	if !remove {
+		if err := rawIPTables("-A", cname, "-j", "DROP"); err != nil {
+			return fmt.Errorf("failed adding default drop rule to overlay network chain %s: %v", cname, err)
+		}
+	}
+
+	return nil
+}
+
+func addNetworkChain(cname string) error {
+	return setNetworkChain(cname, false)
+}
+
+func removeNetworkChain(cname string) error {
+	return setNetworkChain(cname, true)
+}
+
+func setFilters(cname, brName string, remove bool) error {
+	opt := "-I"
+	if remove {
+		opt = "-D"
+	}
+
+	// Everytime we set filters for a new subnet make sure to move the global overlay hook to the top of the both the OUTPUT and forward chains
+	if !remove {
+		for _, chain := range []string{"OUTPUT", "FORWARD"} {
+			exists := iptables.Exists(iptables.Filter, chain, "-j", globalChain)
+			if exists {
+				if err := rawIPTables("-D", chain, "-j", globalChain); err != nil {
+					return fmt.Errorf("failed to delete overlay hook in chain %s while moving the hook: %v", chain, err)
+				}
+			}
+
+			if err := rawIPTables("-I", chain, "-j", globalChain); err != nil {
+				return fmt.Errorf("failed to insert overlay hook in chain %s: %v", chain, err)
+			}
+		}
+	}
+
+	// Insert/Delete the rule to jump to per-bridge chain
+	exists := iptables.Exists(iptables.Filter, globalChain, "-o", brName, "-j", cname)
+	if (!remove && !exists) || (remove && exists) {
+		if err := rawIPTables(opt, globalChain, "-o", brName, "-j", cname); err != nil {
+			return fmt.Errorf("failed to add per-bridge filter rule for bridge %s, network chain %s: %v", brName, cname, err)
+		}
+	}
+
+	exists = iptables.Exists(iptables.Filter, cname, "-i", brName, "-j", "ACCEPT")
+	if (!remove && exists) || (remove && !exists) {
+		return nil
+	}
+
+	if err := rawIPTables(opt, cname, "-i", brName, "-j", "ACCEPT"); err != nil {
+		return fmt.Errorf("failed to add overlay filter rile for network chain %s, bridge %s: %v", cname, brName, err)
+	}
+
+	return nil
+}
+
+func addFilters(cname, brName string) error {
+	return setFilters(cname, brName, false)
+}
+
+func removeFilters(cname, brName string) error {
+	return setFilters(cname, brName, true)
+}

--- a/drivers/overlay/ov_utils.go
+++ b/drivers/overlay/ov_utils.go
@@ -47,13 +47,8 @@ func createVethPair() (string, string, error) {
 	return name1, name2, nil
 }
 
-func createVxlan(vni uint32) (string, error) {
+func createVxlan(name string, vni uint32) error {
 	defer osl.InitOSContext()()
-
-	name, err := netutils.GenerateIfaceName("vxlan", 7)
-	if err != nil {
-		return "", fmt.Errorf("error generating vxlan name: %v", err)
-	}
 
 	vxlan := &netlink.Vxlan{
 		LinkAttrs: netlink.LinkAttrs{Name: name},
@@ -66,10 +61,10 @@ func createVxlan(vni uint32) (string, error) {
 	}
 
 	if err := netlink.LinkAdd(vxlan); err != nil {
-		return "", fmt.Errorf("error creating vxlan interface: %v", err)
+		return fmt.Errorf("error creating vxlan interface: %v", err)
 	}
 
-	return name, nil
+	return nil
 }
 
 func deleteVxlan(name string) error {

--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -41,6 +41,7 @@ type networkNamespace struct {
 	staticRoutes []*types.StaticRoute
 	neighbors    []*neigh
 	nextIfIndex  int
+	isDefault    bool
 	sync.Mutex
 }
 
@@ -146,7 +147,7 @@ func NewSandbox(key string, osCreate bool) (Sandbox, error) {
 		return nil, err
 	}
 
-	return &networkNamespace{path: key}, nil
+	return &networkNamespace{path: key, isDefault: !osCreate}, nil
 }
 
 func (n *networkNamespace) InterfaceOptions() IfaceOptionSetter {

--- a/test/integration/dnet/overlay-consul-host.bats
+++ b/test/integration/dnet/overlay-consul-host.bats
@@ -1,0 +1,9 @@
+# -*- mode: sh -*-
+#!/usr/bin/env bats
+
+load helpers
+
+@test "Test overlay network hostmode with consul" {
+    skip_for_circleci
+    test_overlay_hostmode consul
+}

--- a/test/integration/dnet/run-integration-tests.sh
+++ b/test/integration/dnet/run-integration-tests.sh
@@ -56,6 +56,21 @@ function run_overlay_consul_tests() {
     unset cmap[dnet-3-consul]
 }
 
+function run_overlay_consul_host_tests() {
+    export _OVERLAY_HOST_MODE="true"
+    ## Setup
+    start_dnet 1 consul 1>>${INTEGRATION_ROOT}/test.log 2>&1
+    cmap[dnet-1-consul]=dnet-1-consul
+
+    ## Run the test cases
+    ./integration-tmp/bin/bats ./test/integration/dnet/overlay-consul-host.bats
+
+    ## Teardown
+    stop_dnet 1 consul 1>>${INTEGRATION_ROOT}/test.log 2>&1
+    unset cmap[dnet-1-consul]
+    unset _OVERLAY_HOST_MODE
+}
+
 function run_overlay_zk_tests() {
     ## Test overlay network with zookeeper
     start_dnet 1 zookeeper 1>>${INTEGRATION_ROOT}/test.log 2>&1
@@ -207,7 +222,7 @@ if [ -z "$SUITES" ]; then
 	# old kernel and limited docker environment.
 	suites="dnet simple_consul multi_consul multi_zk multi_etcd"
     else
-	suites="dnet simple_consul multi_consul multi_zk multi_etcd  bridge overlay_consul overlay_zk overlay_etcd"
+	suites="dnet simple_consul multi_consul multi_zk multi_etcd  bridge overlay_consul overlay_consul_host overlay_zk overlay_etcd"
     fi
 else
     suites="$SUITES"


### PR DESCRIPTION
Add support for overlay networking in older kernels.

Following were done to achieve this:
    + Create the vxlan network in host namespace.
    + This may create conflicts with other private
      networks so check for conflicts and fail a
      join if there is any conflict.
    + Add iptable based filtering to only allow
      subnet bridges in the same network to forward
      traffic while different network bridges will
      not be able to forward b/w each other. Also
      block traffic to overlay network originating
      from the host itself.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>