### PR TITLE
Add support to accepting arbitrary network ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ func main() {
 
 	// Create a network for containers to join.
 	// NewNetwork accepts Variadic optional arguments that libnetwork and Drivers can use.
-	network, err := controller.NewNetwork(networkType, "network1")
+	network, err := controller.NewNetwork(networkType, "network1", "")
 	if err != nil {
 		log.Fatalf("controller.NewNetwork: %s", err)
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -307,7 +307,7 @@ func procCreateNetwork(c libnetwork.NetworkController, vars map[string]string, b
 	if len(create.DriverOpts) > 0 {
 		options = append(options, libnetwork.NetworkOptionDriverOpts(create.DriverOpts))
 	}
-	nw, err := c.NewNetwork(create.NetworkType, create.Name, options...)
+	nw, err := c.NewNetwork(create.NetworkType, create.Name, "", options...)
 	if err != nil {
 		return nil, convertNetworkError(err)
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -98,7 +98,7 @@ func createTestNetwork(t *testing.T, network string) (libnetwork.NetworkControll
 		},
 	}
 	netGeneric := libnetwork.NetworkOptionGeneric(netOption)
-	nw, err := c.NewNetwork(bridgeNetType, network, netGeneric)
+	nw, err := c.NewNetwork(bridgeNetType, network, "", netGeneric)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -539,7 +539,7 @@ func TestProcGetServices(t *testing.T) {
 			"BridgeName": netName1,
 		},
 	}
-	nw1, err := c.NewNetwork(bridgeNetType, netName1, libnetwork.NetworkOptionGeneric(netOption))
+	nw1, err := c.NewNetwork(bridgeNetType, netName1, "", libnetwork.NetworkOptionGeneric(netOption))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -550,7 +550,7 @@ func TestProcGetServices(t *testing.T) {
 			"BridgeName": netName2,
 		},
 	}
-	nw2, err := c.NewNetwork(bridgeNetType, netName2, libnetwork.NetworkOptionGeneric(netOption))
+	nw2, err := c.NewNetwork(bridgeNetType, netName2, "", libnetwork.NetworkOptionGeneric(netOption))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1731,7 +1731,7 @@ func TestHttpHandlerUninit(t *testing.T) {
 		t.Fatalf("Expected empty list. Got %v", list)
 	}
 
-	n, err := c.NewNetwork(bridgeNetType, "didietro", nil)
+	n, err := c.NewNetwork(bridgeNetType, "didietro", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -201,7 +201,7 @@ func createDefaultNetwork(c libnetwork.NetworkController) {
 			}
 		}
 
-		_, err := c.NewNetwork(d, nw, createOptions...)
+		_, err := c.NewNetwork(d, nw, "", createOptions...)
 		if err != nil {
 			logrus.Errorf("Error creating default network : %s : %v", nw, err)
 		}

--- a/cmd/readme_test/readme.go
+++ b/cmd/readme_test/readme.go
@@ -30,7 +30,7 @@ func main() {
 
 	// Create a network for containers to join.
 	// NewNetwork accepts Variadic optional arguments that libnetwork and Drivers can use.
-	network, err := controller.NewNetwork(networkType, "network1")
+	network, err := controller.NewNetwork(networkType, "network1", "")
 	if err != nil {
 		log.Fatalf("controller.NewNetwork: %s", err)
 	}

--- a/default_gateway_linux.go
+++ b/default_gateway_linux.go
@@ -14,7 +14,7 @@ func (c *controller) createGWNetwork() (Network, error) {
 		bridge.EnableIPMasquerade: strconv.FormatBool(true),
 	}
 
-	n, err := c.NewNetwork("bridge", libnGWNetwork,
+	n, err := c.NewNetwork("bridge", libnGWNetwork, "",
 		NetworkOptionDriverOpts(netOption),
 		NetworkOptionEnableIPv6(false),
 	)

--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -339,11 +339,11 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 	// Test whether ipam state release is invoked  on network create failure from net driver
 	// by checking whether subsequent network creation requesting same gateway IP succeeds
 	ipamOpt := NetworkOptionIpam(ipamapi.DefaultIPAM, "", []*IpamConf{{PreferredPool: "10.34.0.0/16", Gateway: "10.34.255.254"}}, nil, nil)
-	if _, err := c.NewNetwork(badDriverName, "badnet1", ipamOpt); err == nil {
+	if _, err := c.NewNetwork(badDriverName, "badnet1", "", ipamOpt); err == nil {
 		t.Fatalf("bad network driver should have failed network creation")
 	}
 
-	gnw, err := c.NewNetwork("bridge", "goodnet1", ipamOpt)
+	gnw, err := c.NewNetwork("bridge", "goodnet1", "", ipamOpt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -351,7 +351,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 
 	// Now check whether ipam release works on endpoint creation failure
 	bd.failNetworkCreation = false
-	bnw, err := c.NewNetwork(badDriverName, "badnet2", ipamOpt)
+	bnw, err := c.NewNetwork(badDriverName, "badnet2", "", ipamOpt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +363,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 
 	// Now create good bridge network with different gateway
 	ipamOpt2 := NetworkOptionIpam(ipamapi.DefaultIPAM, "", []*IpamConf{{PreferredPool: "10.34.0.0/16", Gateway: "10.34.255.253"}}, nil, nil)
-	gnw, err = c.NewNetwork("bridge", "goodnet2", ipamOpt2)
+	gnw, err = c.NewNetwork("bridge", "goodnet2", "", ipamOpt2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -85,7 +85,7 @@ func createController() error {
 }
 
 func createTestNetwork(networkType, networkName string, netOption options.Generic, ipamV4Configs, ipamV6Configs []*libnetwork.IpamConf) (libnetwork.Network, error) {
-	return controller.NewNetwork(networkType, networkName,
+	return controller.NewNetwork(networkType, networkName, "",
 		libnetwork.NetworkOptionGeneric(netOption),
 		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", ipamV4Configs, ipamV6Configs, nil))
 }
@@ -333,7 +333,7 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24", Gateway: "192.168.100.1"}}
 	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
 
-	network, err := controller.NewNetwork(bridgeNetType, "testipv6mac",
+	network, err := controller.NewNetwork(bridgeNetType, "testipv6mac", "",
 		libnetwork.NetworkOptionGeneric(netOption),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", ipamV4ConfList, ipamV6ConfList, nil),
@@ -386,7 +386,7 @@ func TestUnknownDriver(t *testing.T) {
 }
 
 func TestNilRemoteDriver(t *testing.T) {
-	_, err := controller.NewNetwork("framerelay", "dummy",
+	_, err := controller.NewNetwork("framerelay", "dummy", "",
 		libnetwork.NetworkOptionGeneric(getEmptyGenericOption()))
 	if err == nil {
 		t.Fatal("Expected to fail. But instead succeeded")
@@ -1016,7 +1016,7 @@ func TestEndpointJoin(t *testing.T) {
 		},
 	}
 	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
-	n1, err := controller.NewNetwork(bridgeNetType, "testnetwork1",
+	n1, err := controller.NewNetwork(bridgeNetType, "testnetwork1", "",
 		libnetwork.NetworkOptionGeneric(netOption),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", nil, ipamV6ConfList, nil),
@@ -2046,7 +2046,7 @@ func TestInvalidRemoteDriver(t *testing.T) {
 	}
 	defer ctrlr.Stop()
 
-	_, err = ctrlr.NewNetwork("invalid-network-driver", "dummy",
+	_, err = ctrlr.NewNetwork("invalid-network-driver", "dummy", "",
 		libnetwork.NetworkOptionGeneric(getEmptyGenericOption()))
 	if err == nil {
 		t.Fatal("Expected to fail. But instead succeeded")
@@ -2095,7 +2095,7 @@ func TestValidRemoteDriver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	n, err := controller.NewNetwork("valid-network-driver", "dummy",
+	n, err := controller.NewNetwork("valid-network-driver", "dummy", "",
 		libnetwork.NetworkOptionGeneric(getEmptyGenericOption()))
 	if err != nil {
 		// Only fail if we could not find the plugin driver
@@ -2357,7 +2357,7 @@ func TestParallel3(t *testing.T) {
 }
 
 func TestNullIpam(t *testing.T) {
-	_, err := controller.NewNetwork(bridgeNetType, "testnetworkinternal", libnetwork.NetworkOptionIpam(ipamapi.NullIPAM, "", nil, nil, nil))
+	_, err := controller.NewNetwork(bridgeNetType, "testnetworkinternal", "", libnetwork.NetworkOptionIpam(ipamapi.NullIPAM, "", nil, nil, nil))
 	if err == nil || err.Error() != "ipv4 pool is empty" {
 		t.Fatal("bridge network should complain empty pool")
 	}

--- a/sandbox_test.go
+++ b/sandbox_test.go
@@ -38,7 +38,7 @@ func getTestEnv(t *testing.T) (NetworkController, Network, Network) {
 			"BridgeName": name1,
 		},
 	}
-	n1, err := c.NewNetwork(netType, name1, NetworkOptionGeneric(netOption1))
+	n1, err := c.NewNetwork(netType, name1, "", NetworkOptionGeneric(netOption1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func getTestEnv(t *testing.T) (NetworkController, Network, Network) {
 			"BridgeName": name2,
 		},
 	}
-	n2, err := c.NewNetwork(netType, name2, NetworkOptionGeneric(netOption2))
+	n2, err := c.NewNetwork(netType, name2, "", NetworkOptionGeneric(netOption2))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -55,7 +55,7 @@ func testLocalBackend(t *testing.T, provider, url string, storeConfig *store.Con
 	if err != nil {
 		t.Fatalf("Error new controller: %v", err)
 	}
-	nw, err := ctrl.NewNetwork("host", "host")
+	nw, err := ctrl.NewNetwork("host", "host", "")
 	if err != nil {
 		t.Fatalf("Error creating default \"host\" network: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestNoPersist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error new controller: %v", err)
 	}
-	nw, err := ctrl.NewNetwork("host", "host", NetworkOptionPersist(false))
+	nw, err := ctrl.NewNetwork("host", "host", "", NetworkOptionPersist(false))
 	if err != nil {
 		t.Fatalf("Error creating default \"host\" network: %v", err)
 	}


### PR DESCRIPTION
Currently the libnetwork function `NewNetwork` does not allow
caller to pass a network ID and it is always generated internally.
This is sufficient for engine use. But it doesn't satisfy the needs
of libnetwork being used as an independent library in programs other
than the engine. This enhancement is one of the many needed to
facilitate a generic libnetwork.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>