### PR TITLE
Handle endpoint & network object in notifyEvent avoiding id lookup

### DIFF
--- a/drivers/overlay/joinleave.go
+++ b/drivers/overlay/joinleave.go
@@ -129,8 +129,8 @@ func (d *driver) Leave(nid, eid string) error {
 	if d.notifyCh != nil {
 		d.notifyCh <- ovNotify{
 			action: "leave",
-			nid:    nid,
-			eid:    eid,
+			nw:     n,
+			ep:     ep,
 		}
 	}
 

--- a/drivers/overlay/ov_serf.go
+++ b/drivers/overlay/ov_serf.go
@@ -12,8 +12,8 @@ import (
 
 type ovNotify struct {
 	action string
-	eid    string
-	nid    string
+	ep     *endpoint
+	nw     *network
 }
 
 type logWriter struct{}
@@ -81,13 +81,12 @@ func (d *driver) serfJoin(neighIP string) error {
 }
 
 func (d *driver) notifyEvent(event ovNotify) {
-	n := d.network(event.nid)
-	ep := n.endpoint(event.eid)
+	ep := event.ep
 
 	ePayload := fmt.Sprintf("%s %s %s %s", event.action, ep.addr.IP.String(),
 		net.IP(ep.addr.Mask).String(), ep.mac.String())
 	eName := fmt.Sprintf("jl %s %s %s", d.serfInstance.LocalMember().Addr.String(),
-		event.nid, event.eid)
+		event.nw.id, ep.id)
 
 	if err := d.serfInstance.UserEvent(eName, []byte(ePayload), true); err != nil {
 		logrus.Errorf("Sending user event failed: %v\n", err)

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -180,13 +180,24 @@ func (d *driver) nodeJoin(node string, self bool) {
 }
 
 func (d *driver) pushLocalEndpointEvent(action, nid, eid string) {
+	n := d.network(nid)
+	if n == nil {
+		logrus.Debugf("Error pushing local endpoint event for network %s", nid)
+		return
+	}
+	ep := n.endpoint(eid)
+	if ep == nil {
+		logrus.Debugf("Error pushing local endpoint event for ep %s / %s", nid, eid)
+		return
+	}
+
 	if !d.isSerfAlive() {
 		return
 	}
 	d.notifyCh <- ovNotify{
 		action: "join",
-		nid:    nid,
-		eid:    eid,
+		nw:     n,
+		ep:     ep,
 	}
 }
 


### PR DESCRIPTION
Join & Leave Serf processing happens in a separate goroutine and there
are cases as in https://github.com/docker/libnetwork/issues/985, it can
cause lookup failures when endpoint delete processing happens before
Serf gets a chance to handle the leave processing.

The fix is to avoid such lookups in this goroutine, but handle the
endpoint and network objects directly.

Fixes #985 

Signed-off-by: Madhu Venugopal <madhu@docker.com>