### PR TITLE
Honor --iptables=false in bridge

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -135,7 +135,7 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 	if err := iptables.FirewalldInit(); err != nil {
 		logrus.Debugf("Fail to initialize firewalld: %v, using raw iptables instead", err)
 	}
-	removeIPChains()
+
 	d := newDriver()
 	if err := d.configure(config); err != nil {
 		return err
@@ -378,6 +378,7 @@ func (d *driver) configure(option map[string]interface{}) error {
 	}
 
 	if config.EnableIPTables {
+		removeIPChains()
 		natChain, filterChain, isolationChain, err = setupIPChains(config)
 		if err != nil {
 			return err

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -817,12 +817,6 @@ func TestSetDefaultGw(t *testing.T) {
 	}
 }
 
-type fakeCallBack struct{}
-
-func (cb fakeCallBack) RegisterDriver(name string, driver driverapi.Driver, capability driverapi.Capability) error {
-	return nil
-}
-
 func TestCleanupIptableRules(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 	bridgeChain := []iptables.ChainInfo{
@@ -838,7 +832,7 @@ func TestCleanupIptableRules(t *testing.T) {
 			t.Fatalf("iptables chain %s of %s table should have been created", chainInfo.Name, chainInfo.Table)
 		}
 	}
-	Init(fakeCallBack{}, make(map[string]interface{}))
+	removeIPChains()
 	for _, chainInfo := range bridgeChain {
 		if iptables.ExistChain(chainInfo.Name, chainInfo.Table) {
 			t.Fatalf("iptables chain %s of %s table should have been deleted", chainInfo.Name, chainInfo.Table)


### PR DESCRIPTION
- When the flag is false, besides not programming the chains, also skip chains cleanup
- Related to https://github.com/docker/docker/issues/19063

Signed-off-by: Alessandro Boch <aboch@docker.com>