### PR TITLE
Check existence of network chain before creating

### DIFF
--- a/drivers/overlay/ov_utils.go
+++ b/drivers/overlay/ov_utils.go
@@ -67,16 +67,16 @@ func createVxlan(name string, vni uint32) error {
 	return nil
 }
 
-func deleteVxlan(name string) error {
+func deleteInterface(name string) error {
 	defer osl.InitOSContext()()
 
 	link, err := netlink.LinkByName(name)
 	if err != nil {
-		return fmt.Errorf("failed to find vxlan interface with name %s: %v", name, err)
+		return fmt.Errorf("failed to find interface with name %s: %v", name, err)
 	}
 
 	if err := netlink.LinkDel(link); err != nil {
-		return fmt.Errorf("error deleting vxlan interface: %v", err)
+		return fmt.Errorf("error deleting interface with name %s: %v", name, err)
 	}
 
 	return nil


### PR DESCRIPTION
We check for existence of all filter rules in
overlay driver before creating it. We should
also do this for chain creation, because even though
we cleanup network chains when the last container
stops, there is a possibility of a stale network
chain in case of ungraceful restart.

Also cleaned up stale bridges if any exist due to
ungraceful shutdown of daemon.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>