### PR TITLE
Mark iptables rules with comment

### DIFF
--- a/drivers/bridge/setup_ip_tables_test.go
+++ b/drivers/bridge/setup_ip_tables_test.go
@@ -24,7 +24,7 @@ func TestProgramIPTable(t *testing.T) {
 		descr string
 	}{
 		{iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-d", "127.1.2.3", "-i", "lo", "-o", "lo", "-j", "DROP"}}, "Test Loopback"},
-		{iptRule{table: iptables.Nat, chain: "POSTROUTING", preArgs: []string{"-t", "nat"}, args: []string{"-s", iptablesTestBridgeIP, "!", "-o", DefaultBridgeName, "-j", "MASQUERADE"}}, "NAT Test"},
+		{iptRule{table: iptables.Nat, chain: "POSTROUTING", args: []string{"-s", iptablesTestBridgeIP, "!", "-o", DefaultBridgeName, "-j", "MASQUERADE"}}, "NAT Test"},
 		{iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-i", DefaultBridgeName, "!", "-o", DefaultBridgeName, "-j", "ACCEPT"}}, "Test ACCEPT NON_ICC OUTGOING"},
 		{iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-o", DefaultBridgeName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}}, "Test ACCEPT INCOMING"},
 		{iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-i", DefaultBridgeName, "-o", DefaultBridgeName, "-j", "ACCEPT"}}, "Test enable ICC"},

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -141,8 +141,8 @@ func TestPrerouting(t *testing.T) {
 		t.Fatalf("rule does not exist")
 	}
 
-	delRule := append([]string{"-D", "PREROUTING", "-t", string(Nat)}, args...)
-	if _, err = Raw(delRule...); err != nil {
+	delRule := append([]string{"PREROUTING"}, args...)
+	if _, err = DispatchRule(Nat, Delete, delRule...); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -161,9 +161,8 @@ func TestOutput(t *testing.T) {
 		t.Fatalf("rule does not exist")
 	}
 
-	delRule := append([]string{"-D", "OUTPUT", "-t",
-		string(natChain.Table)}, args...)
-	if _, err = Raw(delRule...); err != nil {
+	delRule := append([]string{"OUTPUT"}, args...)
+	if _, err = DispatchRule(natChain.Table, Delete, delRule...); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -212,11 +211,11 @@ func TestCleanup(t *testing.T) {
 	var rules []byte
 
 	// Cleanup filter/FORWARD first otherwise output of iptables-save is dirty
-	link := []string{"-t", string(filterChain.Table),
-		string(Delete), "FORWARD",
+	link := []string{
+		"FORWARD",
 		"-o", bridgeName,
 		"-j", filterChain.Name}
-	if _, err = Raw(link...); err != nil {
+	if _, err = DispatchRule(filterChain.Table, Delete, link...); err != nil {
 		t.Fatal(err)
 	}
 	filterChain.Remove()


### PR DESCRIPTION
I've tried to address docker/docker#18908 in a somewhat backwards compatible way. 
- `exists` checks if commented rule exists, then it checks if not commented rule exists if commented one is missing.
- `remove` removes commented rule, then removes not commented rule if commented one is missing.
- `add` and `insert` only insert commented rules.

All rules are installed with `DispatchRule()`, no more `Raw()` calls. I think it's better to make `Raw()` private and expose everything as a specific functions. Example:
- `Raw("-L", DockerChain) -> ListChainRules(iptables.Filter, DockerChain)`

It probably makes sense to unify `Exists()` and `DispatchRule()` signatures.

cc @mavenugo, @thaJeztah 
