### PR TITLE
Fix when connecting/disconnecting to/from default gw network

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -479,7 +479,14 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 		}
 	}
 
-	return sb.clearDefaultGW()
+	if !sb.needDefaultGW() {
+		if err := sb.clearDefaultGW(); err != nil {
+			log.Warnf("Failure while disconnecting sandbox %s (%s) from gateway network: %v",
+				sb.ID(), sb.ContainerID(), err)
+		}
+	}
+
+	return nil
 }
 
 func (ep *endpoint) rename(name string) error {
@@ -622,10 +629,7 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 	}
 
 	sb.deleteHostsEntries(n.getSvcRecords(ep))
-	if !sb.inDelete && sb.needDefaultGW() {
-		if sb.getEPwithoutGateway() == nil {
-			return fmt.Errorf("endpoint without GW expected, but not found")
-		}
+	if sb.needDefaultGW() {
 		return sb.setupDefaultGW()
 	}
 
@@ -639,7 +643,14 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 		}
 	}
 
-	return sb.clearDefaultGW()
+	if !sb.needDefaultGW() {
+		if err := sb.clearDefaultGW(); err != nil {
+			log.Warnf("Failure while disconnecting sandbox %s (%s) from gateway network: %v",
+				sb.ID(), sb.ContainerID(), err)
+		}
+	}
+
+	return nil
 }
 
 func (n *network) validateForceDelete(locator string) error {

--- a/sandbox.go
+++ b/sandbox.go
@@ -197,6 +197,10 @@ func (sb *sandbox) delete(force bool) error {
 	// Detach from all endpoints
 	retain := false
 	for _, ep := range sb.getConnectedEndpoints() {
+		// gw network endpoint detach and removal are automatic
+		if ep.endpointInGWNetwork() {
+			continue
+		}
 		// Retain the sanbdox if we can't obtain the network from store.
 		if _, err := c.getNetworkFromStore(ep.getNetwork().ID()); err != nil {
 			retain = true

--- a/test/integration/dnet/helpers.bash
+++ b/test/integration/dnet/helpers.bash
@@ -345,10 +345,6 @@ function test_overlay() {
             # Disconnect from overlay network
             net_disconnect ${start} container_${start} multihost
 
-            # Make sure external connectivity works
-            runc $(dnet_container_name ${start} $dnet_suffix) $(get_sbox_id ${start} container_${start}) \
-                "ping -c 1 www.google.com"
-
             # Connect to overlay network again
             net_connect ${start} container_${start} multihost
 


### PR DESCRIPTION
On stopping a container running on overlay network, daemon prints following logs:
```
WARN[0010] Failed detaching sandbox 1a117bfe9a3274928e371854ed581633c3cf40d25a7eb4ce473a2110cb04153f from endpoint 93f6c261f8a6bcd3ce94ff8bb40e93afbbf13767b9fef653b43c31bb7bdb23f5: failed to get endpoint from store during leave: could not find endpoint 93f6c261f8a6bcd3ce94ff8bb40e93afbbf13767b9fef653b43c31bb7bdb23f5: []
WARN[0010] Failed deleting endpoint 93f6c261f8a6bcd3ce94ff8bb40e93afbbf13767b9fef653b43c31bb7bdb23f5: failed to get endpoint from store during Delete: could not find endpoint 93f6c261f8a6bcd3ce94ff8bb40e93afbbf13767b9fef653b43c31bb7bdb23f5: []
```
- On sandbox delete, the leave and delete of each
  endpoint is performed, regardless of whether the endpoint
  is the gw network endpoint. This endpoint is already
  automatically removed in endpoint.sbLeave() by
  sb.clearDefaultGW() when the sandbox is marked for
  deletion.
- Also restoring otiginal behavior where on disconnect
  from overlay network (only connected network), it also
  disconnects from default gw network.
- Also do not let internal network dictate container does
  not need external connectivity. Before this fix, if a container
  was connected to an overlay and an internal network, it may not
  get attached to the default gw network.
- needDefaultGw() takes now into account whether the sandbox
  is marked for deletion

Signed-off-by: Alessandro Boch <aboch@docker.com>