### PR TITLE
Don't treat non-nil output as error in ChainExists

### DIFF
--- a/drivers/overlay/filter.go
+++ b/drivers/overlay/filter.go
@@ -23,7 +23,7 @@ func rawIPTables(args ...string) error {
 }
 
 func chainExists(cname string) bool {
-	if err := rawIPTables("-L", cname); err != nil {
+	if _, err := iptables.Raw("-L", cname); err != nil {
 		return false
 	}
 


### PR DESCRIPTION
ChainExists should not treat non-nil output as
error because there is always going to be some
output while dumping iptable rules.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>