### PR TITLE
Get libnetwork to build on Solaris

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ container_env = -e "INSIDECONTAINER=-incontainer=true"
 docker = docker run --rm -it ${dockerargs} $$EXTRA_ARGS ${container_env} ${build_image}
 ciargs = -e CIRCLECI -e "COVERALLS_TOKEN=$$COVERALLS_TOKEN" -e "INSIDECONTAINER=-incontainer=true"
 cidocker = docker run ${dockerargs} ${ciargs} ${container_env} ${build_image}
-CROSS_PLATFORMS = linux/amd64 linux/386 linux/arm windows/amd64 windows/386
+CROSS_PLATFORMS = linux/amd64 linux/386 linux/arm windows/amd64 windows/386 solaris/amd64 solaris/386
 
 all: ${build_image}.created build check integration-tests clean
 
@@ -102,4 +102,4 @@ circle-ci-check: ${build_image}.created
 circle-ci-build: ${build_image}.created
 	@${cidocker} make build-local
 
-circle-ci: circle-ci-check circle-ci-build integration-tests
+circle-ci: circle-ci-check circle-ci-cross circle-ci-build integration-tests

--- a/default_gateway_solaris.go
+++ b/default_gateway_solaris.go
@@ -1,0 +1,7 @@
+package libnetwork
+
+import "github.com/docker/libnetwork/types"
+
+func (c *controller) createGWNetwork() (Network, error) {
+	return nil, types.NotImplementedErrorf("default gateway functionality is not implemented in solaris")
+}

--- a/drivers_solaris.go
+++ b/drivers_solaris.go
@@ -1,0 +1,5 @@
+package libnetwork
+
+func getInitializers() []initializer {
+	return []initializer{}
+}

--- a/ipams/builtin/builtin_unix.go
+++ b/ipams/builtin/builtin_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd
+// +build linux freebsd solaris
 
 package builtin
 

--- a/ipamutils/utils_solaris.go
+++ b/ipamutils/utils_solaris.go
@@ -1,0 +1,31 @@
+// Package ipamutils provides utililty functions for ipam management
+package ipamutils
+
+// Solaris: TODO
+
+import (
+	"net"
+)
+
+// ElectInterfaceAddresses looks for an interface on the OS with the specified name
+// and returns its IPv4 and IPv6 addresses in CIDR form. If the interface does not exist,
+// it chooses from a predifined list the first IPv4 address which does not conflict
+// with other interfaces on the system.
+func ElectInterfaceAddresses(name string) (*net.IPNet, []*net.IPNet, error) {
+	var (
+		v4Net *net.IPNet
+		err   error
+	)
+
+	v4Net, err = FindAvailableNetwork(PredefinedBroadNetworks)
+	if err != nil {
+		return nil, nil, err
+	}
+	return v4Net, nil, nil
+}
+
+// FindAvailableNetwork returns a network from the passed list which does not
+// overlap with existing interfaces in the system
+func FindAvailableNetwork(list []*net.IPNet) (*net.IPNet, error) {
+	return list[0], nil
+}

--- a/osl/interface_solaris.go
+++ b/osl/interface_solaris.go
@@ -1,0 +1,4 @@
+package osl
+
+// IfaceOption is a function option type to set interface options
+type IfaceOption func()

--- a/osl/neigh_solaris.go
+++ b/osl/neigh_solaris.go
@@ -1,0 +1,4 @@
+package osl
+
+// NeighOption is a function option type to set interface options
+type NeighOption func()

--- a/sandbox_externalkey_solaris.go
+++ b/sandbox_externalkey_solaris.go
@@ -1,0 +1,45 @@
+// +build solaris
+
+package libnetwork
+
+import (
+	"io"
+	"net"
+
+	"github.com/docker/libnetwork/types"
+)
+
+// processSetKeyReexec is a private function that must be called only on an reexec path
+// It expects 3 args { [0] = "libnetwork-setkey", [1] = <container-id>, [2] = <controller-id> }
+// It also expects libcontainer.State as a json string in <stdin>
+// Refer to https://github.com/opencontainers/runc/pull/160/ for more information
+func processSetKeyReexec() {
+}
+
+// SetExternalKey provides a convenient way to set an External key to a sandbox
+func SetExternalKey(controllerID string, containerID string, key string) error {
+	return types.NotImplementedErrorf("SetExternalKey isn't supported on non linux systems")
+}
+
+func sendKey(c net.Conn, data setKeyData) error {
+	return types.NotImplementedErrorf("sendKey isn't supported on non linux systems")
+}
+
+func processReturn(r io.Reader) error {
+	return types.NotImplementedErrorf("processReturn isn't supported on non linux systems")
+}
+
+// no-op on non linux systems
+func (c *controller) startExternalKeyListener() error {
+	return nil
+}
+
+func (c *controller) acceptClientConnections(sock string, l net.Listener) {
+}
+
+func (c *controller) processExternalKey(conn net.Conn) error {
+	return types.NotImplementedErrorf("processExternalKey isn't supported on non linux systems")
+}
+
+func (c *controller) stopExternalKeyListener() {
+}


### PR DESCRIPTION
This is a build clean PR for libnetwork on Solaris.
This is a part of a larger effort for a native port of Docker on Solaris.

Signed-off-by: Amit Krishnan <krish.amit@gmail.com>