### PR TITLE
Remove kvstore backend deps from datastore package

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -205,27 +205,33 @@
 		},
 		{
 			"ImportPath": "github.com/docker/libkv",
-			"Rev": "c2aac5dbbaa5c872211edea7c0f32b3bd67e7410"
+			"Comment": "v0.1.0-35-g7283ef2",
+			"Rev": "7283ef27ed32fe267388510a91709b307bb9942c"
 		},
 		{
 			"ImportPath": "github.com/docker/libkv/store",
-			"Rev": "c2aac5dbbaa5c872211edea7c0f32b3bd67e7410"
+			"Comment": "v0.1.0-35-g7283ef2",
+			"Rev": "7283ef27ed32fe267388510a91709b307bb9942c"
 		},
 		{
 			"ImportPath": "github.com/docker/libkv/store/boltdb",
-			"Rev": "c2aac5dbbaa5c872211edea7c0f32b3bd67e7410"
+			"Comment": "v0.1.0-35-g7283ef2",
+			"Rev": "7283ef27ed32fe267388510a91709b307bb9942c"
 		},
 		{
 			"ImportPath": "github.com/docker/libkv/store/consul",
-			"Rev": "c2aac5dbbaa5c872211edea7c0f32b3bd67e7410"
+			"Comment": "v0.1.0-35-g7283ef2",
+			"Rev": "7283ef27ed32fe267388510a91709b307bb9942c"
 		},
 		{
 			"ImportPath": "github.com/docker/libkv/store/etcd",
-			"Rev": "c2aac5dbbaa5c872211edea7c0f32b3bd67e7410"
+			"Comment": "v0.1.0-35-g7283ef2",
+			"Rev": "7283ef27ed32fe267388510a91709b307bb9942c"
 		},
 		{
 			"ImportPath": "github.com/docker/libkv/store/zookeeper",
-			"Rev": "c2aac5dbbaa5c872211edea7c0f32b3bd67e7410"
+			"Comment": "v0.1.0-35-g7283ef2",
+			"Rev": "7283ef27ed32fe267388510a91709b307bb9942c"
 		},
 		{
 			"ImportPath": "github.com/godbus/dbus",

--- a/Godeps/_workspace/src/github.com/docker/libkv/.travis.yml
+++ b/Godeps/_workspace/src/github.com/docker/libkv/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 
 go:
-  - 1.3
-#  - 1.4
-# see https://github.com/moovweb/gvm/pull/116 for why Go 1.4 is currently disabled
+  - 1.5.3
 
 # let us have speedy Docker-based Travis workers
 sudo: false
@@ -11,19 +9,18 @@ sudo: false
 before_install:
   # Symlink below is needed for Travis CI to work correctly on personal forks of libkv
   - ln -s $HOME/gopath/src/github.com/${TRAVIS_REPO_SLUG///libkv/} $HOME/gopath/src/github.com/docker
-  - go get golang.org/x/tools/cmd/vet
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
   - go get github.com/golang/lint/golint
   - go get github.com/GeertJohan/fgt
 
 before_script:
-  - script/travis_consul.sh 0.5.2 
-  - script/travis_etcd.sh 2.2.0
-  - script/travis_zk.sh 3.4.6
+  - script/travis_consul.sh 0.6.3
+  - script/travis_etcd.sh 2.2.5
+  - script/travis_zk.sh 3.5.1-alpha
 
 script:
-  - ./consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul -config-file=./config.json 1>/dev/null &
+  - ./consul agent -server -bootstrap -advertise=127.0.0.1 -data-dir /tmp/consul -config-file=./config.json 1>/dev/null &
   - ./etcd/etcd --listen-client-urls 'http://0.0.0.0:4001' --advertise-client-urls 'http://127.0.0.1:4001' >/dev/null 2>&1 &
   - ./zk/bin/zkServer.sh start ./zk/conf/zoo.cfg 1> /dev/null
   - script/validate-gofmt

--- a/Godeps/_workspace/src/github.com/docker/libkv/LICENSE.code
+++ b/Godeps/_workspace/src/github.com/docker/libkv/LICENSE.code
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2014-2015 Docker, Inc.
+   Copyright 2014-2016 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Godeps/_workspace/src/github.com/docker/libkv/MAINTAINERS
+++ b/Godeps/_workspace/src/github.com/docker/libkv/MAINTAINERS
@@ -1,0 +1,46 @@
+# Libkv maintainers file
+#
+# This file describes who runs the docker/libkv project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"abronan",
+			"aluzzardi",
+			"sanimej",
+			"vieux",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+
+	[people.abronan]
+	Name = "Alexandre Beslic"
+	Email = "abronan@docker.com"
+	GitHub = "abronan"
+
+	[people.aluzzardi]
+	Name = "Andrea Luzzardi"
+	Email = "al@docker.com"
+	GitHub = "aluzzardi"
+
+	[people.sanimej]
+	Name = "Santhosh Manohar"
+	Email = "santhosh@docker.com"
+	GitHub = "sanimej"
+
+	[people.vieux]
+	Name = "Victor Vieux"
+	Email = "vieux@docker.com"
+	GitHub = "vieux"

--- a/Godeps/_workspace/src/github.com/docker/libkv/README.md
+++ b/Godeps/_workspace/src/github.com/docker/libkv/README.md
@@ -3,6 +3,7 @@
 [![GoDoc](https://godoc.org/github.com/docker/libkv?status.png)](https://godoc.org/github.com/docker/libkv)
 [![Build Status](https://travis-ci.org/docker/libkv.svg?branch=master)](https://travis-ci.org/docker/libkv)
 [![Coverage Status](https://coveralls.io/repos/docker/libkv/badge.svg)](https://coveralls.io/r/docker/libkv)
+[![Go Report Card](https://goreportcard.com/badge/github.com/docker/libkv)](https://goreportcard.com/report/github.com/docker/libkv)
 
 `libkv` provides a `Go` native library to store metadata.
 
@@ -10,7 +11,7 @@ The goal of `libkv` is to abstract common store operations for multiple distribu
 
 For example, you can use it to store your metadata or for service discovery to register machines and endpoints inside your cluster.
 
-You can also easily implement a generic *Leader Election* on top of it (see the [swarm/leadership](https://github.com/docker/swarm/tree/master/leadership) package).
+You can also easily implement a generic *Leader Election* on top of it (see the [docker/leadership](https://github.com/docker/leadership) repository).
 
 As of now, `libkv` offers support for `Consul`, `Etcd`, `Zookeeper` (**Distributed** store) and `BoltDB` (**Local** store).
 
@@ -30,7 +31,7 @@ You can find examples of usage for `libkv` under in `docs/examples.go`. Optional
 
 `libkv` supports:
 - Consul versions >= `0.5.1` because it uses Sessions with `Delete` behavior for the use of `TTLs` (mimics zookeeper's Ephemeral node support), If you don't plan to use `TTLs`: you can use Consul version `0.4.0+`.
-- Etcd versions >= `2.0` because it uses the new `coreos/etcd/client`, this might change in the future as the support for `APIv3` comes along and adds mor capabilities.
+- Etcd versions >= `2.0` because it uses the new `coreos/etcd/client`, this might change in the future as the support for `APIv3` comes along and adds more capabilities.
 - Zookeeper versions >= `3.4.5`. Although this might work with previous version but this remains untested as of now.
 - Boltdb, which shouldn't be subject to any version dependencies.
 
@@ -83,7 +84,7 @@ Please refer to the `docs/compatibility.md` to see what are the special cases fo
 
 Other than those special cases, you should expect the same experience for basic operations like `Get`/`Put`, etc.
 
-Calls like `WatchTree` may return different events (or number of events) depending on the backend (for now, `Etcd` and `Consul` will likely return more events than `Zookeeper` that you should triage properly). Although you should be able to use it successfully to watch on events in an interchangeable way (see the **swarm/leadership** or **swarm/discovery** packages in **docker/swarm**).
+Calls like `WatchTree` may return different events (or number of events) depending on the backend (for now, `Etcd` and `Consul` will likely return more events than `Zookeeper` that you should triage properly). Although you should be able to use it successfully to watch on events in an interchangeable way (see the **docker/leadership** repository or the **pkg/discovery/kv** package in **docker/docker**).
 
 ## TLS
 
@@ -103,4 +104,4 @@ Want to hack on libkv? [Docker's contributions guidelines](https://github.com/do
 
 ##Copyright and license
 
-Copyright © 2014-2015 Docker, Inc. All rights reserved, except as follows. Code is released under the Apache 2.0 license. The README.md file, and files in the "docs" folder are licensed under the Creative Commons Attribution 4.0 International License under the terms and conditions set forth in the file "LICENSE.docs". You may obtain a duplicate copy of the same license, titled CC-BY-SA-4.0, at http://creativecommons.org/licenses/by/4.0/.
+Copyright © 2014-2016 Docker, Inc. All rights reserved, except as follows. Code is released under the Apache 2.0 license. The README.md file, and files in the "docs" folder are licensed under the Creative Commons Attribution 4.0 International License under the terms and conditions set forth in the file "LICENSE.docs". You may obtain a duplicate copy of the same license, titled CC-BY-SA-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/Godeps/_workspace/src/github.com/docker/libkv/libkv.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/libkv.go
@@ -25,7 +25,7 @@ var (
 	}()
 )
 
-// NewStore creates a an instance of store
+// NewStore creates an instance of store
 func NewStore(backend store.Backend, addrs []string, options *store.Config) (store.Store, error) {
 	if init, exists := initializers[backend]; exists {
 		return init(addrs, options)

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/boltdb/boltdb.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/boltdb/boltdb.go
@@ -19,8 +19,6 @@ var (
 	// ErrMultipleEndpointsUnsupported is thrown when multiple endpoints specified for
 	// BoltDB. Endpoint has to be a local file path
 	ErrMultipleEndpointsUnsupported = errors.New("boltdb supports one endpoint and should be a file path")
-	// ErrBoltBucketNotFound is thrown when specified BoltBD bucket doesn't exist in the DB
-	ErrBoltBucketNotFound = errors.New("boltdb bucket doesn't exist")
 	// ErrBoltBucketOptionMissing is thrown when boltBcuket config option is missing
 	ErrBoltBucketOptionMissing = errors.New("boltBucket config option missing")
 )
@@ -141,7 +139,7 @@ func (b *BoltDB) Get(key string) (*store.KVPair, error) {
 	err = db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
-			return ErrBoltBucketNotFound
+			return store.ErrKeyNotFound
 		}
 
 		v := bucket.Get([]byte(key))
@@ -217,7 +215,7 @@ func (b *BoltDB) Delete(key string) error {
 	err = db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
-			return ErrBoltBucketNotFound
+			return store.ErrKeyNotFound
 		}
 		err := bucket.Delete([]byte(key))
 		return err
@@ -243,7 +241,7 @@ func (b *BoltDB) Exists(key string) (bool, error) {
 	err = db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
-			return ErrBoltBucketNotFound
+			return store.ErrKeyNotFound
 		}
 
 		val = bucket.Get([]byte(key))
@@ -276,7 +274,7 @@ func (b *BoltDB) List(keyPrefix string) ([]*store.KVPair, error) {
 	err = db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
-			return ErrBoltBucketNotFound
+			return store.ErrKeyNotFound
 		}
 
 		cursor := bucket.Cursor()
@@ -326,7 +324,7 @@ func (b *BoltDB) AtomicDelete(key string, previous *store.KVPair) (bool, error) 
 	err = db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
-			return ErrBoltBucketNotFound
+			return store.ErrKeyNotFound
 		}
 
 		val = bucket.Get([]byte(key))
@@ -370,7 +368,7 @@ func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair, opt
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
 			if previous != nil {
-				return ErrBoltBucketNotFound
+				return store.ErrKeyNotFound
 			}
 			bucket, err = tx.CreateBucket(b.boltBucket)
 			if err != nil {
@@ -381,7 +379,7 @@ func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair, opt
 		// doesn't exist in the DB.
 		val = bucket.Get([]byte(key))
 		if previous == nil && len(val) != 0 {
-			return store.ErrKeyModified
+			return store.ErrKeyExists
 		}
 		if previous != nil {
 			if len(val) == 0 {
@@ -440,7 +438,7 @@ func (b *BoltDB) DeleteTree(keyPrefix string) error {
 	err = db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(b.boltBucket)
 		if bucket == nil {
-			return ErrBoltBucketNotFound
+			return store.ErrKeyNotFound
 		}
 
 		cursor := bucket.Cursor()

--- a/Godeps/_workspace/src/github.com/docker/libkv/store/store.go
+++ b/Godeps/_workspace/src/github.com/docker/libkv/store/store.go
@@ -35,6 +35,8 @@ var (
 	ErrKeyNotFound = errors.New("Key not found in store")
 	// ErrPreviousNotSpecified is thrown when the previous value is not specified for an atomic operation
 	ErrPreviousNotSpecified = errors.New("Previous K/V pair should be provided for the Atomic operation")
+	// ErrKeyExists is thrown when the previous value exists in the case of an AtomicPut
+	ErrKeyExists = errors.New("Previous K/V pair exists, cannot complete Atomic operation")
 )
 
 // Config contains the options for a storage client
@@ -44,6 +46,8 @@ type Config struct {
 	ConnectionTimeout time.Duration
 	Bucket            string
 	PersistConnection bool
+	Username          string
+	Password          string
 }
 
 // ClientTLSConfig contains data for a Client TLS configuration in the form

--- a/bitseq/sequence_test.go
+++ b/bitseq/sequence_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/store/boltdb"
 	"github.com/docker/libnetwork/datastore"
 	_ "github.com/docker/libnetwork/testutils"
 )
@@ -15,6 +16,10 @@ import (
 const (
 	defaultPrefix = "/tmp/libnetwork/test/bitseq"
 )
+
+func init() {
+	boltdb.Register()
+}
 
 func randomLocalStore() (datastore.DataStore, error) {
 	tmp, err := ioutil.TempFile("", "libnetwork-")

--- a/datastore/cache.go
+++ b/datastore/cache.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/docker/libkv/store"
-	"github.com/docker/libkv/store/boltdb"
 )
 
 type kvMap map[string]KVObject
@@ -42,9 +41,7 @@ func (c *cache) kmap(kvObject KVObject) (kvMap, error) {
 
 	kvList, err := c.ds.store.List(keyPrefix)
 	if err != nil {
-		// In case of BoltDB it may return ErrBoltBucketNotFound when no writes
-		// have ever happened on the db bucket. So check for both err codes
-		if err == store.ErrKeyNotFound || err == boltdb.ErrBoltBucketNotFound {
+		if err == store.ErrKeyNotFound {
 			// If the store doesn't have anything then there is nothing to
 			// populate in the cache. Just bail out.
 			goto out

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -9,10 +9,6 @@ import (
 
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
-	"github.com/docker/libkv/store/boltdb"
-	"github.com/docker/libkv/store/consul"
-	"github.com/docker/libkv/store/etcd"
-	"github.com/docker/libkv/store/zookeeper"
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/types"
 )
@@ -147,13 +143,6 @@ func makeDefaultScopes() map[string]*ScopeCfg {
 
 var defaultRootChain = []string{"docker", "network", "v1.0"}
 var rootChain = defaultRootChain
-
-func init() {
-	consul.Register()
-	zookeeper.Register()
-	etcd.Register()
-	boltdb.Register()
-}
 
 // DefaultScopes returns a map of default scopes and it's config for clients to use.
 func DefaultScopes(dataDir string) map[string]*ScopeCfg {
@@ -411,6 +400,9 @@ func (ds *datastore) PutObjectAtomic(kvObject KVObject) error {
 
 	_, pair, err = ds.store.AtomicPut(Key(kvObject.Key()...), kvObjValue, previous, nil)
 	if err != nil {
+		if err == store.ErrKeyExists {
+			return ErrKeyModified
+		}
 		return err
 	}
 
@@ -571,6 +563,9 @@ func (ds *datastore) DeleteObjectAtomic(kvObject KVObject) error {
 	}
 
 	if _, err := ds.store.AtomicDelete(Key(kvObject.Key()...), previous); err != nil {
+		if err == store.ErrKeyExists {
+			return ErrKeyModified
+		}
 		return err
 	}
 

--- a/drivers/bridge/bridge_store.go
+++ b/drivers/bridge/bridge_store.go
@@ -6,7 +6,6 @@ import (
 	"net"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/libkv/store/boltdb"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/netlabel"
@@ -35,7 +34,7 @@ func (d *driver) initStore(option map[string]interface{}) error {
 
 func (d *driver) populateNetworks() error {
 	kvol, err := d.store.List(datastore.Key(bridgePrefix), &networkConfiguration{})
-	if err != nil && err != datastore.ErrKeyNotFound && err != boltdb.ErrBoltBucketNotFound {
+	if err != nil && err != datastore.ErrKeyNotFound {
 		return fmt.Errorf("failed to get bridge network configurations from store: %v", err)
 	}
 

--- a/drivers/ipvlan/ipvlan_store.go
+++ b/drivers/ipvlan/ipvlan_store.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/libkv/store/boltdb"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/netlabel"
@@ -60,7 +59,7 @@ func (d *driver) initStore(option map[string]interface{}) error {
 // populateNetworks is invoked at driver init to recreate persistently stored networks
 func (d *driver) populateNetworks() error {
 	kvol, err := d.store.List(datastore.Key(ipvlanPrefix), &configuration{})
-	if err != nil && err != datastore.ErrKeyNotFound && err != boltdb.ErrBoltBucketNotFound {
+	if err != nil && err != datastore.ErrKeyNotFound {
 		return fmt.Errorf("failed to get ipvlan network configurations from store: %v", err)
 	}
 	// If empty it simply means no ipvlan networks have been created yet

--- a/drivers/macvlan/macvlan_store.go
+++ b/drivers/macvlan/macvlan_store.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/libkv/store/boltdb"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/netlabel"
@@ -60,7 +59,7 @@ func (d *driver) initStore(option map[string]interface{}) error {
 // populateNetworks is invoked at driver init to recreate persistently stored networks
 func (d *driver) populateNetworks() error {
 	kvol, err := d.store.List(datastore.Key(macvlanPrefix), &configuration{})
-	if err != nil && err != datastore.ErrKeyNotFound && err != boltdb.ErrBoltBucketNotFound {
+	if err != nil && err != datastore.ErrKeyNotFound {
 		return fmt.Errorf("failed to get macvlan network configurations from store: %v", err)
 	}
 	// If empty it simply means no macvlan networks have been created yet

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/docker/libkv/store/boltdb"
 	"github.com/docker/libnetwork/bitseq"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
@@ -24,6 +25,10 @@ const (
 	dsConfigKey = "ipam/" + ipamapi.DefaultIPAM + "/config"
 	dsDataKey   = "ipam/" + ipamapi.DefaultIPAM + "/data"
 )
+
+func init() {
+	boltdb.Register()
+}
 
 // Allocator provides per address space ipv4/ipv6 book keeping
 type Allocator struct {

--- a/store.go
+++ b/store.go
@@ -4,8 +4,19 @@ import (
 	"fmt"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/docker/libkv/store/boltdb"
+	"github.com/docker/libkv/store/consul"
+	"github.com/docker/libkv/store/etcd"
+	"github.com/docker/libkv/store/zookeeper"
 	"github.com/docker/libnetwork/datastore"
 )
+
+func registerKVStores() {
+	consul.Register()
+	zookeeper.Register()
+	etcd.Register()
+	boltdb.Register()
+}
 
 func (c *controller) initScopedStore(scope string, scfg *datastore.ScopeCfg) error {
 	store, err := datastore.NewDataStore(scope, scfg)
@@ -20,6 +31,8 @@ func (c *controller) initScopedStore(scope string, scfg *datastore.ScopeCfg) err
 }
 
 func (c *controller) initStores() error {
+	registerKVStores()
+
 	c.Lock()
 	if c.cfg == nil {
 		c.Unlock()


### PR DESCRIPTION
Currently datastore has dependencies on various kv backends.
This is undesirable if datastore had to be used as a backend
agnostic store management package with it's cache layer. This
PR aims to achieve that.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>