### PR TITLE
discoverapi.Discover interface

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -56,6 +56,7 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/hostdiscovery"
 	"github.com/docker/libnetwork/ipamapi"
@@ -288,12 +289,12 @@ func (c *controller) pushNodeDiscovery(d *driverData, nodes []net.IP, add bool) 
 		return
 	}
 	for _, node := range nodes {
-		nodeData := driverapi.NodeDiscoveryData{Address: node.String(), Self: node.Equal(self)}
+		nodeData := discoverapi.NodeDiscoveryData{Address: node.String(), Self: node.Equal(self)}
 		var err error
 		if add {
-			err = d.driver.DiscoverNew(driverapi.NodeDiscovery, nodeData)
+			err = d.driver.DiscoverNew(discoverapi.NodeDiscovery, nodeData)
 		} else {
-			err = d.driver.DiscoverDelete(driverapi.NodeDiscovery, nodeData)
+			err = d.driver.DiscoverDelete(discoverapi.NodeDiscovery, nodeData)
 		}
 		if err != nil {
 			log.Debugf("discovery notification error : %v", err)

--- a/discoverapi/discoverapi.go
+++ b/discoverapi/discoverapi.go
@@ -1,0 +1,34 @@
+package discoverapi
+
+// Discover is an interface to be implemented by the componenet interested in receiving discover events
+// like new node joining the cluster or datastore updates
+type Discover interface {
+	// DiscoverNew is a notification for a new discovery event, Example:a new node joining a cluster
+	DiscoverNew(dType DiscoveryType, data interface{}) error
+
+	// DiscoverDelete is a notification for a discovery delete event, Example:a node leaving a cluster
+	DiscoverDelete(dType DiscoveryType, data interface{}) error
+}
+
+// DiscoveryType represents the type of discovery element the DiscoverNew function is invoked on
+type DiscoveryType int
+
+const (
+	// NodeDiscovery represents Node join/leave events provided by discovery
+	NodeDiscovery = iota + 1
+	// DatastoreUpdate represents a add/remove datastore event
+	DatastoreUpdate
+)
+
+// NodeDiscoveryData represents the structure backing the node discovery data json string
+type NodeDiscoveryData struct {
+	Address string
+	Self    bool
+}
+
+// DatastoreUpdateData is the data for the datastore update event message
+type DatastoreUpdateData struct {
+	Provider string
+	Address  string
+	Config   interface{}
+}

--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -1,12 +1,18 @@
 package driverapi
 
-import "net"
+import (
+	"net"
+
+	"github.com/docker/libnetwork/discoverapi"
+)
 
 // NetworkPluginEndpointType represents the Endpoint Type used by Plugin system
 const NetworkPluginEndpointType = "NetworkDriver"
 
 // Driver is an interface that every plugin driver needs to implement.
 type Driver interface {
+	discoverapi.Discover
+
 	// CreateNetwork invokes the driver method to create a network passing
 	// the network id and network specific config. The config mechanism will
 	// eventually be replaced with labels which are yet to be introduced.
@@ -35,12 +41,6 @@ type Driver interface {
 
 	// Leave method is invoked when a Sandbox detaches from an endpoint.
 	Leave(nid, eid string) error
-
-	// DiscoverNew is a notification for a new discovery event, Example:a new node joining a cluster
-	DiscoverNew(dType DiscoveryType, data interface{}) error
-
-	// DiscoverDelete is a notification for a discovery delete event, Example:a node leaving a cluster
-	DiscoverDelete(dType DiscoveryType, data interface{}) error
 
 	// Type returns the the type of this driver, the network type this driver manages
 	Type() string
@@ -105,20 +105,6 @@ type DriverCallback interface {
 // Capability represents the high level capabilities of the drivers which libnetwork can make use of
 type Capability struct {
 	DataScope string
-}
-
-// DiscoveryType represents the type of discovery element the DiscoverNew function is invoked on
-type DiscoveryType int
-
-const (
-	// NodeDiscovery represents Node join/leave events provided by discovery
-	NodeDiscovery = iota + 1
-)
-
-// NodeDiscoveryData represents the structure backing the node discovery data json string
-type NodeDiscoveryData struct {
-	Address string
-	Self    bool
 }
 
 // IPAMData represents the per-network ip related

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/netlabel"
@@ -1283,12 +1284,12 @@ func (d *driver) Type() string {
 }
 
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
-func (d *driver) DiscoverNew(dType driverapi.DiscoveryType, data interface{}) error {
+func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }
 
 // DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
-func (d *driver) DiscoverDelete(dType driverapi.DiscoveryType, data interface{}) error {
+func (d *driver) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }
 

--- a/drivers/host/host.go
+++ b/drivers/host/host.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/types"
 )
@@ -67,11 +68,11 @@ func (d *driver) Type() string {
 }
 
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
-func (d *driver) DiscoverNew(dType driverapi.DiscoveryType, data interface{}) error {
+func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }
 
 // DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
-func (d *driver) DiscoverDelete(dType driverapi.DiscoveryType, data interface{}) error {
+func (d *driver) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }

--- a/drivers/null/null.go
+++ b/drivers/null/null.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/types"
 )
@@ -67,11 +68,11 @@ func (d *driver) Type() string {
 }
 
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
-func (d *driver) DiscoverNew(dType driverapi.DiscoveryType, data interface{}) error {
+func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }
 
 // DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
-func (d *driver) DiscoverDelete(dType driverapi.DiscoveryType, data interface{}) error {
+func (d *driver) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/idm"
 	"github.com/docker/libnetwork/netlabel"
@@ -192,9 +193,9 @@ func (d *driver) pushLocalEndpointEvent(action, nid, eid string) {
 }
 
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
-func (d *driver) DiscoverNew(dType driverapi.DiscoveryType, data interface{}) error {
-	if dType == driverapi.NodeDiscovery {
-		nodeData, ok := data.(driverapi.NodeDiscoveryData)
+func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
+	if dType == discoverapi.NodeDiscovery {
+		nodeData, ok := data.(discoverapi.NodeDiscoveryData)
 		if !ok || nodeData.Address == "" {
 			return fmt.Errorf("invalid discovery data")
 		}
@@ -204,6 +205,6 @@ func (d *driver) DiscoverNew(dType driverapi.DiscoveryType, data interface{}) er
 }
 
 // DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
-func (d *driver) DiscoverDelete(dType driverapi.DiscoveryType, data interface{}) error {
+func (d *driver) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 	_ "github.com/docker/libnetwork/testutils"
 )
@@ -34,11 +35,11 @@ func setupDriver(t *testing.T) *driverTester {
 	if err != nil || len(addrs) == 0 {
 		t.Fatal(err)
 	}
-	data := driverapi.NodeDiscoveryData{
+	data := discoverapi.NodeDiscoveryData{
 		Address: addrs[0].String(),
 		Self:    true,
 	}
-	dt.d.DiscoverNew(driverapi.NodeDiscovery, data)
+	dt.d.DiscoverNew(discoverapi.NodeDiscovery, data)
 	return dt
 }
 

--- a/drivers/remote/api/api.go
+++ b/drivers/remote/api/api.go
@@ -7,6 +7,7 @@ package api
 import (
 	"net"
 
+	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 )
 
@@ -154,7 +155,7 @@ type LeaveResponse struct {
 
 // DiscoveryNotification represents a discovery notification
 type DiscoveryNotification struct {
-	DiscoveryType driverapi.DiscoveryType
+	DiscoveryType discoverapi.DiscoveryType
 	DiscoveryData interface{}
 }
 

--- a/drivers/remote/driver.go
+++ b/drivers/remote/driver.go
@@ -7,6 +7,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/drivers/remote/api"
 	"github.com/docker/libnetwork/types"
@@ -251,8 +252,8 @@ func (d *driver) Type() string {
 }
 
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
-func (d *driver) DiscoverNew(dType driverapi.DiscoveryType, data interface{}) error {
-	if dType != driverapi.NodeDiscovery {
+func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
+	if dType != discoverapi.NodeDiscovery {
 		return fmt.Errorf("Unknown discovery type : %v", dType)
 	}
 	notif := &api.DiscoveryNotification{
@@ -263,8 +264,8 @@ func (d *driver) DiscoverNew(dType driverapi.DiscoveryType, data interface{}) er
 }
 
 // DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
-func (d *driver) DiscoverDelete(dType driverapi.DiscoveryType, data interface{}) error {
-	if dType != driverapi.NodeDiscovery {
+func (d *driver) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
+	if dType != discoverapi.NodeDiscovery {
 		return fmt.Errorf("Unknown discovery type : %v", dType)
 	}
 	notif := &api.DiscoveryNotification{

--- a/drivers/remote/driver_test.go
+++ b/drivers/remote/driver_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 	_ "github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
@@ -425,13 +426,13 @@ func TestRemoteDriver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data := driverapi.NodeDiscoveryData{
+	data := discoverapi.NodeDiscoveryData{
 		Address: "192.168.1.1",
 	}
-	if err = d.DiscoverNew(driverapi.NodeDiscovery, data); err != nil {
+	if err = d.DiscoverNew(discoverapi.NodeDiscovery, data); err != nil {
 		t.Fatal(err)
 	}
-	if err = d.DiscoverDelete(driverapi.NodeDiscovery, data); err != nil {
+	if err = d.DiscoverDelete(discoverapi.NodeDiscovery, data); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -2,6 +2,7 @@ package windows
 
 import (
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 )
 
@@ -54,11 +55,11 @@ func (d *driver) Type() string {
 }
 
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
-func (d *driver) DiscoverNew(dType driverapi.DiscoveryType, data interface{}) error {
+func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }
 
 // DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
-func (d *driver) DiscoverDelete(dType driverapi.DiscoveryType, data interface{}) error {
+func (d *driver) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }

--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/libnetwork/netlabel"
@@ -445,10 +446,10 @@ func (b *badDriver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinIn
 func (b *badDriver) Leave(nid, eid string) error {
 	return nil
 }
-func (b *badDriver) DiscoverNew(dType driverapi.DiscoveryType, data interface{}) error {
+func (b *badDriver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }
-func (b *badDriver) DiscoverDelete(dType driverapi.DiscoveryType, data interface{}) error {
+func (b *badDriver) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }
 func (b *badDriver) Type() string {


### PR DESCRIPTION
- Move DiscoverNew() and DiscoverDelete() methods into the new interface
- Add DatastoreUpdate notification
- Now this interface can be implemented by any drivers, not only network drivers

Signed-off-by: Alessandro Boch <aboch@docker.com>