### PR TITLE
Fix nil pointer reference in ServeDNS() with concurrent go routines.

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -324,6 +324,13 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 					continue
 				}
 			}
+			// If two go routines are executing in parralel one will
+			// block on the Once.Do and in case of error connecting
+			// to the external server it will end up with a nil err
+			// but extConn also being nil.
+			if extConn == nil {
+				continue
+			}
 
 			// Timeout has to be set for every IO operation.
 			extConn.SetDeadline(time.Now().Add(extIOTimeout))


### PR DESCRIPTION
related to [docker #21240] (https://github.com/docker/docker/issues/21240)

Signed-off-by: Santhosh Manohar <santhosh@docker.com>