### PR TITLE
Adjust filter iptables chains

### DIFF
--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -811,13 +811,18 @@ func TestSetDefaultGw(t *testing.T) {
 
 func TestCleanupIptableRules(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
+
+	d := newDriver()
+	d.config = &configuration{EnableIPTables: true}
+
 	bridgeChain := []iptables.ChainInfo{
-		{Name: DockerChain, Table: iptables.Nat},
+		{Name: ExposedChain, Table: iptables.Nat},
 		{Name: DockerChain, Table: iptables.Filter},
+		{Name: ExposedChain, Table: iptables.Filter},
 		{Name: IsolationChain, Table: iptables.Filter},
 	}
-	if _, _, _, err := setupIPChains(&configuration{EnableIPTables: true}); err != nil {
-		t.Fatalf("Error setting up ip chains: %v", err)
+	if err := d.setupIPChains(); err != nil {
+		t.Fatal(err)
 	}
 	for _, chainInfo := range bridgeChain {
 		if !iptables.ExistChain(chainInfo.Name, chainInfo.Table) {

--- a/drivers/bridge/port_mapping.go
+++ b/drivers/bridge/port_mapping.go
@@ -84,6 +84,10 @@ func (n *bridgeNetwork) allocatePort(bnd *types.PortBinding, containerIP, defHos
 		return err
 	}
 
+	if err := ensureReturnRule(ExposedChain); err != nil {
+		logrus.Warnf("Failed to ensure return rule as last in %s chain: %v", ExposedChain, err)
+	}
+
 	// Save the host port (regardless it was or not specified in the binding)
 	switch netAddr := host.(type) {
 	case *net.TCPAddr:

--- a/drivers/bridge/setup_ip_forwarding.go
+++ b/drivers/bridge/setup_ip_forwarding.go
@@ -10,7 +10,11 @@ const (
 	ipv4ForwardConfPerm = 0644
 )
 
-func setupIPForwarding() error {
+func (d *driver) setupIPForwarding() error {
+	if !d.config.EnableIPForwarding {
+		return nil
+	}
+
 	// Get current IPv4 forward setup
 	ipv4ForwardData, err := ioutil.ReadFile(ipv4ForwardConf)
 	if err != nil {

--- a/drivers/bridge/setup_ip_forwarding_test.go
+++ b/drivers/bridge/setup_ip_forwarding_test.go
@@ -17,7 +17,8 @@ func TestSetupIPForwarding(t *testing.T) {
 	}
 
 	// Set IP Forwarding
-	if err := setupIPForwarding(); err != nil {
+	d := &driver{config: &configuration{EnableIPForwarding: true}}
+	if err := d.setupIPForwarding(); err != nil {
 		t.Fatalf("Failed to setup IP forwarding: %v", err)
 	}
 

--- a/drivers/bridge/setup_ip_tables_test.go
+++ b/drivers/bridge/setup_ip_tables_test.go
@@ -104,7 +104,7 @@ func assertIPTableChainProgramming(rule iptRule, descr string, t *testing.T) {
 func assertChainConfig(d *driver, t *testing.T) {
 	var err error
 
-	d.natChain, d.filterChain, d.isolationChain, err = setupIPChains(d.config)
+	d.setupIPChains()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -214,6 +214,18 @@ func (c *ChainInfo) Forward(action Action, ip net.IP, port int, proto, destAddr 
 		return ChainError{Chain: "FORWARD", Output: output}
 	}
 
+	if output, err := Raw("-t", string(Filter), string(action), c.Name,
+		"-i", bridgeName,
+		"!", "-o", bridgeName,
+		"-p", proto,
+		"-s", destAddr,
+		"--sport", strconv.Itoa(destPort),
+		"-j", "ACCEPT"); err != nil {
+		return err
+	} else if len(output) != 0 {
+		return ChainError{Chain: "FORWARD", Output: output}
+	}
+
 	if output, err := Raw("-t", string(Nat), string(action), "POSTROUTING",
 		"-p", proto,
 		"-s", destAddr,


### PR DESCRIPTION
- In filter "FORWARD" chain send all docker bridge packets to DOCKER chain
- In DOCKER chain jump to a new DOCKER-EXPOSED chain which will contain the
  ACCEPT rules for containers' exposed ports. Then returns to caller.
- In DOCKER chain jump to DOCKER-ISOLATION chain which contains the DROP rules
  for inter-network communications and internal networks. Then returns to caller.
- The rest of DOCKER chain rules are ACCEPT and DROP for ICC true/false.
  Then it returns to caller.
- Change the nat Docker chain name to DOCKER-EXPOSED because of the way
  portmapper programs the "forward" rule

Related to https://github.com/docker/docker/issues/18354

Signed-off-by: Alessandro Boch <aboch@docker.com>