### PR TITLE
Use newly introduce plugins method to validate plugin response 

### DIFF
--- a/docs/remote.md
+++ b/docs/remote.md
@@ -31,6 +31,8 @@ The remote driver protocol is a set of RPCs, issued as HTTP POSTs with JSON payl
 
 If the remote process cannot decode, or otherwise detects a syntactic problem with the HTTP request or payload, it must respond with an HTTP error status (4xx or 5xx).
 
+If the remote process http server receives a request for an unknown URI, it should respond with the HTTP StatusCode `404 Not Found`. This allows libnetwork to detect when a remote driver does not implement yet a newly added method, therefore not to deem the request as failed.
+
 If the remote process can decode the request, but cannot complete the operation, it must send a response in the form
 
     {

--- a/drivers/remote/driver.go
+++ b/drivers/remote/driver.go
@@ -3,7 +3,6 @@ package remote
 import (
 	"fmt"
 	"net"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/plugins"
@@ -12,10 +11,6 @@ import (
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/drivers/remote/api"
 	"github.com/docker/libnetwork/types"
-)
-
-const (
-	missingMethod = "404 page not found"
 )
 
 type driver struct {
@@ -260,7 +255,7 @@ func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string
 		Options:    options,
 	}
 	err := d.call("ProgramExternalConnectivity", data, &api.ProgramExternalConnectivityResponse{})
-	if err != nil && strings.Contains(err.Error(), missingMethod) {
+	if err != nil && plugins.IsNotFound(err) {
 		// It is not mandatory yet to support this method
 		return nil
 	}
@@ -274,7 +269,7 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 		EndpointID: eid,
 	}
 	err := d.call("RevokeExternalConnectivity", data, &api.RevokeExternalConnectivityResponse{})
-	if err != nil && strings.Contains(err.Error(), missingMethod) {
+	if err != nil && plugins.IsNotFound(err) {
 		// It is not mandatory yet to support this method
 		return nil
 	}


### PR DESCRIPTION
- for endpoints which are not expected to be implemented
  by all remote drivers.

Signed-off-by: Alessandro Boch <aboch@docker.com>