### PR TITLE
Reducing the complexity in default gateway service handling

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -465,7 +465,7 @@ func (ep *endpoint) sbJoin(sbox Sandbox, options ...EndpointOption) error {
 	if sb.needDefaultGW() {
 		return sb.setupDefaultGW(ep)
 	}
-	return sb.clearDefaultGW()
+	return nil
 }
 
 func (ep *endpoint) rename(name string) error {
@@ -597,15 +597,7 @@ func (ep *endpoint) sbLeave(sbox Sandbox, force bool, options ...EndpointOption)
 	}
 
 	sb.deleteHostsEntries(n.getSvcRecords(ep))
-
-	if !sb.inDelete && sb.needDefaultGW() {
-		ep := sb.getEPwithoutGateway()
-		if ep == nil {
-			return fmt.Errorf("endpoint without GW expected, but not found")
-		}
-		return sb.setupDefaultGW(ep)
-	}
-	return sb.clearDefaultGW()
+	return nil
 }
 
 func (n *network) validateForceDelete(locator string) error {

--- a/sandbox.go
+++ b/sandbox.go
@@ -186,12 +186,6 @@ func (sb *sandbox) delete(force bool) error {
 	// Detach from all endpoints
 	retain := false
 	for _, ep := range sb.getConnectedEndpoints() {
-		// endpoint in the Gateway network will be cleaned up
-		// when when sandbox no longer needs external connectivity
-		if ep.endpointInGWNetwork() {
-			continue
-		}
-
 		// Retain the sanbdox if we can't obtain the network from store.
 		if _, err := c.getNetworkFromStore(ep.getNetwork().ID()); err != nil {
 			retain = true


### PR DESCRIPTION
By removing the need to clear the default gateway during sbJoin and
sbLeave to account for other bridge network, the default-gw endpoint
will stay with the container, it will also help retain the container
property.

Signed-off-by: Madhu Venugopal <madhu@docker.com>