### PR TITLE
Fix error message on bridge network creation conflict.

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -581,7 +581,7 @@ func (d *driver) createNetwork(config *networkConfiguration) error {
 		nw.Unlock()
 		if err := nwConfig.Conflicts(config); err != nil {
 			return types.ForbiddenErrorf("cannot create network %s (%s): conflicts with network %s (%s): %s",
-				nwConfig.BridgeName, config.ID, nw.id, nw.config.BridgeName, err.Error())
+				config.ID, config.BridgeName, nwConfig.ID, nwConfig.BridgeName, err.Error())
 		}
 	}
 


### PR DESCRIPTION
We now report the correct bridge name and network id when
reporting a conflict.

This fixes #914 

Note that `make all` resulted in a few failures, but that seem to be because I'm not able to ping external host from my work network (and some tests ping google.com), not due to this changeset.