### PR TITLE
Don't quote the addresses when we hit errors setting interface addresses

### DIFF
--- a/osl/interface_linux.go
+++ b/osl/interface_linux.go
@@ -313,8 +313,8 @@ func configureInterface(iface netlink.Link, i *nwIface) error {
 	}{
 		{setInterfaceName, fmt.Sprintf("error renaming interface %q to %q", ifaceName, i.DstName())},
 		{setInterfaceMAC, fmt.Sprintf("error setting interface %q MAC to %q", ifaceName, i.MacAddress())},
-		{setInterfaceIP, fmt.Sprintf("error setting interface %q IP to %q", ifaceName, i.Address())},
-		{setInterfaceIPv6, fmt.Sprintf("error setting interface %q IPv6 to %q", ifaceName, i.AddressIPv6())},
+		{setInterfaceIP, fmt.Sprintf("error setting interface %q IP to %v", ifaceName, i.Address())},
+		{setInterfaceIPv6, fmt.Sprintf("error setting interface %q IPv6 to %v", ifaceName, i.AddressIPv6())},
 		{setInterfaceMaster, fmt.Sprintf("error setting interface %q master to %q", ifaceName, i.DstMaster())},
 	}
 


### PR DESCRIPTION
Before we call setInterfaceIP() and setInterfaceIPv6(), we construct partial error messages for use if they return errors.  While both functions check for nil addresses, we don't guard against passing nil
addresses to fmt.Sprintf when constructing those messages, which causes us to panic if they're nil.  Add wrappers that supply the text "(no address)" when the address is nil.