### PR TITLE
Have resources initialized before deleting overlay network

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -104,6 +104,11 @@ func (d *driver) DeleteNetwork(nid string) error {
 		return fmt.Errorf("invalid network id")
 	}
 
+	// Make sure driver resources are initialized before proceeding
+	if err := d.configure(); err != nil {
+		return err
+	}
+
 	n := d.network(nid)
 	if n == nil {
 		return fmt.Errorf("could not find network with id %s", nid)


### PR DESCRIPTION
- Otherwise a overlay network delete after daemon restart
  will hit a nil pointer dereference while releasing the
  vxlan id

Steps to reproduce:
- create an overlay network
- restart the daemon
- delete the overlay network

Signed-off-by: Alessandro Boch <aboch@docker.com>