### PR TITLE
Clear cached udp connections on resolver Stop()

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -139,6 +139,11 @@ func (r *resolver) Start() error {
 }
 
 func (r *resolver) Stop() {
+	for i := 0; i < maxExtDNS; i++ {
+		r.extDNSList[i].extConn = nil
+		r.extDNSList[i].extOnce = sync.Once{}
+	}
+
 	if r.server != nil {
 		r.server.Shutdown()
 	}


### PR DESCRIPTION
If the cached connections are not cleared sending the query to the corresponding external server fails for containers with the restart policy configured.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>