### PR TITLE
Fix some typos in comments and strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@
 - DEPRECATE service discovery from default bridge network
 - Introduced new network UX
 - Support for multiple networks in bridge driver
-- Local persistance with boltdb
+- Local persistence with boltdb
 
 ## 0.4.0 (2015-07-24)
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -709,7 +709,7 @@ func TestProcGetService(t *testing.T) {
 	vars := map[string]string{urlEpID: ""}
 	_, errRsp := procGetService(c, vars, nil)
 	if errRsp.isOK() {
-		t.Fatalf("Expected failure, but suceeded")
+		t.Fatalf("Expected failure, but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("Expected %d, but got: %d", http.StatusBadRequest, errRsp.StatusCode)
@@ -718,7 +718,7 @@ func TestProcGetService(t *testing.T) {
 	vars[urlEpID] = "unknown-service-id"
 	_, errRsp = procGetService(c, vars, nil)
 	if errRsp.isOK() {
-		t.Fatalf("Expected failure, but suceeded")
+		t.Fatalf("Expected failure, but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusNotFound {
 		t.Fatalf("Expected %d, but got: %d. (%v)", http.StatusNotFound, errRsp.StatusCode, errRsp)
@@ -864,7 +864,7 @@ func TestProcPublishUnpublishService(t *testing.T) {
 
 	_, errRsp = procGetService(c, vars, nil)
 	if errRsp.isOK() {
-		t.Fatalf("Expected failure, but suceeded")
+		t.Fatalf("Expected failure, but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusNotFound {
 		t.Fatalf("Expected %d, but got: %d. (%v)", http.StatusNotFound, errRsp.StatusCode, errRsp)
@@ -1545,7 +1545,7 @@ func checkPanic(t *testing.T) {
 			panic(r)
 		}
 	} else {
-		t.Fatalf("Expected to panic, but suceeded")
+		t.Fatalf("Expected to panic, but succeeded")
 	}
 }
 

--- a/bitseq/sequence.go
+++ b/bitseq/sequence.go
@@ -163,7 +163,7 @@ func (s *sequence) toByteArray() ([]byte, error) {
 func (s *sequence) fromByteArray(data []byte) error {
 	l := len(data)
 	if l%12 != 0 {
-		return fmt.Errorf("cannot deserialize byte sequence of lenght %d (%v)", l, data)
+		return fmt.Errorf("cannot deserialize byte sequence of length %d (%v)", l, data)
 	}
 
 	p := s

--- a/controller.go
+++ b/controller.go
@@ -170,7 +170,7 @@ func New(cfgOptions ...config.Option) (NetworkController, error) {
 
 	if c.cfg != nil && c.cfg.Cluster.Watcher != nil {
 		if err := c.initDiscovery(c.cfg.Cluster.Watcher); err != nil {
-			// Failing to initalize discovery is a bad situation to be in.
+			// Failing to initialize discovery is a bad situation to be in.
 			// But it cannot fail creating the Controller
 			log.Errorf("Failed to Initialize Discovery : %v", err)
 		}

--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -89,7 +89,7 @@ type JoinInfo interface {
 	SetGatewayIPv6(net.IP) error
 
 	// AddStaticRoute adds a route to the sandbox.
-	// It may be used in addtion to or instead of a default gateway (as above).
+	// It may be used in addition to or instead of a default gateway (as above).
 	AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error
 
 	// DisableGatewayService tells libnetwork not to provide Default GW for the container

--- a/driverapi/driverapi_test.go
+++ b/driverapi/driverapi_test.go
@@ -87,7 +87,7 @@ func TestValidateAndIsV6(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err = i.Validate(); err == nil {
-		t.Fatalf("expected error but succeded")
+		t.Fatalf("expected error but succeeded")
 	}
 	i.Gateway = nil
 
@@ -96,7 +96,7 @@ func TestValidateAndIsV6(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err = i.Validate(); err == nil {
-		t.Fatalf("expected error but succeded")
+		t.Fatalf("expected error but succeeded")
 	}
 	delete(i.AuxAddresses, "ip2")
 
@@ -105,7 +105,7 @@ func TestValidateAndIsV6(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err = i.Validate(); err == nil {
-		t.Fatalf("expected error but succeded")
+		t.Fatalf("expected error but succeeded")
 	}
 	i.Gateway = nil
 
@@ -114,6 +114,6 @@ func TestValidateAndIsV6(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err = i.Validate(); err == nil {
-		t.Fatalf("expected error but succeded")
+		t.Fatalf("expected error but succeeded")
 	}
 }

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -183,7 +183,7 @@ func (c *networkConfiguration) Conflicts(o *networkConfiguration) error {
 		return fmt.Errorf("same configuration")
 	}
 
-	// Also empty, becasue only one network with empty name is allowed
+	// Also empty, because only one network with empty name is allowed
 	if c.BridgeName == o.BridgeName {
 		return fmt.Errorf("networks have same bridge name")
 	}
@@ -450,7 +450,7 @@ func parseNetworkGenericOptions(data interface{}) (*networkConfiguration, error)
 
 func (c *networkConfiguration) processIPAM(id string, ipamV4Data, ipamV6Data []driverapi.IPAMData) error {
 	if len(ipamV4Data) > 1 || len(ipamV6Data) > 1 {
-		return types.ForbiddenErrorf("bridge driver doesnt support multiple subnets")
+		return types.ForbiddenErrorf("bridge driver doesn't support multiple subnets")
 	}
 
 	if len(ipamV4Data) == 0 {

--- a/drivers/overlay/filter.go
+++ b/drivers/overlay/filter.go
@@ -78,7 +78,7 @@ func setFilters(cname, brName string, remove bool) error {
 		opt = "-D"
 	}
 
-	// Everytime we set filters for a new subnet make sure to move the global overlay hook to the top of the both the OUTPUT and forward chains
+	// Every time we set filters for a new subnet make sure to move the global overlay hook to the top of the both the OUTPUT and forward chains
 	if !remove {
 		for _, chain := range []string{"OUTPUT", "FORWARD"} {
 			exists := iptables.Exists(iptables.Filter, chain, "-j", globalChain)

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -126,7 +126,7 @@ func (d *driver) parseNetworkOptions(id string, genericOptions map[string]string
 
 func (c *networkConfiguration) processIPAM(id string, ipamV4Data, ipamV6Data []driverapi.IPAMData) error {
 	if len(ipamV6Data) > 0 {
-		return types.ForbiddenErrorf("windowsshim driver doesnt support v6 subnets")
+		return types.ForbiddenErrorf("windowsshim driver doesn't support v6 subnets")
 	}
 
 	if len(ipamV4Data) == 0 {

--- a/ipams/windowsipam/windowsipam.go
+++ b/ipams/windowsipam/windowsipam.go
@@ -33,7 +33,7 @@ func (a *allocator) GetDefaultAddressSpaces() (string, string, error) {
 }
 
 // RequestPool returns an address pool along with its unique id. This is a null ipam driver. It allocates the
-// subnet user asked and does not validate anything. Doesnt support subpool allocation
+// subnet user asked and does not validate anything. Doesn't support subpool allocation
 func (a *allocator) RequestPool(addressSpace, pool, subPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
 	log.Debugf("RequestPool(%s, %s, %s, %v, %t)", addressSpace, pool, subPool, options, v6)
 	if subPool != "" || v6 {

--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -44,7 +44,7 @@ func TestIpamDriverRegistration(t *testing.T) {
 
 	err = c.(*controller).RegisterIpamDriver("", nil)
 	if err == nil {
-		t.Fatalf("Expected failure, but suceeded")
+		t.Fatalf("Expected failure, but succeeded")
 	}
 	if _, ok := err.(types.BadRequestError); !ok {
 		t.Fatalf("Failed for unexpected reason: %v", err)
@@ -52,7 +52,7 @@ func TestIpamDriverRegistration(t *testing.T) {
 
 	err = c.(*controller).RegisterIpamDriver(ipamapi.DefaultIPAM, nil)
 	if err == nil {
-		t.Fatalf("Expected failure, but suceeded")
+		t.Fatalf("Expected failure, but succeeded")
 	}
 	if _, ok := err.(types.ForbiddenError); !ok {
 		t.Fatalf("Failed for unexpected reason: %v", err)

--- a/network.go
+++ b/network.go
@@ -600,7 +600,7 @@ func (n *network) driver(load bool) (driverapi.Driver, error) {
 			return nil, err
 		}
 	} else if !ok {
-		// dont fail if driver loading is not required
+		// don't fail if driver loading is not required
 		return nil, nil
 	}
 

--- a/sandbox.go
+++ b/sandbox.go
@@ -466,7 +466,7 @@ func (sb *sandbox) resolveName(req string, networkName string, epList []*endpoin
 			}
 		} else {
 			// If it is a regular lookup and if the requested name is an alias
-			// dont perform a svc lookup for this endpoint.
+			// don't perform a svc lookup for this endpoint.
 			ep.Lock()
 			if _, ok := ep.aliases[req]; ok {
 				ep.Unlock()

--- a/sandbox_externalkey_unix.go
+++ b/sandbox_externalkey_unix.go
@@ -130,7 +130,7 @@ func (c *controller) acceptClientConnections(sock string, l net.Listener) {
 		conn, err := l.Accept()
 		if err != nil {
 			if _, err1 := os.Stat(sock); os.IsNotExist(err1) {
-				logrus.Debugf("Unix socket %s doesnt exist. cannot accept client connections", sock)
+				logrus.Debugf("Unix socket %s doesn't exist. cannot accept client connections", sock)
 				return
 			}
 			logrus.Errorf("Error accepting connection %v", err)

--- a/test/integration/dnet/helpers.bash
+++ b/test/integration/dnet/helpers.bash
@@ -476,20 +476,20 @@ function test_overlay_hostmode() {
 	    hrun runc $(dnet_container_name 1 $dnet_suffix) $(get_sbox_id 1 mh2_${i}) "nslookup mh2_$j"
 	    mh2_j_ip=$(echo ${output} | awk '{print $11}')
 
-	    # Ping the j containers in the same network and ensure they are successfull
+	    # Ping the j containers in the same network and ensure they are successful
 	    runc $(dnet_container_name 1 $dnet_suffix) $(get_sbox_id 1 mh1_${i}) \
 		 "ping -c 1 mh1_$j"
 	    runc $(dnet_container_name 1 $dnet_suffix) $(get_sbox_id 1 mh2_${i}) \
 		 "ping -c 1 mh2_$j"
 
-	    # Try pinging j container IPs from the container in the other network and make sure that they are not successfull
+	    # Try pinging j container IPs from the container in the other network and make sure that they are not successful
 	    runc_nofail $(dnet_container_name 1 $dnet_suffix) $(get_sbox_id 1 mh1_${i}) "ping -c 1 ${mh2_j_ip}"
 	    [ "${status}" -ne 0 ]
 
 	    runc_nofail $(dnet_container_name 1 $dnet_suffix) $(get_sbox_id 1 mh2_${i}) "ping -c 1 ${mh1_j_ip}"
 	    [ "${status}" -ne 0 ]
 
-	    # Try pinging the j container IPS from the host(dnet container in this case) and make syre that they are not successfull
+	    # Try pinging the j container IPS from the host(dnet container in this case) and make syre that they are not successful
 	    hrun docker exec -it $(dnet_container_name 1 $dnet_suffix) "ping -c 1 ${mh1_j_ip}"
 	    [ "${status}" -ne 0 ]
 


### PR DESCRIPTION
All of them were found and fixed by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>