### PR TITLE
Remove solaris/386 from cross platform list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ container_env = -e "INSIDECONTAINER=-incontainer=true"
 docker = docker run --rm -it ${dockerargs} $$EXTRA_ARGS ${container_env} ${build_image}
 ciargs = -e CIRCLECI -e "COVERALLS_TOKEN=$$COVERALLS_TOKEN" -e "INSIDECONTAINER=-incontainer=true"
 cidocker = docker run ${dockerargs} ${ciargs} ${container_env} ${build_image}
-CROSS_PLATFORMS = linux/amd64 linux/386 linux/arm windows/amd64 windows/386 solaris/amd64 solaris/386
+CROSS_PLATFORMS = linux/amd64 linux/386 linux/arm windows/amd64 windows/386 solaris/amd64
 
 all: ${build_image}.created build check integration-tests clean
 


### PR DESCRIPTION
This is a minor edit on #1110.
GO on Solaris supports only 64-bit programs so removing solaris/386 from cross platform list.

Signed-off-by: Amit Krishnan <krish.amit@gmail.com>