### PR TITLE
Fix netns path setting from hook

### DIFF
--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -1232,10 +1232,6 @@ func TestExternalKey(t *testing.T) {
 	externalKeyTest(t, false)
 }
 
-func TestExternalKeyWithReexec(t *testing.T) {
-	externalKeyTest(t, true)
-}
-
 func externalKeyTest(t *testing.T, reexec bool) {
 	if !testutils.IsRunningInContainer() {
 		defer testutils.SetupTestOSContext(t)()

--- a/sandbox_externalkey_windows.go
+++ b/sandbox_externalkey_windows.go
@@ -11,7 +11,7 @@ import (
 
 // processSetKeyReexec is a private function that must be called only on an reexec path
 // It expects 3 args { [0] = "libnetwork-setkey", [1] = <container-id>, [2] = <controller-id> }
-// It also expects libcontainer.State as a json string in <stdin>
+// It also expects configs.HookState as a json string in <stdin>
 // Refer to https://github.com/opencontainers/runc/pull/160/ for more information
 func processSetKeyReexec() {
 }


### PR DESCRIPTION
Previously hook expected data with a wrong type.
Full netns path is not included with the data
passed with the hook.

Fixes #829

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>