### PR TITLE
Conform IPAM driver init to nw drivers init

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -180,8 +180,7 @@ func New(cfgOptions ...config.Option) (NetworkController, error) {
 		return nil, err
 	}
 
-	if err := initIpams(c, c.getStore(datastore.LocalScope),
-		c.getStore(datastore.GlobalScope)); err != nil {
+	if err := initIpams(c); err != nil {
 		return nil, err
 	}
 

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -46,6 +46,8 @@ type driver struct {
 
 // Init registers a new instance of overlay driver
 func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
+	var err error
+
 	c := driverapi.Capability{
 		DataScope: datastore.GlobalScope,
 	}
@@ -59,13 +61,7 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 	}
 
 	if data, ok := config[netlabel.GlobalKVClient]; ok {
-		var err error
-		dsc, ok := data.(discoverapi.DatastoreConfigData)
-		if !ok {
-			return types.InternalErrorf("incorrect data in datastore configuration: %v", data)
-		}
-		d.store, err = datastore.NewDataStoreFromConfig(dsc)
-		if err != nil {
+		if d.store, err = datastore.NewDataStoreFromConfig(data); err != nil {
 			return types.InternalErrorf("failed to initialize data store: %v", err)
 		}
 	}
@@ -204,11 +200,7 @@ func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) 
 		if d.store != nil {
 			return types.ForbiddenErrorf("cannot accept datastore configuration: Overlay driver has a datastore configured already")
 		}
-		dsc, ok := data.(discoverapi.DatastoreConfigData)
-		if !ok {
-			return types.InternalErrorf("incorrect data in datastore configuration: %v", data)
-		}
-		d.store, err = datastore.NewDataStoreFromConfig(dsc)
+		d.store, err = datastore.NewDataStoreFromConfig(data)
 		if err != nil {
 			return types.InternalErrorf("failed to initialize data store: %v", err)
 		}

--- a/ipams/builtin/builtin_unix.go
+++ b/ipams/builtin/builtin_unix.go
@@ -3,32 +3,13 @@
 package builtin
 
 import (
-	"fmt"
-
-	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/ipam"
 	"github.com/docker/libnetwork/ipamapi"
 )
 
 // Init registers the built-in ipam service with libnetwork
-func Init(ic ipamapi.Callback, l, g interface{}) error {
-	var (
-		ok                bool
-		localDs, globalDs datastore.DataStore
-	)
-
-	if l != nil {
-		if localDs, ok = l.(datastore.DataStore); !ok {
-			return fmt.Errorf("incorrect local datastore passed to built-in ipam init")
-		}
-	}
-
-	if g != nil {
-		if globalDs, ok = g.(datastore.DataStore); !ok {
-			return fmt.Errorf("incorrect global datastore passed to built-in ipam init")
-		}
-	}
-	a, err := ipam.NewAllocator(localDs, globalDs)
+func Init(ic ipamapi.Callback, config map[string]interface{}) error {
+	a, err := ipam.NewAllocator(config)
 	if err != nil {
 		return err
 	}

--- a/ipams/builtin/builtin_windows.go
+++ b/ipams/builtin/builtin_windows.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Init registers the built-in ipam service with libnetwork
-func Init(ic ipamapi.Callback, l, g interface{}) error {
+func Init(ic ipamapi.Callback, config map[string]interface{}) error {
 	initFunc := windowsipam.GetInit(ipamapi.DefaultIPAM)
 
-	return initFunc(ic, l, g)
+	return initFunc(ic, config)
 }

--- a/ipams/remote/remote.go
+++ b/ipams/remote/remote.go
@@ -29,7 +29,7 @@ func newAllocator(name string, client *plugins.Client) ipamapi.Ipam {
 }
 
 // Init registers a remote ipam when its plugin is activated
-func Init(cb ipamapi.Callback, l, g interface{}) error {
+func Init(cb ipamapi.Callback, config map[string]interface{}) error {
 	plugins.Handle(ipamapi.PluginEndpointType, func(name string, client *plugins.Client) {
 		a := newAllocator(name, client)
 		if cps, err := a.(*allocator).getCapabilities(); err == nil {

--- a/ipams/windowsipam/windowsipam.go
+++ b/ipams/windowsipam/windowsipam.go
@@ -22,8 +22,8 @@ type allocator struct {
 }
 
 // GetInit registers the built-in ipam service with libnetwork
-func GetInit(ipamName string) func(ic ipamapi.Callback, l, g interface{}) error {
-	return func(ic ipamapi.Callback, l, g interface{}) error {
+func GetInit(ipamName string) func(ic ipamapi.Callback, config map[string]interface{}) error {
+	return func(ic ipamapi.Callback, config map[string]interface{}) error {
 		return ic.RegisterIpamDriver(ipamName, &allocator{})
 	}
 }


### PR DESCRIPTION
- This conforms IPAM drivers init to network drivers init. And allows code reuse for datastore update handling code in ipam and overlay.

Signed-off-by: Alessandro Boch <aboch@docker.com>