### PR TITLE
Avoid network/endpoint_count inconsistences

### DIFF
--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -252,15 +252,6 @@ func TestHost(t *testing.T) {
 	if err := ep3.Delete(false); err != nil {
 		t.Fatal(err)
 	}
-
-	// host type is special network. Cannot be removed.
-	err = network.Delete()
-	if err == nil {
-		t.Fatal(err)
-	}
-	if _, ok := err.(types.ForbiddenError); !ok {
-		t.Fatalf("Unexpected error type")
-	}
 }
 
 func TestBridge(t *testing.T) {


### PR DESCRIPTION
- ... on ungraceful shutdown during network create
- Allow forceful deletion of network
- On network delete, first mark the network for deletion
- On controller creation, first forcefully remove any network
  that is marked for deletion.

Related to https://github.com/docker/docker/issues/20312

Signed-off-by: Alessandro Boch <aboch@docker.com>