### PR TITLE
Resolver sockets not flushed on default gw change

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -477,6 +477,10 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 					ep.Name(), ep.ID(), err)
 			}
 		}
+
+		if sb.resolver != nil {
+			sb.resolver.FlushExtServers()
+		}
 	}
 
 	if !sb.needDefaultGW() {

--- a/resolver.go
+++ b/resolver.go
@@ -158,6 +158,10 @@ func (r *resolver) Start() error {
 
 func (r *resolver) FlushExtServers() {
 	for i := 0; i < maxExtDNS; i++ {
+		if r.extDNSList[i].extConn != nil {
+			r.extDNSList[i].extConn.Close()
+		}
+
 		r.extDNSList[i].extConn = nil
 		r.extDNSList[i].extOnce = sync.Once{}
 	}


### PR DESCRIPTION
Currently when the default gw changes because of
other network connections happening in the container
the resolver sockets are not flushed. This results
in a subsequent DNS failure for external queries

A sequence of connecting the container to an overlay
network and subsequently to a bridge network without
disconnecting from any network will result in this
behaviour. This was revealed by one of the libnetwork
IT tests.

This is now fixed as part of the commit by flushing
the external query sockets when a default gw change
is detected.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>