### PR TITLE
Cleanup vxlan interface by id before creating

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -267,8 +267,8 @@ func (n *network) initSubnetSandbox(s *subnet) error {
 
 	vxlanName := n.generateVxlanName(s)
 
-	// Try to delete the vxlan interface if already present
-	deleteVxlan(vxlanName)
+	// Try to delete the vxlan interface by vni if already present
+	deleteVxlanByVNI(n.vxlanID(s))
 
 	err := createVxlan(vxlanName, n.vxlanID(s))
 	if err != nil {

--- a/drivers/overlay/ov_utils.go
+++ b/drivers/overlay/ov_utils.go
@@ -81,3 +81,25 @@ func deleteVxlan(name string) error {
 
 	return nil
 }
+
+func deleteVxlanByVNI(vni uint32) error {
+	defer osl.InitOSContext()()
+
+	links, err := netlink.LinkList()
+	if err != nil {
+		return fmt.Errorf("failed to list interfaces while deleting vxlan interface by vni: %v", err)
+	}
+
+	for _, l := range links {
+		if l.Type() == "vxlan" && l.(*netlink.Vxlan).VxlanId == int(vni) {
+			err = netlink.LinkDel(l)
+			if err != nil {
+				return fmt.Errorf("error deleting vxlan interface with id %d: %v", vni, err)
+			}
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("could not find a vxlan interface to delete with id %d", vni)
+}


### PR DESCRIPTION
Currently we are cleaning up vxlan interfaces by name
before trying to setup an interface with the same name.
But this doesn't work for properly cleaning up vxlan
interfaces with the same vni, if the interface has a
a different name than the one expected. The fix is to
delete the interface based on vni.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>