### PR TITLE
Register natChain with portmapper

### DIFF
--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -115,7 +115,7 @@ func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInt
 			return iptables.ProgramChain(filterChain, config.BridgeName, hairpinMode, false)
 		})
 
-		n.portMapper.SetIptablesChain(filterChain, n.getNetworkBridgeName())
+		n.portMapper.SetIptablesChain(natChain, n.getNetworkBridgeName())
 	}
 
 	if err := ensureJumpRule("FORWARD", IsolationChain); err != nil {
@@ -148,6 +148,9 @@ func setupIPTablesInternal(bridgeIface string, addr net.Addr, icc, ipmasq, hairp
 		if err := programChainRule(natRule, "NAT", enable); err != nil {
 			return err
 		}
+	}
+
+	if ipmasq && !hairpin {
 		if err := programChainRule(skipDNAT, "SKIP DNAT", enable); err != nil {
 			return err
 		}


### PR DESCRIPTION
- On network creation bridge driver registers the `filter` iptables chain with portmapper. portmapper will invoke that chain's `Forward()` method when a endpoint with exposed ports joins the network. 
`Forward()` installs rules in the `nat` DOCKER chain and in the `filter` DOCKER chain (this works under the assumption `filter` and `nat` chains have same name...). When it works on the `nat` table chain, the rule is created differently based on whether the chain object has hairpin mode enabled.
The problem is that on `filter` chain creation the hairpin mode flag is no longer passed, it is always set to false. This will cause an incorrect `nat` rule configuration when `userland-proxy==false`.
Fix this by registering the bridge driver's `natChain` with portmapper on network creation.

- Also on network creation install the `skip DNAT` rule only when `userland-proxy==true`

Signed-off-by: Alessandro Boch <aboch@docker.com>