### PR TITLE
Fix predefined pool reservation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ run-tests:
 	    if ls $$dir/*.go &> /dev/null; then \
 		pushd . &> /dev/null ; \
 		cd $$dir ; \
-		$(shell which godep) go test ${INSIDECONTAINER} -test.parallel 3 -test.v -covermode=count -coverprofile=./profile.tmp ; \
+		$(shell which godep) go test ${INSIDECONTAINER} -test.parallel 5 -test.v -covermode=count -coverprofile=./profile.tmp ; \
 		ret=$$? ;\
 		if [ $$ret -ne 0 ]; then exit $$ret; fi ;\
 		popd &> /dev/null; \

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -2,10 +2,12 @@ package ipam
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -1167,4 +1169,100 @@ func checkDBEquality(a1, a2 *Allocator, t *testing.T) {
 			t.Fatalf("%s\n%s", bm1, bm2)
 		}
 	}
+}
+
+const (
+	numInstances = 5
+	first        = 0
+	last         = numInstances - 1
+)
+
+var (
+	allocator *Allocator
+	start     = make(chan struct{})
+	done      = make(chan chan struct{}, numInstances-1)
+	pools     = make([]*net.IPNet, numInstances)
+)
+
+func runParallelTests(t *testing.T, instance int) {
+	var err error
+
+	t.Parallel()
+
+	pTest := flag.Lookup("test.parallel")
+	if pTest == nil {
+		t.Skip("Skipped because test.parallel flag not set;")
+	}
+	numParallel, err := strconv.Atoi(pTest.Value.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if numParallel < numInstances {
+		t.Skip("Skipped because t.parallel was less than ", numInstances)
+	}
+
+	// The first instance creates the allocator, gives the start
+	// and finally checks the pools each instance was assigned
+	if instance == first {
+		allocator, err = getAllocator()
+		if err != nil {
+			t.Fatal(err)
+		}
+		close(start)
+	}
+
+	if instance != first {
+		select {
+		case <-start:
+		}
+
+		instDone := make(chan struct{})
+		done <- instDone
+		defer close(instDone)
+
+		if instance == last {
+			defer close(done)
+		}
+	}
+
+	_, pools[instance], _, err = allocator.RequestPool(localAddressSpace, "", "", nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if instance == first {
+		for instDone := range done {
+			select {
+			case <-instDone:
+			}
+		}
+		// Now check each instance got a different pool
+		for i := 0; i < numInstances; i++ {
+			for j := i + 1; j < numInstances; j++ {
+				if types.CompareIPNet(pools[i], pools[j]) {
+					t.Fatalf("Instance %d and %d were given the same predefined pool: %v", i, j, pools)
+				}
+			}
+		}
+	}
+}
+
+func TestParallelPredefinedRequest1(t *testing.T) {
+	runParallelTests(t, 0)
+}
+
+func TestParallelPredefinedRequest2(t *testing.T) {
+	runParallelTests(t, 1)
+}
+
+func TestParallelPredefinedRequest3(t *testing.T) {
+	runParallelTests(t, 2)
+}
+
+func TestParallelPredefinedRequest4(t *testing.T) {
+	runParallelTests(t, 3)
+}
+
+func TestParallelPredefinedRequest5(t *testing.T) {
+	runParallelTests(t, 4)
 }

--- a/ipam/structures.go
+++ b/ipam/structures.go
@@ -257,12 +257,15 @@ func (aSpace *addrSpace) New() datastore.KVObject {
 	}
 }
 
-func (aSpace *addrSpace) updatePoolDBOnAdd(k SubnetKey, nw *net.IPNet, ipr *AddressRange) (func() error, error) {
+func (aSpace *addrSpace) updatePoolDBOnAdd(k SubnetKey, nw *net.IPNet, ipr *AddressRange, pdf bool) (func() error, error) {
 	aSpace.Lock()
 	defer aSpace.Unlock()
 
 	// Check if already allocated
 	if p, ok := aSpace.subnets[k]; ok {
+		if pdf {
+			return nil, types.InternalMaskableErrorf("predefined pool %s is already reserved", nw)
+		}
 		aSpace.incRefCount(p, 1)
 		return func() error { return nil }, nil
 	}


### PR DESCRIPTION
- The pool request code does not behave properly in
  case of concurrent requests when client does not
  specify a preferred pool. It may dispense the same
  predefined pool to different networks.
- The issue is common for local and global
  address spaces

- Verified it fixes the issue running parallel network creation requests to docker. ~~Will add tests in libnetwork in following PR update.~~

Signed-off-by: Alessandro Boch <aboch@docker.com>