### PR TITLE
Make IPAM work even without a backing store

### DIFF
--- a/ipam/store.go
+++ b/ipam/store.go
@@ -82,8 +82,10 @@ func (a *Allocator) getStore(as string) datastore.DataStore {
 
 func (a *Allocator) getAddressSpaceFromStore(as string) (*addrSpace, error) {
 	store := a.getStore(as)
+
+	// IPAM may not have a valid store. In such cases it is just in-memory state.
 	if store == nil {
-		return nil, types.InternalErrorf("store for address space %s not found", as)
+		return nil, nil
 	}
 
 	pc := &addrSpace{id: dsConfigKey + "/" + as, ds: store, alloc: a}
@@ -100,8 +102,10 @@ func (a *Allocator) getAddressSpaceFromStore(as string) (*addrSpace, error) {
 
 func (a *Allocator) writeToStore(aSpace *addrSpace) error {
 	store := aSpace.store()
+
+	// IPAM may not have a valid store. In such cases it is just in-memory state.
 	if store == nil {
-		return types.InternalErrorf("invalid store while trying to write %s address space", aSpace.DataScope())
+		return nil
 	}
 
 	err := store.PutObjectAtomic(aSpace)
@@ -114,8 +118,10 @@ func (a *Allocator) writeToStore(aSpace *addrSpace) error {
 
 func (a *Allocator) deleteFromStore(aSpace *addrSpace) error {
 	store := aSpace.store()
+
+	// IPAM may not have a valid store. In such cases it is just in-memory state.
 	if store == nil {
-		return types.InternalErrorf("invalid store while trying to delete %s address space", aSpace.DataScope())
+		return nil
 	}
 
 	return store.DeleteObjectAtomic(aSpace)


### PR DESCRIPTION
In general the core IPAM and bitseq implementation has
very little assumptions about the presence of a backing
store. But there are a few places where this assumption exists
and this makes it not useful as a simple in-memory allocator.
This PR removes those false assumptions.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>