### PR TITLE
tools/cmd/vet has been deleted and go tool vet works natively on 1.5+

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,6 +3,5 @@ RUN apt-get update && apt-get -y install iptables
 
 RUN go get github.com/tools/godep \
 		github.com/golang/lint/golint \
-		golang.org/x/tools/cmd/vet \
 		golang.org/x/tools/cmd/cover\
 		github.com/mattn/goveralls


### PR DESCRIPTION
Signed-off-by: Chun Chen <ramichen@tencent.com>

Fix CI building failure