### PR TITLE
Fix docker IT failures for 0.7.0-dev.4 vendoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.0-dev.5 (2016-03-08)
+- Fixes https://github.com/docker/docker/issues/20847
+- Fixes https://github.com/docker/docker/issues/20997
+- Fixes issues unveiled by docker integ test over 0.7.0-dev.4
+
 ## 0.7.0-dev.4 (2016-03-07)
 - Changed ownership of exposed ports and port-mapping options from Endpoint to Sandbox
 - Implement DNS RR in the Docker embedded DNS server

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -1362,26 +1362,22 @@ func parseContainerOptions(cOptions map[string]interface{}) (*containerConfigura
 	if cOptions == nil {
 		return nil, nil
 	}
-
-	cc := &containerConfiguration{}
-
-	if opt, ok := cOptions[ParentEndpoints]; ok {
-		if pe, ok := opt.([]string); ok {
-			cc.ParentEndpoints = pe
-		} else {
-			return nil, types.BadRequestErrorf("Invalid parent endpoints data in sandbox configuration: %v", opt)
-		}
+	genericData := cOptions[netlabel.GenericData]
+	if genericData == nil {
+		return nil, nil
 	}
-
-	if opt, ok := cOptions[ChildEndpoints]; ok {
-		if ce, ok := opt.([]string); ok {
-			cc.ChildEndpoints = ce
-		} else {
-			return nil, types.BadRequestErrorf("Invalid child endpoints data in sandbox configuration: %v", opt)
+	switch opt := genericData.(type) {
+	case options.Generic:
+		opaqueConfig, err := options.GenerateFromModel(opt, &containerConfiguration{})
+		if err != nil {
+			return nil, err
 		}
+		return opaqueConfig.(*containerConfiguration), nil
+	case *containerConfiguration:
+		return opt, nil
+	default:
+		return nil, nil
 	}
-
-	return cc, nil
 }
 
 func parseConnectivityOptions(cOptions map[string]interface{}) (*connectivityConfiguration, error) {

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/libnetwork/ipamutils"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/netlabel"
+	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
 )
@@ -599,7 +600,9 @@ func TestLinkContainers(t *testing.T) {
 	}
 
 	sbOptions = make(map[string]interface{})
-	sbOptions[ChildEndpoints] = []string{"ep1"}
+	sbOptions[netlabel.GenericData] = options.Generic{
+		"ChildEndpoints": []string{"ep1"},
+	}
 
 	err = d.Join("net1", "ep2", "", te2, sbOptions)
 	if err != nil {
@@ -655,7 +658,9 @@ func TestLinkContainers(t *testing.T) {
 
 	// Error condition test with an invalid endpoint-id "ep4"
 	sbOptions = make(map[string]interface{})
-	sbOptions[ChildEndpoints] = []string{"ep1", "ep4"}
+	sbOptions[netlabel.GenericData] = options.Generic{
+		"ChildEndpoints": []string{"ep1", "ep4"},
+	}
 
 	err = d.Join("net1", "ep2", "", te2, sbOptions)
 	if err != nil {

--- a/drivers/bridge/labels.go
+++ b/drivers/bridge/labels.go
@@ -15,10 +15,4 @@ const (
 
 	// DefaultBridge label
 	DefaultBridge = "com.docker.network.bridge.default_bridge"
-
-	// ChildEndpoints for links
-	ChildEndpoints = "com.docker.network.bridge.child_endpoints"
-
-	// ParentEndpoints for links
-	ParentEndpoints = "com.docker.network.bridge.parent_endpoints"
 )

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -306,6 +306,8 @@ func Exists(table Table, chain string, rule ...string) bool {
 		table = Filter
 	}
 
+	initCheck()
+
 	if supportsCOpt {
 		// if exit status is 0 then return true, the rule exists
 		_, err := Raw(append([]string{"-t", string(table), "-C", chain}, rule...)...)


### PR DESCRIPTION
- Fix npe in sbJoin error path
- Fail again endpoint Join in case of failure
  in programming the external connectivity
- In bridge, look for parent and child container configs
  in the generic data
- iptables.Exists() might be called before any other call to
  iptables.raw(). We need to call checkInit() then.

Signed-off-by: Alessandro Boch <aboch@docker.com>