### PR TITLE
Add Santhosh as libnetwork maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -16,6 +16,7 @@
 			"icecrime",
 			"mrjana",
 			"mavenugo",
+                        "sanimej",
 		]
 
 [people]
@@ -50,3 +51,8 @@
 	Name = "Madhu Venugopal"
 	Email = "madhu@docker.com"
 	GitHub = "mavenugo"
+
+	[people.sanimej]
+	Name = "Santhosh Manohar"
+	Email = "santhosh@docker.com"
+	GitHub = "sanimej"


### PR DESCRIPTION

Santhosh has been contributing to various features in 1.9 & 1.10 releases and an active maintainer who helps with bug fixes and PR reviews

Signed-off-by: Madhu Venugopal <madhu@docker.com>