### PR TITLE
Added kernel version checks for macvlan/ipvlan

### DIFF
--- a/drivers/ipvlan/ipvlan_setup.go
+++ b/drivers/ipvlan/ipvlan_setup.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	dummyPrefix     = "di-"  // ipvlan prefix for dummy parent interface
-	ipvlanKernelVer = "3.19" // minimum ipvlan kernel version support
+	dummyPrefix     = "di-" // ipvlan prefix for dummy parent interface
+	ipvlanKernelVer = 4     // minimum ipvlan kernel support
+	ipvlanMajorVer  = 0     // minimum ipvlan major kernel support
 )
 
 // createIPVlan Create the ipvlan slave specifying the source name

--- a/drivers/macvlan/macvlan_setup.go
+++ b/drivers/macvlan/macvlan_setup.go
@@ -15,7 +15,8 @@ import (
 
 const (
 	dummyPrefix      = "dm-" // macvlan prefix for dummy parent interface
-	macvlanKernelVer = "3.9" // minimum ipvlan kernel version support
+	macvlanKernelVer = 3     // minimum macvlan kernel support
+	macvlanMajorVer  = 9     // minimum macvlan major kernel support
 )
 
 // Create the macvlan slave specifying the source name


### PR DESCRIPTION
ipvlan >= 4.0.0 due to early instability
macvlan >= 3.9

Signed-off-by: Brent Salisbury <brent@docker.com>