### PR TITLE
Fixed IP information not displayed properly in docker network inspect on Windows

### DIFF
--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -186,8 +186,11 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, ipV4Dat
 
 		for _, ipData := range ipV4Data {
 			subnet := hcsshim.Subnet{
-				AddressPrefix:  ipData.Pool.String(),
-				GatewayAddress: ipData.Gateway.IP.String(),
+				AddressPrefix: ipData.Pool.String(),
+			}
+
+			if ipData.Gateway != nil {
+				subnet.GatewayAddress = ipData.Gateway.IP.String()
 			}
 
 			subnets = append(subnets, subnet)

--- a/endpoint.go
+++ b/endpoint.go
@@ -957,9 +957,13 @@ func (ep *endpoint) releaseAddress() {
 		log.Warnf("Failed to retrieve ipam driver to release interface address on delete of endpoint %s (%s): %v", ep.Name(), ep.ID(), err)
 		return
 	}
-	if err := ipam.ReleaseAddress(ep.iface.v4PoolID, ep.iface.addr.IP); err != nil {
-		log.Warnf("Failed to release ip address %s on delete of endpoint %s (%s): %v", ep.iface.addr.IP, ep.Name(), ep.ID(), err)
+
+	if ep.iface.addr != nil {
+		if err := ipam.ReleaseAddress(ep.iface.v4PoolID, ep.iface.addr.IP); err != nil {
+			log.Warnf("Failed to release ip address %s on delete of endpoint %s (%s): %v", ep.iface.addr.IP, ep.Name(), ep.ID(), err)
+		}
 	}
+
 	if ep.iface.addrv6 != nil && ep.iface.addrv6.IP.IsGlobalUnicast() {
 		if err := ipam.ReleaseAddress(ep.iface.v6PoolID, ep.iface.addrv6.IP); err != nil {
 			log.Warnf("Failed to release ip address %s on delete of endpoint %s (%s): %v", ep.iface.addrv6.IP, ep.Name(), ep.ID(), err)

--- a/ipams/windowsipam/windowsipam_test.go
+++ b/ipams/windowsipam/windowsipam_test.go
@@ -51,7 +51,7 @@ func TestWindowsIPAM(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !types.CompareIPNet(ip, requestPool) {
+	if ip != nil {
 		t.Fatalf("Unexpected data returned. Expected %v . Got: %v ", requestPool, ip)
 	}
 


### PR DESCRIPTION
The information was not being displayed because we were trying to set the IP already set through IPAM. Fixing windows IPAM to return nil IP so that it can be overridden once we receive IP from HNS

CI run results:
PS C:\gopath\src\github.com\docker\libnetwork\drivers\windows> godep go test -v
=== RUN   TestNAT
--- PASS: TestNAT (1.06s)
=== RUN   TestTransparent
--- PASS: TestTransparent (13.46s)
PASS
ok      github.com/docker/libnetwork/drivers/windows    14.605s
PS C:\gopath\src\github.com\docker\libnetwork\drivers\windows> godep go test -v
=== RUN   TestNAT
--- PASS: TestNAT (0.86s)
=== RUN   TestTransparent
--- PASS: TestTransparent (13.57s)
PASS
ok      github.com/docker/libnetwork/drivers/windows    14.463s