### PR TITLE
Fixes docker/docker#19404

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -913,7 +913,7 @@ func (ep *endpoint) assignAddressVersion(ipVer int, ipam ipamapi.Ipam) error {
 		}
 	}
 	if progAdd != nil {
-		return types.BadRequestErrorf("Invalid preferred address %s: It does not belong to any of this network's subnets")
+		return types.BadRequestErrorf("Invalid preferred address %s: It does not belong to any of this network's subnets", prefAdd)
 	}
 	return fmt.Errorf("no available IPv%d addresses on this network's address pools: %s (%s)", ipVer, n.Name(), n.ID())
 }


### PR DESCRIPTION
> incorrect error message if custom IP if the custom IP-address is not within a subnet of the network.

Will fix docker/docker#19404 once vendored.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>