### PR TITLE
Added maximum egress bandwidth qos for Windows

### DIFF
--- a/drivers/windows/labels.go
+++ b/drivers/windows/labels.go
@@ -12,4 +12,7 @@ const (
 
 	// Interface of the network
 	Interface = "com.docker.network.windowsshim.interface"
+
+	// QosPolicies of the endpoint
+	QosPolicies = "com.docker.endpoint.windowsshim.qospolicies"
 )

--- a/types/types.go
+++ b/types/types.go
@@ -12,6 +12,11 @@ import (
 // UUID represents a globally unique ID of various resources like network and endpoint
 type UUID string
 
+// QosPolicy represents a quality of service policy on an endpoint
+type QosPolicy struct {
+	MaxEgressBandwidth uint64
+}
+
 // TransportPort represent a local Layer 4 endpoint
 type TransportPort struct {
 	Proto Protocol


### PR DESCRIPTION
This adds QoS policies to the Windows driver passed via a generic option. 

Signed-off-by: Darren Stahl <darst@microsoft.com>