### PR TITLE
Reload config should initialize only the appropriate datastore

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -218,6 +218,9 @@ func (c *controller) ReloadConfiguration(cfgOptions ...config.Option) error {
 				return types.ForbiddenErrorf("cannot accept new configuration because it modifies an existing datastore client")
 			}
 		} else {
+			if err := c.initScopedStore(s, nSCfg); err != nil {
+				return err
+			}
 			update = true
 		}
 	}
@@ -228,10 +231,6 @@ func (c *controller) ReloadConfiguration(cfgOptions ...config.Option) error {
 	c.Lock()
 	c.cfg = cfg
 	c.Unlock()
-
-	if err := c.initStores(); err != nil {
-		return err
-	}
 
 	if c.discovery == nil && c.cfg.Cluster.Watcher != nil {
 		if err := c.initDiscovery(c.cfg.Cluster.Watcher); err != nil {

--- a/store.go
+++ b/store.go
@@ -7,6 +7,18 @@ import (
 	"github.com/docker/libnetwork/datastore"
 )
 
+func (c *controller) initScopedStore(scope string, scfg *datastore.ScopeCfg) error {
+	store, err := datastore.NewDataStore(scope, scfg)
+	if err != nil {
+		return err
+	}
+	c.Lock()
+	c.stores = append(c.stores, store)
+	c.Unlock()
+
+	return nil
+}
+
 func (c *controller) initStores() error {
 	c.Lock()
 	if c.cfg == nil {
@@ -18,13 +30,9 @@ func (c *controller) initStores() error {
 	c.Unlock()
 
 	for scope, scfg := range scopeConfigs {
-		store, err := datastore.NewDataStore(scope, scfg)
-		if err != nil {
+		if err := c.initScopedStore(scope, scfg); err != nil {
 			return err
 		}
-		c.Lock()
-		c.stores = append(c.stores, store)
-		c.Unlock()
 	}
 
 	c.startWatch()


### PR DESCRIPTION
With the current implementation, a config relaod event causes all the
datastores to reinitialize and that impacts objects with Persist=false
such as none and host network.

Signed-off-by: Madhu Venugopal <madhu@docker.com>