### PR TITLE
Bridge driver needs to store the network config internal flag

### DIFF
--- a/drivers/bridge/bridge_store.go
+++ b/drivers/bridge/bridge_store.go
@@ -95,6 +95,7 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap["EnableIPMasquerade"] = ncfg.EnableIPMasquerade
 	nMap["EnableICC"] = ncfg.EnableICC
 	nMap["Mtu"] = ncfg.Mtu
+	nMap["Internal"] = ncfg.Internal
 	nMap["DefaultBridge"] = ncfg.DefaultBridge
 	nMap["DefaultBindingIP"] = ncfg.DefaultBindingIP.String()
 	nMap["DefaultGatewayIPv4"] = ncfg.DefaultGatewayIPv4.String()
@@ -143,6 +144,9 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 	ncfg.EnableIPMasquerade = nMap["EnableIPMasquerade"].(bool)
 	ncfg.EnableICC = nMap["EnableICC"].(bool)
 	ncfg.Mtu = int(nMap["Mtu"].(float64))
+	if v, ok := nMap["Internal"]; ok {
+		ncfg.Internal = v.(bool)
+	}
 
 	return nil
 }


### PR DESCRIPTION
- otherwise after daemon reload, the network is no longer internal

Steps to reproduce
- Create an internal bridge network x
- Restart the daemon
- Connect a container to the network x and you can ping 8.8.8.8 from inside the container

Signed-off-by: Alessandro Boch <aboch@docker.com>