### PR TITLE
Fixing bulid break because of improper formatting in windows_test.go

### DIFF
--- a/drivers/windows/windows_test.go
+++ b/drivers/windows/windows_test.go
@@ -23,7 +23,7 @@ func testNetwork(networkType string, t *testing.T) {
 
 	netOption[netlabel.GenericData] = networkOptions
 	ipdList := []driverapi.IPAMData{
-		driverapi.IPAMData{
+		{
 			Pool:    bnw,
 			Gateway: br,
 		},


### PR DESCRIPTION
Signed-off-by: msabansal <sabansal@microsoft.com>