### PR TITLE
Fix golang.org/x/tools breakage in go 1.4

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,10 @@
 FROM golang:1.4-cross
 RUN apt-get update && apt-get -y install iptables
+
+RUN cd /go/src && mkdir -p golang.org/x && \
+    cd golang.org/x && git clone https://github.com/golang/tools && \
+    cd tools && git checkout release-branch.go1.5
+
 RUN go get github.com/tools/godep \
 		github.com/golang/lint/golint \
 		golang.org/x/tools/cmd/vet \


### PR DESCRIPTION
A commit today(1/6/2016) in golang.org/x/tools broke
libnetwork builds because it now requires certain
go 1.5 packages while libnetwork still uses go1.4.
Fixed it by manually installing golang.org/x/tools from
release-branch.go1.5 which should work for us
even though it is versioned 1.5. The 1.4 release
branch is too old and doesn't work with latest golint
package.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>