### PR TITLE
Remove caching UDP connections to external nameservers

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -547,10 +547,6 @@ func (ep *endpoint) Leave(sbox Sandbox, options ...EndpointOption) error {
 	sb.joinLeaveStart()
 	defer sb.joinLeaveEnd()
 
-	if sb.resolver != nil {
-		sb.resolver.FlushExtServers()
-	}
-
 	return ep.sbLeave(sb, false, options...)
 }
 


### PR DESCRIPTION
An optimization was added earlier to cache the connections to external UDP servers so that it can be reused for subsequent queries. But this creates an issue when multiple concurrent queries are sent on the connection and replies come back in a different order. This PR removes the udp connection caching in embedded DNS server.

Fixes #1070 

Signed-off-by: Santhosh Manohar <santhosh@docker.com>