### PR TITLE
add a option to disable initialization of specific driver

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,12 +21,13 @@ type Config struct {
 
 // DaemonCfg represents libnetwork core configuration
 type DaemonCfg struct {
-	Debug          bool
-	DataDir        string
-	DefaultNetwork string
-	DefaultDriver  string
-	Labels         []string
-	DriverCfg      map[string]interface{}
+	Debug             bool
+	DataDir           string
+	DefaultNetwork    string
+	DefaultDriver     string
+	Labels            []string
+	DriverCfg         map[string]interface{}
+	UnsupportedDriver map[string]interface{}
 }
 
 // ClusterCfg represents cluster configuration
@@ -66,7 +67,8 @@ func ParseConfig(tomlCfgFile string) (*Config, error) {
 func ParseConfigOptions(cfgOptions ...Option) *Config {
 	cfg := &Config{
 		Daemon: DaemonCfg{
-			DriverCfg: make(map[string]interface{}),
+			DriverCfg:         make(map[string]interface{}),
+			UnsupportedDriver: make(map[string]interface{}),
 		},
 		Scopes: make(map[string]*datastore.ScopeCfg),
 	}
@@ -239,5 +241,13 @@ func OptionLocalKVProviderConfig(config *store.Config) Option {
 			c.Scopes[datastore.LocalScope] = &datastore.ScopeCfg{}
 		}
 		c.Scopes[datastore.LocalScope].Client.Config = config
+	}
+}
+
+// OptionUnsupportedDriver function returns an option setter for a unsupported driver
+func OptionUnsupportedDriver(ud string) Option {
+	return func(c *Config) {
+		log.Debugf("Option UnsupportDriver: %s", ud)
+		c.Daemon.UnsupportedDriver[ud] = nil
 	}
 }

--- a/drivers.go
+++ b/drivers.go
@@ -19,8 +19,10 @@ type initializer struct {
 
 func initDrivers(c *controller) error {
 	for _, i := range getInitializers() {
-		if err := i.fn(c, makeDriverConfig(c, i.ntype)); err != nil {
-			return err
+		if _, ok := c.cfg.Daemon.UnsupportedDriver[i.ntype]; !ok {
+			if err := i.fn(c, makeDriverConfig(c, i.ntype)); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
@@ -454,4 +455,16 @@ func (b *badDriver) DiscoverDelete(dType discoverapi.DiscoveryType, data interfa
 }
 func (b *badDriver) Type() string {
 	return badDriverName
+}
+
+func TestUnsupportedDriver(t *testing.T) {
+	bridgeNetType := "bridge"
+	c, err := New(config.OptionUnsupportedDriver("bridge"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Stop()
+	if _, err := c.(*controller).NewNetwork(bridgeNetType, "dummy"); err == nil {
+		t.Fatalf("Expecting the NewNetwork to faild for %s", bridgeNetType)
+	}
 }


### PR DESCRIPTION
When user's machine does not support some driver such as bridge, we should not initialize the driver, so this PR adds a option to disable specific driver intialization.
Signed-off-by: mYmNeo <mymneo@163.com>