### PR TITLE
Set Recursion Available bit in query responses.

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -35,7 +35,7 @@ const (
 	dnsPort       = "53"
 	ptrIPv4domain = ".in-addr.arpa."
 	ptrIPv6domain = ".ip6.arpa."
-	respTTL       = 1800
+	respTTL       = 600
 	maxExtDNS     = 3 //max number of external servers to try
 )
 
@@ -147,6 +147,10 @@ func (r *resolver) ResolverOptions() []string {
 	return []string{"ndots:0"}
 }
 
+func setCommonFlags(msg *dns.Msg) {
+	msg.RecursionAvailable = true
+}
+
 func (r *resolver) handleIPv4Query(name string, query *dns.Msg) (*dns.Msg, error) {
 	addr := r.sb.ResolveName(name)
 	if addr == nil {
@@ -157,6 +161,7 @@ func (r *resolver) handleIPv4Query(name string, query *dns.Msg) (*dns.Msg, error
 
 	resp := new(dns.Msg)
 	resp.SetReply(query)
+	setCommonFlags(resp)
 
 	rr := new(dns.A)
 	rr.Hdr = dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: respTTL}
@@ -186,6 +191,7 @@ func (r *resolver) handlePTRQuery(ptr string, query *dns.Msg) (*dns.Msg, error) 
 
 	resp := new(dns.Msg)
 	resp.SetReply(query)
+	setCommonFlags(resp)
 
 	rr := new(dns.PTR)
 	rr.Hdr = dns.RR_Header{Name: ptr, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: respTTL}


### PR DESCRIPTION
Without the RA bit the replies may not get cached..

Signed-off-by: Santhosh Manohar <santhosh@docker.com>