### PR TITLE
Close dbus connection if firewalld is not started

### DIFF
--- a/iptables/firewalld.go
+++ b/iptables/firewalld.go
@@ -44,11 +44,15 @@ func FirewalldInit() error {
 	if connection, err = newConnection(); err != nil {
 		return fmt.Errorf("Failed to connect to D-Bus system bus: %v", err)
 	}
+	firewalldRunning = checkRunning()
+	if !firewalldRunning {
+		connection.sysconn.Close()
+		connection = nil
+	}
 	if connection != nil {
 		go signalHandler()
 	}
 
-	firewalldRunning = checkRunning()
 	return nil
 }
 


### PR DESCRIPTION
It closes 3 unused goroutines. I don't think that it's good pattern to wait for some software forever.