### PR TITLE
allow users to defined own interface name in remote api

### DIFF
--- a/cmd/ovrouter/ovrouter.go
+++ b/cmd/ovrouter/ovrouter.go
@@ -74,7 +74,7 @@ func (ep *endpoint) InterfaceName() driverapi.InterfaceNameInfo {
 	return ep
 }
 
-func (ep *endpoint) SetNames(srcName, dstPrefix string) error {
+func (ep *endpoint) SetNames(srcName, dstName, dstPrefix string) error {
 	ep.name = srcName
 	return nil
 }

--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -80,7 +80,7 @@ type InterfaceInfo interface {
 // to interfaces.
 type InterfaceNameInfo interface {
 	// SetNames method assigns the srcName and dstPrefix for the interface.
-	SetNames(srcName, dstPrefix string) error
+	SetNames(srcName, dstName, dstPrefix string) error
 }
 
 // JoinInfo represents a set of resources that the driver has the ability to provide during

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -1132,7 +1132,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 	}
 
 	iNames := jinfo.InterfaceName()
-	err = iNames.SetNames(endpoint.srcName, containerVethPrefix)
+	err = iNames.SetNames(endpoint.srcName, "", containerVethPrefix)
 	if err != nil {
 		return err
 	}

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -399,9 +399,9 @@ func setAddress(ifaceAddr **net.IPNet, address *net.IPNet) error {
 	return nil
 }
 
-func (i *testInterface) SetNames(srcName string, dstName string) error {
+func (i *testInterface) SetNames(srcName string, dstName string, dstPrefix string) error {
 	i.srcName = srcName
-	i.dstName = dstName
+	i.dstName = dstPrefix
 	return nil
 }
 

--- a/drivers/ipvlan/ipvlan_joinleave.go
+++ b/drivers/ipvlan/ipvlan_joinleave.go
@@ -111,7 +111,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		}
 	}
 	iNames := jinfo.InterfaceName()
-	err = iNames.SetNames(vethName, containerVethPrefix)
+	err = iNames.SetNames(vethName, "", containerVethPrefix)
 	if err != nil {
 		return err
 	}

--- a/drivers/macvlan/macvlan_joinleave.go
+++ b/drivers/macvlan/macvlan_joinleave.go
@@ -72,7 +72,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 			ep.addrv6.IP.String(), v6gw.String(), n.config.MacvlanMode, n.config.Parent)
 	}
 	iNames := jinfo.InterfaceName()
-	err = iNames.SetNames(vethName, containerVethPrefix)
+	err = iNames.SetNames(vethName, "", containerVethPrefix)
 	if err != nil {
 		return err
 	}

--- a/drivers/overlay/joinleave.go
+++ b/drivers/overlay/joinleave.go
@@ -96,7 +96,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 	}
 
 	if iNames := jinfo.InterfaceName(); iNames != nil {
-		err = iNames.SetNames(containerIfName, "eth")
+		err = iNames.SetNames(containerIfName, "", "eth")
 		if err != nil {
 			return err
 		}

--- a/drivers/remote/driver.go
+++ b/drivers/remote/driver.go
@@ -204,7 +204,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 
 	ifaceName := res.InterfaceName
 	if iface := jinfo.InterfaceName(); iface != nil && ifaceName != nil {
-		if err := iface.SetNames(ifaceName.SrcName, ifaceName.DstPrefix); err != nil {
+		if err := iface.SetNames(ifaceName.SrcName, ifaceName.DstName, ifaceName.DstPrefix); err != nil {
 			return errorWithRollback(fmt.Sprintf("failed to set interface name: %s", err), d.Leave(nid, eid))
 		}
 	}

--- a/drivers/remote/driver_test.go
+++ b/drivers/remote/driver_test.go
@@ -174,7 +174,7 @@ func (test *testEndpoint) SetGatewayIPv6(ipv6 net.IP) error {
 	return nil
 }
 
-func (test *testEndpoint) SetNames(src string, dst string) error {
+func (test *testEndpoint) SetNames(src string, dstName string, dst string) error {
 	if test.src != src {
 		test.t.Fatalf(`Wrong SrcName; expected "%s", got "%s"`, test.src, src)
 	}

--- a/drivers/windows/windows_test.go
+++ b/drivers/windows/windows_test.go
@@ -128,7 +128,7 @@ func (test *testEndpoint) SetGatewayIPv6(ipv6 net.IP) error {
 	return nil
 }
 
-func (test *testEndpoint) SetNames(src string, dst string) error {
+func (test *testEndpoint) SetNames(src string, dstName string, dst string) error {
 	return nil
 }
 

--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -50,6 +50,7 @@ type endpointInterface struct {
 	addr      *net.IPNet
 	addrv6    *net.IPNet
 	srcName   string
+	dstName   string
 	dstPrefix string
 	routes    []*net.IPNet
 	v4PoolID  string
@@ -259,9 +260,10 @@ func (epi *endpointInterface) AddressIPv6() *net.IPNet {
 	return types.GetIPNetCopy(epi.addrv6)
 }
 
-func (epi *endpointInterface) SetNames(srcName string, dstPrefix string) error {
+func (epi *endpointInterface) SetNames(srcName string, dstName string, dstPrefix string) error {
 	epi.srcName = srcName
 	epi.dstPrefix = dstPrefix
+	epi.dstName = dstName
 	return nil
 }
 

--- a/osl/interface_linux.go
+++ b/osl/interface_linux.go
@@ -212,7 +212,7 @@ func (n *networkNamespace) findDst(srcName string, isBridge bool) string {
 }
 
 func (n *networkNamespace) AddInterface(srcName, dstPrefix string, options ...IfaceOption) error {
-	i := &nwIface{srcName: srcName, dstName: dstPrefix, ns: n}
+	i := &nwIface{srcName: srcName, ns: n}
 	i.processInterfaceOptions(options...)
 
 	if i.master != "" {
@@ -226,8 +226,8 @@ func (n *networkNamespace) AddInterface(srcName, dstPrefix string, options ...If
 	n.Lock()
 	if n.isDefault {
 		i.dstName = i.srcName
-	} else {
-		i.dstName = fmt.Sprintf("%s%d", i.dstName, n.nextIfIndex)
+	} else if i.dstName == "" {
+		i.dstName = fmt.Sprintf("%s%d", dstPrefix, n.nextIfIndex)
 		n.nextIfIndex++
 	}
 

--- a/osl/options_linux.go
+++ b/osl/options_linux.go
@@ -65,3 +65,9 @@ func (n *networkNamespace) Routes(routes []*net.IPNet) IfaceOption {
 		i.routes = routes
 	}
 }
+
+func (n *networkNamespace) DstName(name string) IfaceOption {
+	return func(i *nwIface) {
+		i.dstName = name
+	}
+}

--- a/osl/sandbox.go
+++ b/osl/sandbox.go
@@ -92,6 +92,9 @@ type IfaceOptionSetter interface {
 
 	// Address returns an option setter to set interface routes.
 	Routes([]*net.IPNet) IfaceOption
+
+	// DstName returns an option setter to set interface dstName
+	DstName(string) IfaceOption
 }
 
 // Info represents all possible information that

--- a/sandbox.go
+++ b/sandbox.go
@@ -664,6 +664,10 @@ func (sb *sandbox) populateNetworkResources(ep *endpoint) error {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().MacAddress(i.mac))
 		}
 
+		if i.dstName != "" {
+			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().DstName(i.dstName))
+		}
+
 		if err := sb.osSbox.AddInterface(i.srcName, i.dstPrefix, ifaceOptions...); err != nil {
 			return fmt.Errorf("failed to add interface %s to sandbox: %v", i.srcName, err)
 		}


### PR DESCRIPTION
# Background

We are migrating programs from machines to containers. As most physical network interface naming eth1 in our company and lots of programs hard coding of retrieving ip address from eth1, it would be nice if we can define the name of the veth interface inside container which connects to a single network to be eth1 instead of eth0.
# Solution

this PR adds an option to allow users to define the whole interface name inside container instead of prefix name plus automatic generated index by libnetwork.

Signed-off-by: mYmNeo thomassong@tencent.com
