### PR TITLE
Fix the panic when a query response comes after the read() timesout

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -45,7 +45,7 @@ const (
 	ptrIPv6domain   = ".ip6.arpa."
 	respTTL         = 600
 	maxExtDNS       = 3 //max number of external servers to try
-	extIOTimeout    = 3 * time.Second
+	extIOTimeout    = 4 * time.Second
 	defaultRespSize = 512
 	maxConcurrent   = 50
 	logInterval     = 2 * time.Second
@@ -344,9 +344,6 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			if extDNS.ipStr == "" {
 				break
 			}
-			log.Debugf("Query %s[%d] from %s, forwarding to %s:%s", name, query.Question[0].Qtype,
-				w.LocalAddr().String(), proto, extDNS.ipStr)
-
 			extConnect := func() {
 				addr := fmt.Sprintf("%s:%d", extDNS.ipStr, 53)
 				extConn, err = net.DialTimeout(proto, addr, extIOTimeout)
@@ -378,6 +375,8 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			if extConn == nil {
 				continue
 			}
+			log.Debugf("Query %s[%d] from %s, forwarding to %s:%s", name, query.Question[0].Qtype,
+				extConn.LocalAddr().String(), proto, extDNS.ipStr)
 
 			// Timeout has to be set for every IO operation.
 			extConn.SetDeadline(time.Now().Add(extIOTimeout))
@@ -424,7 +423,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			break
 		}
 
-		if resp == nil {
+		if resp == nil || w == nil {
 			return
 		}
 	}


### PR DESCRIPTION
With the cached udp connection to an external nameserver the following can happen..

```DEBU[0064] Query name.[1] from 127.0.0.11:42291, forwarding to udp:8.8.8.8 ```
```DEBU[0067] Read from DNS server failed, read udp 172.20.0.2:47916->8.8.8.8:53: i/o timeout ```

now the saved context for the forwarded query will be cleared

```DEBU[0069] Query name.[1] from 127.0.0.11:42291, forwarding to udp:8.8.8.8 ```

Since the first query timed out client resolver retries; when the DNS server is waiting for the response it could receive the reply for the previous query whose context has been cleaned up already.

DEBU[0069] Can't retrieve client context for dns id 6063 

Added a missing nil check for this case and increased the read timeout (typical client resolver timeout is 5 seconds; hence keeping the read timeout to 4 seconds)

Fixes #1087 
Signed-off-by: Santhosh Manohar <santhosh@docker.com>