### PR TITLE
Revert "Do not leave/delete gw endpoint twice"

### DIFF
--- a/default_gateway.go
+++ b/default_gateway.go
@@ -65,13 +65,20 @@ func (sb *sandbox) setupDefaultGW() error {
 	return nil
 }
 
-// If present, detach and remove the endpoint connecting the sandbox to the default gw network.
+// If present, removes the endpoint connecting the sandbox to the default gw network.
+// Unless it is the endpoint designated to provide the external connectivity.
+// If the sandbox is being deleted, removes the endpoint unconditionally.
 func (sb *sandbox) clearDefaultGW() error {
 	var ep *endpoint
 
 	if ep = sb.getEndpointInGWNetwork(); ep == nil {
 		return nil
 	}
+
+	if ep == sb.getGatewayEndpoint() && !sb.inDelete {
+		return nil
+	}
+
 	if err := ep.sbLeave(sb, false); err != nil {
 		return fmt.Errorf("container %s: endpoint leaving GW Network failed: %v", sb.containerID, err)
 	}
@@ -81,27 +88,20 @@ func (sb *sandbox) clearDefaultGW() error {
 	return nil
 }
 
-// Evaluate whether the sandbox needs to be attached to the default
-// gateway network.
 func (sb *sandbox) needDefaultGW() bool {
 	var needGW bool
 
-	if sb.inDelete {
-		return false
-	}
-
 	for _, ep := range sb.getConnectedEndpoints() {
 		if ep.endpointInGWNetwork() {
-			continue
+			return false
 		}
 		if ep.getNetwork().Type() == "null" || ep.getNetwork().Type() == "host" {
 			continue
 		}
 		if ep.getNetwork().Internal() {
-			continue
+			return false
 		}
-		// During stale sandbox cleanup, joinInfo may be nil
-		if ep.joinInfo != nil && ep.joinInfo.disableGatewayService {
+		if ep.joinInfo.disableGatewayService {
 			return false
 		}
 		// TODO v6 needs to be handled.
@@ -115,7 +115,6 @@ func (sb *sandbox) needDefaultGW() bool {
 		}
 		needGW = true
 	}
-
 	return needGW
 }
 

--- a/endpoint.go
+++ b/endpoint.go
@@ -479,14 +479,7 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 		}
 	}
 
-	if !sb.needDefaultGW() {
-		if err := sb.clearDefaultGW(); err != nil {
-			log.Warnf("Failure while disconnecting sandbox %s (%s) from gateway network: %v",
-				sb.ID(), sb.ContainerID(), err)
-		}
-	}
-
-	return nil
+	return sb.clearDefaultGW()
 }
 
 func (ep *endpoint) rename(name string) error {
@@ -629,7 +622,10 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 	}
 
 	sb.deleteHostsEntries(n.getSvcRecords(ep))
-	if sb.needDefaultGW() {
+	if !sb.inDelete && sb.needDefaultGW() {
+		if sb.getEPwithoutGateway() == nil {
+			return fmt.Errorf("endpoint without GW expected, but not found")
+		}
 		return sb.setupDefaultGW()
 	}
 
@@ -643,14 +639,7 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 		}
 	}
 
-	if !sb.needDefaultGW() {
-		if err := sb.clearDefaultGW(); err != nil {
-			log.Warnf("Failure while disconnecting sandbox %s (%s) from gateway network: %v",
-				sb.ID(), sb.ContainerID(), err)
-		}
-	}
-
-	return nil
+	return sb.clearDefaultGW()
 }
 
 func (n *network) validateForceDelete(locator string) error {

--- a/sandbox.go
+++ b/sandbox.go
@@ -197,10 +197,6 @@ func (sb *sandbox) delete(force bool) error {
 	// Detach from all endpoints
 	retain := false
 	for _, ep := range sb.getConnectedEndpoints() {
-		// gw network endpoint detach and removal are automatic
-		if ep.endpointInGWNetwork() {
-			continue
-		}
 		// Retain the sanbdox if we can't obtain the network from store.
 		if _, err := c.getNetworkFromStore(ep.getNetwork().ID()); err != nil {
 			retain = true

--- a/test/integration/dnet/helpers.bash
+++ b/test/integration/dnet/helpers.bash
@@ -345,6 +345,10 @@ function test_overlay() {
             # Disconnect from overlay network
             net_disconnect ${start} container_${start} multihost
 
+            # Make sure external connectivity works
+            runc $(dnet_container_name ${start} $dnet_suffix) $(get_sbox_id ${start} container_${start}) \
+                "ping -c 1 www.google.com"
+
             # Connect to overlay network again
             net_connect ${start} container_${start} multihost
 


### PR DESCRIPTION
This reverts commit c42884a5b29326840e05549293a4d560d0e4ce2a introduced via https://github.com/docker/libnetwork/pull/1064.

This Patch causes the IT failure in rc.2 & it is not a mandatory patch for the release.