### PR TITLE
Fix when connecting/disconnecting to/from default gw network

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -197,6 +197,10 @@ func (sb *sandbox) delete(force bool) error {
 	// Detach from all endpoints
 	retain := false
 	for _, ep := range sb.getConnectedEndpoints() {
+		// gw network endpoint detach and removal are automatic
+		if ep.endpointInGWNetwork() {
+			continue
+		}
 		// Retain the sanbdox if we can't obtain the network from store.
 		if _, err := c.getNetworkFromStore(ep.getNetwork().ID()); err != nil {
 			retain = true

--- a/test/integration/dnet/helpers.bash
+++ b/test/integration/dnet/helpers.bash
@@ -345,10 +345,6 @@ function test_overlay() {
             # Disconnect from overlay network
             net_disconnect ${start} container_${start} multihost
 
-            # Make sure external connectivity works
-            runc $(dnet_container_name ${start} $dnet_suffix) $(get_sbox_id ${start} container_${start}) \
-                "ping -c 1 www.google.com"
-
             # Connect to overlay network again
             net_connect ${start} container_${start} multihost
 


### PR DESCRIPTION
- Restoring original behavior where on disconnect
  from overlay network (only connected network), it also
  disconnects from default gw network.
- On sandbox delete, the leave and delete of each
  endpoint is performed, regardless of whether the endpoint
  is the gw network endpoint. This endpoint is already
  automatically removed in endpoint.sbLeave()
- Also do not let internal network dictate container does
  not need external connectivity. Before this fix, if a container
  was connected to an overlay and an internal network, it may not
  get attached to the default gw network.

Signed-off-by: Alessandro Boch <aboch@docker.com>