### PR TITLE
Delete the interface on endpoint delete in overlay

### DIFF
--- a/drivers/overlay/ov_endpoint.go
+++ b/drivers/overlay/ov_endpoint.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"net"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netutils"
+	"github.com/vishvananda/netlink"
 )
 
 type endpointTable map[string]*endpoint
@@ -97,6 +99,20 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 	}
 
 	n.deleteEndpoint(eid)
+
+	if ep.ifName == "" {
+		return nil
+	}
+
+	link, err := netlink.LinkByName(ep.ifName)
+	if err != nil {
+		log.Debugf("Failed to retrieve interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
+		return nil
+	}
+	if err := netlink.LinkDel(link); err != nil {
+		log.Debugf("Failed to delete interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
+	}
+
 	return nil
 }
 

--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -160,7 +160,9 @@ func (n *network) destroySandbox() {
 	sbox := n.sandbox()
 	if sbox != nil {
 		for _, iface := range sbox.Info().Interfaces() {
-			iface.Remove()
+			if err := iface.Remove(); err != nil {
+				logrus.Debugf("Remove interface %s failed: %v", iface.SrcName(), err)
+			}
 		}
 
 		for _, s := range n.subnets {

--- a/osl/interface_linux.go
+++ b/osl/interface_linux.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"syscall"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 )
@@ -127,7 +128,7 @@ func (i *nwIface) Remove() error {
 
 		err = netlink.LinkSetName(iface, i.SrcName())
 		if err != nil {
-			fmt.Println("LinkSetName failed: ", err)
+			log.Debugf("LinkSetName failed for interface %s: %v", i.SrcName(), err)
 			return err
 		}
 
@@ -139,7 +140,7 @@ func (i *nwIface) Remove() error {
 		} else if !isDefault {
 			// Move the network interface to caller namespace.
 			if err := netlink.LinkSetNsFd(iface, callerFD); err != nil {
-				fmt.Println("LinkSetNsPid failed: ", err)
+				log.Debugf("LinkSetNsPid failed for interface %s: %v", i.SrcName(), err)
 				return err
 			}
 		}

--- a/sandbox.go
+++ b/sandbox.go
@@ -589,7 +589,7 @@ func releaseOSSboxResources(osSbox osl.Sandbox, ep *endpoint) {
 		// Only remove the interfaces owned by this endpoint from the sandbox.
 		if ep.hasInterface(i.SrcName()) {
 			if err := i.Remove(); err != nil {
-				log.Debugf("Remove interface failed: %v", err)
+				log.Debugf("Remove interface %s failed: %v", i.SrcName(), err)
 			}
 		}
 	}


### PR DESCRIPTION
- Attempt the veth delete only after both ends are moved into the default network namespace.
  Which is after both driver.Leave() and sandbox.clearNetworkResources() are called.

Signed-off-by: Alessandro Boch <aboch@docker.com>