### PR TITLE
Accept IpamOptions via NetworkOptionIpam

### DIFF
--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -435,7 +435,7 @@ func ipamOption(bridgeName string) libnetwork.NetworkOption {
 		if hip.IsGlobalUnicast() {
 			ipamV4Conf.Gateway = nw.IP.String()
 		}
-		return libnetwork.NetworkOptionIpam("default", "", []*libnetwork.IpamConf{ipamV4Conf}, nil)
+		return libnetwork.NetworkOptionIpam("default", "", []*libnetwork.IpamConf{ipamV4Conf}, nil, nil)
 	}
 	return nil
 }

--- a/docs/ipam.md
+++ b/docs/ipam.md
@@ -56,7 +56,7 @@ The following sections explain the each of the above API's semantics, when they 
 A libnetwork user can provide IPAM related configuration when creating a network, via the `NetworkOptionIpam` setter function. 
 
 ```go
-func NetworkOptionIpam(ipamDriver string, addrSpace string, ipV4 []*IpamConf, ipV6 []*IpamConf) NetworkOption
+func NetworkOptionIpam(ipamDriver string, addrSpace string, ipV4 []*IpamConf, ipV6 []*IpamConf, opts map[string]string) NetworkOption
 ```
 
 The caller has to provide the IPAM driver name and may provide the address space and a list of `IpamConf` structures for IPv4 and a list for IPv6. The IPAM driver name is the only mandatory field. If not provided, network creation will fail.

--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -67,20 +67,19 @@ func TestNetworkMarshalling(t *testing.T) {
 		networkType: "bridge",
 		enableIPv6:  true,
 		persist:     true,
+		ipamOptions: map[string]string{
+			netlabel.MacAddress: "a:b:c:d:e:f",
+		},
 		ipamV4Config: []*IpamConf{
 			&IpamConf{
 				PreferredPool: "10.2.0.0/16",
 				SubPool:       "10.2.0.0/24",
-				Options: map[string]string{
-					netlabel.MacAddress: "a:b:c:d:e:f",
-				},
-				Gateway:      "",
-				AuxAddresses: nil,
+				Gateway:       "",
+				AuxAddresses:  nil,
 			},
 			&IpamConf{
 				PreferredPool: "10.2.0.0/16",
 				SubPool:       "10.2.1.0/24",
-				Options:       nil,
 				Gateway:       "10.2.1.254",
 			},
 		},
@@ -265,7 +264,6 @@ func compareIpamConfList(listA, listB []*IpamConf) bool {
 		b = listB[i]
 		if a.PreferredPool != b.PreferredPool ||
 			a.SubPool != b.SubPool ||
-			!compareStringMaps(a.Options, b.Options) ||
 			a.Gateway != b.Gateway || !compareStringMaps(a.AuxAddresses, b.AuxAddresses) {
 			return false
 		}
@@ -374,7 +372,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 
 	// Test whether ipam state release is invoked  on network create failure from net driver
 	// by checking whether subsequent network creation requesting same gateway IP succeeds
-	ipamOpt := NetworkOptionIpam(ipamapi.DefaultIPAM, "", []*IpamConf{&IpamConf{PreferredPool: "10.34.0.0/16", Gateway: "10.34.255.254"}}, nil)
+	ipamOpt := NetworkOptionIpam(ipamapi.DefaultIPAM, "", []*IpamConf{&IpamConf{PreferredPool: "10.34.0.0/16", Gateway: "10.34.255.254"}}, nil, nil)
 	if _, err := c.NewNetwork(badDriverName, "badnet1", ipamOpt); err == nil {
 		t.Fatalf("bad network driver should have failed network creation")
 	}
@@ -398,7 +396,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 	}
 
 	// Now create good bridge network with different gateway
-	ipamOpt2 := NetworkOptionIpam(ipamapi.DefaultIPAM, "", []*IpamConf{&IpamConf{PreferredPool: "10.34.0.0/16", Gateway: "10.34.255.253"}}, nil)
+	ipamOpt2 := NetworkOptionIpam(ipamapi.DefaultIPAM, "", []*IpamConf{&IpamConf{PreferredPool: "10.34.0.0/16", Gateway: "10.34.255.253"}}, nil, nil)
 	gnw, err = c.NewNetwork("bridge", "goodnet2", ipamOpt2)
 	if err != nil {
 		t.Fatal(err)

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -87,7 +87,7 @@ func createController() error {
 func createTestNetwork(networkType, networkName string, netOption options.Generic, ipamV4Configs, ipamV6Configs []*libnetwork.IpamConf) (libnetwork.Network, error) {
 	return controller.NewNetwork(networkType, networkName,
 		libnetwork.NetworkOptionGeneric(netOption),
-		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", ipamV4Configs, ipamV6Configs))
+		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", ipamV4Configs, ipamV6Configs, nil))
 }
 
 func getEmptyGenericOption() map[string]interface{} {
@@ -333,7 +333,7 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 
 	network, err := controller.NewNetwork(bridgeNetType, "testipv6mac",
 		libnetwork.NetworkOptionGeneric(netOption),
-		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", ipamV4ConfList, ipamV6ConfList),
+		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", ipamV4ConfList, ipamV6ConfList, nil),
 		libnetwork.NetworkOptionDeferIPv6Alloc(true))
 	if err != nil {
 		t.Fatal(err)
@@ -1016,7 +1016,7 @@ func TestEndpointJoin(t *testing.T) {
 	ipamV6ConfList := []*libnetwork.IpamConf{&libnetwork.IpamConf{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
 	n1, err := controller.NewNetwork(bridgeNetType, "testnetwork1",
 		libnetwork.NetworkOptionGeneric(netOption),
-		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", nil, ipamV6ConfList),
+		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", nil, ipamV6ConfList, nil),
 		libnetwork.NetworkOptionDeferIPv6Alloc(true))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Accept IpamOptions via NetworkOptionIpam. 

This change also removes subnet specific IPAM Options and moves them to per network. 

See pull docker/docker#17316 for corresponding changes and discussion