### PR TITLE
Fix veth leak in overlay driver

### DIFF
--- a/drivers/overlay/joinleave.go
+++ b/drivers/overlay/joinleave.go
@@ -54,7 +54,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		return err
 	}
 
-	ep.ifName = overlayIfName
+	ep.ifName = containerIfName
 
 	// Set the container interface and its peer MTU to 1450 to allow
 	// for 50 bytes vxlan encap (inner eth header(14) + outer IP(20) +


### PR DESCRIPTION
- Because of the lazy logic in Leave(), the overlay
  veth end is not moved from the sandbox to the host
  network namspace until the last endpoint leaves.
  We cannot rely on this logic to clear the veth pairs,
  because on last endpoint leave we have no reference to
  the other N-1 veth names.

- The fix is to delete the container veth end on endpoint delete.
  This anyways deletes both veth ends, regardless they are in different
  namespaces.

~~Note: I'd be happy to remove the code at https://github.com/docker/libnetwork/blob/master/drivers/overlay/ov_network.go#L173
as it is no longer needed.~~ [That cannot be removed as it was not intended to handle the veth pairs that connect to the container sandbox]

Fixes #984

Signed-off-by: Alessandro Boch <aboch@docker.com>