### PR TITLE
Fixing a possible endpoint_cnt state inconsistency issue

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -1000,5 +1000,17 @@ func (c *controller) cleanupLocalEndpoints() {
 				log.Warnf("Could not delete local endpoint %s during endpoint cleanup: %v", ep.name, err)
 			}
 		}
+
+		epl, err = n.getEndpointsFromStore()
+		if err != nil {
+			log.Warnf("Could not get list of endpoints in network %s for count update: %v", n.name, err)
+			continue
+		}
+
+		epCnt := n.getEpCnt().EndpointCnt()
+		if epCnt != uint64(len(epl)) {
+			log.Warnf("Inconsistent endpoint_cnt for network %s. Expected=%d, Actual=%d", n.name, len(epl), epCnt)
+			n.getEpCnt().setCnt(uint64(len(epl)))
+		}
 	}
 }

--- a/endpoint_cnt.go
+++ b/endpoint_cnt.go
@@ -123,6 +123,13 @@ func (ec *endpointCnt) updateStore() error {
 	}
 }
 
+func (ec *endpointCnt) setCnt(cnt uint64) error {
+	ec.Lock()
+	ec.Count = cnt
+	ec.Unlock()
+	return ec.updateStore()
+}
+
 func (ec *endpointCnt) atomicIncDecEpCnt(inc bool) error {
 retry:
 	ec.Lock()


### PR DESCRIPTION
During ungraceful shutdown, it is possible that the endpoint_cnt can be
inconsistent with the actual endpoints in a network. This fix will
resolve that inconsistency

Signed-off-by: Madhu Venugopal <madhu@docker.com>