### PR TITLE
Make local connections persistent.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -171,6 +171,13 @@ func OptionKVOpts(opts map[string]string) Option {
 	}
 }
 
+// OptionKVStore function returns an option setter for a cluster store scope.
+func OptionKVStore(scope string, store *datastore.ScopeCfg) Option {
+	return func(c *Config) {
+		c.Scopes[scope] = store
+	}
+}
+
 // OptionDiscoveryWatcher function returns an option setter for discovery watcher
 func OptionDiscoveryWatcher(watcher discovery.Watcher) Option {
 	return func(c *Config) {

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -166,6 +166,15 @@ func DefaultScopes(dataDir string) map[string]*ScopeCfg {
 	return defaultScopes
 }
 
+// PersistConnection returns true if the client
+// is configured to persist the connection.
+func (cfg *ScopeCfg) PersistConnection() bool {
+	if cfg.Client.Config == nil {
+		return false
+	}
+	return cfg.Client.Config.PersistConnection
+}
+
 // IsValid checks if the scope config has valid configuration.
 func (cfg *ScopeCfg) IsValid() bool {
 	if cfg == nil ||

--- a/drivers.go
+++ b/drivers.go
@@ -19,55 +19,55 @@ type initializer struct {
 }
 
 func initDrivers(c *controller) error {
+	scopesConfig := make(map[string]interface{})
+
+	for k, v := range c.cfg.Scopes {
+		if v.PersistConnection() {
+			scopesConfig[netlabel.MakeKVStore(k)] = c.getStore(k)
+		} else {
+			if !v.IsValid() {
+				continue
+			}
+
+			scopesConfig[netlabel.MakeKVClient(k)] = discoverapi.DatastoreConfigData{
+				Scope:    k,
+				Provider: v.Client.Provider,
+				Address:  v.Client.Address,
+				Config:   v.Client.Config,
+			}
+		}
+	}
+
 	for _, i := range getInitializers() {
-		if err := i.fn(c, makeDriverConfig(c, i.ntype)); err != nil {
+		config := make(map[string]interface{})
+
+		if drvCfg, ok := c.cfg.Daemon.DriverCfg[i.ntype]; ok {
+			for k, v := range drvCfg.(map[string]interface{}) {
+				config[k] = v
+			}
+		}
+
+		for _, label := range c.cfg.Daemon.Labels {
+			if !strings.HasPrefix(netlabel.Key(label), netlabel.DriverPrefix+"."+i.ntype) {
+				continue
+			}
+
+			config[netlabel.Key(label)] = netlabel.Value(label)
+		}
+
+		// We don't send datastore configs to external plugins
+		if i.ntype != "remote" {
+			for sk, sv := range scopesConfig {
+				config[sk] = sv
+			}
+		}
+
+		if err := i.fn(c, config); err != nil {
 			return err
 		}
 	}
 
 	return nil
-}
-
-func makeDriverConfig(c *controller, ntype string) map[string]interface{} {
-	if c.cfg == nil {
-		return nil
-	}
-
-	config := make(map[string]interface{})
-
-	for _, label := range c.cfg.Daemon.Labels {
-		if !strings.HasPrefix(netlabel.Key(label), netlabel.DriverPrefix+"."+ntype) {
-			continue
-		}
-
-		config[netlabel.Key(label)] = netlabel.Value(label)
-	}
-
-	drvCfg, ok := c.cfg.Daemon.DriverCfg[ntype]
-	if ok {
-		for k, v := range drvCfg.(map[string]interface{}) {
-			config[k] = v
-		}
-	}
-
-	// We don't send datastore configs to external plugins
-	if ntype == "remote" {
-		return config
-	}
-
-	for k, v := range c.cfg.Scopes {
-		if !v.IsValid() {
-			continue
-		}
-		config[netlabel.MakeKVClient(k)] = discoverapi.DatastoreConfigData{
-			Scope:    k,
-			Provider: v.Client.Provider,
-			Address:  v.Client.Address,
-			Config:   v.Client.Config,
-		}
-	}
-
-	return config
 }
 
 func initIpams(ic ipamapi.Callback, lDs, gDs interface{}) error {

--- a/drivers/bridge/bridge_store.go
+++ b/drivers/bridge/bridge_store.go
@@ -26,7 +26,11 @@ func (d *driver) initStore(option map[string]interface{}) error {
 		if err != nil {
 			return types.InternalErrorf("bridge driver failed to initialize data store: %v", err)
 		}
+	} else if store, ok := option[netlabel.LocalKVStore]; ok {
+		d.store = store.(datastore.DataStore)
+	}
 
+	if d.store != nil {
 		return d.populateNetworks()
 	}
 

--- a/drivers/ipvlan/ipvlan_store.go
+++ b/drivers/ipvlan/ipvlan_store.go
@@ -51,6 +51,11 @@ func (d *driver) initStore(option map[string]interface{}) error {
 			return types.InternalErrorf("ipvlan driver failed to initialize data store: %v", err)
 		}
 
+	} else if store, ok := option[netlabel.LocalKVStore]; ok {
+		d.store = store.(datastore.DataStore)
+	}
+
+	if d.store != nil {
 		return d.populateNetworks()
 	}
 

--- a/drivers/macvlan/macvlan_store.go
+++ b/drivers/macvlan/macvlan_store.go
@@ -50,7 +50,11 @@ func (d *driver) initStore(option map[string]interface{}) error {
 		if err != nil {
 			return types.InternalErrorf("macvlan driver failed to initialize data store: %v", err)
 		}
+	} else if store, ok := option[netlabel.LocalKVStore]; ok {
+		d.store = store.(datastore.DataStore)
+	}
 
+	if d.store != nil {
 		return d.populateNetworks()
 	}
 

--- a/netlabel/labels.go
+++ b/netlabel/labels.go
@@ -59,6 +59,9 @@ var (
 	// GlobalKVClient constants represents the global kv store client
 	GlobalKVClient = MakeKVClient("global")
 
+	// GlobalKVStore containt represents the global kv store connection
+	GlobalKVStore = MakeKVStore("global")
+
 	// LocalKVProvider constant represents the KV provider backend
 	LocalKVProvider = MakeKVProvider("local")
 
@@ -68,8 +71,11 @@ var (
 	// LocalKVProviderConfig constant represents the KV provider Config
 	LocalKVProviderConfig = MakeKVProviderConfig("local")
 
-	// LocalKVClient constants represents the local kv store client
+	// LocalKVClient constant represents the local kv store client
 	LocalKVClient = MakeKVClient("local")
+
+	// LocalKVStore containt represents the local kv store connection
+	LocalKVStore = MakeKVStore("local")
 )
 
 // MakeKVProvider returns the kvprovider label for the scope
@@ -90,6 +96,11 @@ func MakeKVProviderConfig(scope string) string {
 // MakeKVClient returns the kv client label for the scope
 func MakeKVClient(scope string) string {
 	return DriverPrivatePrefix + scope + "kv_client"
+}
+
+// MakeKVStore returns the kv store label for the scope
+func MakeKVStore(scope string) string {
+	return DriverPrivatePrefix + scope + "kv_store"
 }
 
 // Key extracts the key portion of the label

--- a/store.go
+++ b/store.go
@@ -37,6 +37,7 @@ func (c *controller) closeStores() {
 	}
 }
 
+// getStore returns the datastore for the given scope.
 func (c *controller) getStore(scope string) datastore.DataStore {
 	c.Lock()
 	defer c.Unlock()


### PR DESCRIPTION
This change allows consumers of libnetwork to create persistent datastore connections and reuse them across local drivers.

Signed-off-by: David Calavera <david.calavera@gmail.com>