### PR TITLE
Correct the check in l3 miss handling in overlay driver

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -403,9 +403,10 @@ func (n *network) watchMiss(nlSock *nl.NetlinkSocket) {
 				continue
 			}
 
-			if neigh.IP.To16() != nil {
+			if neigh.IP.To4() == nil {
 				continue
 			}
+			logrus.Debugf("miss notification for dest IP, %v", neigh.IP.String())
 
 			if neigh.State&(netlink.NUD_STALE|netlink.NUD_INCOMPLETE) == 0 {
 				continue


### PR DESCRIPTION
Fixes #1069 
Verified with a code change to set the serf eventbuffer to a very low number.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>