### PR TITLE
Don't allow passing EnableIPv6 as a driver option (a label)

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -225,11 +225,13 @@ func TestCreateDeleteNetwork(t *testing.T) {
 		t.Fatalf("Expected StatusBadRequest status code, got: %v", errRsp)
 	}
 
-	ops := map[string]string{
-		bridge.BridgeName:   "abc",
+	dops := map[string]string{
+		bridge.BridgeName: "abc",
+	}
+	nops := map[string]string{
 		netlabel.EnableIPv6: "true",
 	}
-	nc := networkCreate{Name: "network_1", NetworkType: bridgeNetType, DriverOpts: ops}
+	nc := networkCreate{Name: "network_1", NetworkType: bridgeNetType, DriverOpts: dops, NetworkOpts: nops}
 	goodBody, err := json.Marshal(nc)
 	if err != nil {
 		t.Fatal(err)
@@ -257,29 +259,6 @@ func TestCreateDeleteNetwork(t *testing.T) {
 	if errRsp != &successResponse {
 		t.Fatalf("Unexepected failure: %v", errRsp)
 	}
-
-	// Create with labels
-	labels := map[string]string{
-		netlabel.EnableIPv6: "true",
-		bridge.BridgeName:   "abc",
-	}
-	nc = networkCreate{Name: "network_2", NetworkType: bridgeNetType, DriverOpts: labels}
-	goodBody, err = json.Marshal(nc)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, errRsp = procCreateNetwork(c, vars, goodBody)
-	if errRsp != &createdResponse {
-		t.Fatalf("Unexepected failure: %v", errRsp)
-	}
-
-	vars[urlNwName] = "network_2"
-	_, errRsp = procDeleteNetwork(c, vars, nil)
-	if errRsp != &successResponse {
-		t.Fatalf("Unexepected failure: %v", errRsp)
-	}
-
 }
 
 func TestGetNetworksAndEndpoints(t *testing.T) {
@@ -1830,14 +1809,16 @@ func TestEndToEnd(t *testing.T) {
 
 	handleRequest := NewHTTPHandler(c)
 
-	ops := map[string]string{
-		bridge.BridgeName:   "cdef",
+	dops := map[string]string{
+		bridge.BridgeName:  "cdef",
+		netlabel.DriverMTU: "1460",
+	}
+	nops := map[string]string{
 		netlabel.EnableIPv6: "true",
-		netlabel.DriverMTU:  "1460",
 	}
 
 	// Create network
-	nc := networkCreate{Name: "network-fiftyfive", NetworkType: bridgeNetType, DriverOpts: ops}
+	nc := networkCreate{Name: "network-fiftyfive", NetworkType: bridgeNetType, DriverOpts: dops, NetworkOpts: nops}
 	body, err := json.Marshal(nc)
 	if err != nil {
 		t.Fatal(err)

--- a/client/network.go
+++ b/client/network.go
@@ -43,6 +43,7 @@ func (cli *NetworkCli) CmdNetworkCreate(chain string, args ...string) error {
 	cmd := cli.Subcmd(chain, "create", "NETWORK-NAME", "Creates a new network with a name specified by the user", false)
 	flDriver := cmd.String([]string{"d", "-driver"}, "", "Driver to manage the Network")
 	flInternal := cmd.Bool([]string{"-internal"}, false, "Config the network to be internal")
+	flIPv6 := cmd.Bool([]string{"-ipv6"}, false, "Enable IPv6 on the network")
 	cmd.Require(flag.Exact, 1)
 	err := cmd.ParseFlags(args, true)
 	if err != nil {
@@ -51,6 +52,9 @@ func (cli *NetworkCli) CmdNetworkCreate(chain string, args ...string) error {
 	networkOpts := make(map[string]string)
 	if *flInternal {
 		networkOpts[netlabel.Internal] = "true"
+	}
+	if *flIPv6 {
+		networkOpts[netlabel.EnableIPv6] = "true"
 	}
 	// Construct network create request body
 	var driverOpts []string

--- a/default_gateway_linux.go
+++ b/default_gateway_linux.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 
 	"github.com/docker/libnetwork/drivers/bridge"
-	"github.com/docker/libnetwork/netlabel"
-	"github.com/docker/libnetwork/options"
 )
 
 func (c *controller) createGWNetwork() (Network, error) {
@@ -17,10 +15,9 @@ func (c *controller) createGWNetwork() (Network, error) {
 	}
 
 	n, err := c.NewNetwork("bridge", libnGWNetwork,
-		NetworkOptionGeneric(options.Generic{
-			netlabel.GenericData: netOption,
-			netlabel.EnableIPv6:  false,
-		}))
+		NetworkOptionDriverOpts(netOption),
+		NetworkOptionEnableIPv6(false),
+	)
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating external connectivity network: %v", err)

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -45,10 +45,6 @@ func TestCreateFullOptions(t *testing.T) {
 	br, _ := types.ParseCIDR("172.16.0.1/16")
 	defgw, _ := types.ParseCIDR("172.16.0.100/16")
 
-	netConfig := &networkConfiguration{
-		BridgeName: DefaultBridgeName,
-		EnableIPv6: true,
-	}
 	genericOption := make(map[string]interface{})
 	genericOption[netlabel.GenericData] = config
 
@@ -57,7 +53,10 @@ func TestCreateFullOptions(t *testing.T) {
 	}
 
 	netOption := make(map[string]interface{})
-	netOption[netlabel.GenericData] = netConfig
+	netOption[netlabel.EnableIPv6] = true
+	netOption[netlabel.GenericData] = &networkConfiguration{
+		BridgeName: DefaultBridgeName,
+	}
 
 	ipdList := []driverapi.IPAMData{
 		driverapi.IPAMData{
@@ -118,15 +117,15 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 	gwV6, _ := types.ParseCIDR(gwV6s)
 
 	labels := map[string]string{
-		BridgeName:          DefaultBridgeName,
-		DefaultBridge:       "true",
-		netlabel.EnableIPv6: "true",
-		EnableICC:           "true",
-		EnableIPMasquerade:  "true",
-		DefaultBindingIP:    bndIPs,
+		BridgeName:         DefaultBridgeName,
+		DefaultBridge:      "true",
+		EnableICC:          "true",
+		EnableIPMasquerade: "true",
+		DefaultBindingIP:   bndIPs,
 	}
 
 	netOption := make(map[string]interface{})
+	netOption[netlabel.EnableIPv6] = true
 	netOption[netlabel.GenericData] = labels
 
 	ipdList := getIPv4Data(t)
@@ -783,13 +782,13 @@ func TestSetDefaultGw(t *testing.T) {
 
 	config := &networkConfiguration{
 		BridgeName:         DefaultBridgeName,
-		EnableIPv6:         true,
 		AddressIPv6:        subnetv6,
 		DefaultGatewayIPv4: gw4,
 		DefaultGatewayIPv6: gw6,
 	}
 
 	genericOption := make(map[string]interface{})
+	genericOption[netlabel.EnableIPv6] = true
 	genericOption[netlabel.GenericData] = config
 
 	err := d.CreateNetwork("dummy", genericOption, ipdList, nil)

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -269,9 +269,9 @@ func TestBridge(t *testing.T) {
 	}
 
 	netOption := options.Generic{
+		netlabel.EnableIPv6: true,
 		netlabel.GenericData: options.Generic{
 			"BridgeName":         "testnetwork",
-			"EnableIPv6":         true,
 			"EnableICC":          true,
 			"EnableIPMasquerade": true,
 		},
@@ -323,7 +323,6 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 	netOption := options.Generic{
 		netlabel.GenericData: options.Generic{
 			"BridgeName":         "testipv6mac",
-			"EnableIPv6":         true,
 			"EnableICC":          true,
 			"EnableIPMasquerade": true,
 		},
@@ -333,6 +332,7 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 
 	network, err := controller.NewNetwork(bridgeNetType, "testipv6mac",
 		libnetwork.NetworkOptionGeneric(netOption),
+		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", ipamV4ConfList, ipamV6ConfList, nil),
 		libnetwork.NetworkOptionDeferIPv6Alloc(true))
 	if err != nil {
@@ -1008,7 +1008,6 @@ func TestEndpointJoin(t *testing.T) {
 	netOption := options.Generic{
 		netlabel.GenericData: options.Generic{
 			"BridgeName":         "testnetwork1",
-			"EnableIPv6":         true,
 			"EnableICC":          true,
 			"EnableIPMasquerade": true,
 		},
@@ -1016,6 +1015,7 @@ func TestEndpointJoin(t *testing.T) {
 	ipamV6ConfList := []*libnetwork.IpamConf{&libnetwork.IpamConf{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
 	n1, err := controller.NewNetwork(bridgeNetType, "testnetwork1",
 		libnetwork.NetworkOptionGeneric(netOption),
+		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", nil, ipamV6ConfList, nil),
 		libnetwork.NetworkOptionDeferIPv6Alloc(true))
 	if err != nil {


### PR DESCRIPTION
docker/docker#17513

Per point two at the end of https://github.com/docker/docker/pull/17513#issuecomment-164032291