### PR TITLE
Need boltdb Register only in tests

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/docker/libkv/store/boltdb"
 	"github.com/docker/libnetwork/bitseq"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
@@ -25,10 +24,6 @@ const (
 	dsConfigKey = "ipam/" + ipamapi.DefaultIPAM + "/config"
 	dsDataKey   = "ipam/" + ipamapi.DefaultIPAM + "/data"
 )
-
-func init() {
-	boltdb.Register()
-}
 
 // Allocator provides per address space ipv4/ipv6 book keeping
 type Allocator struct {

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/store/boltdb"
 	"github.com/docker/libnetwork/bitseq"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/ipamapi"
@@ -23,6 +24,10 @@ import (
 const (
 	defaultPrefix = "/tmp/libnetwork/test/ipam"
 )
+
+func init() {
+	boltdb.Register()
+}
 
 // OptionBoltdbWithRandomDBFile function returns a random dir for local store backend
 func randomLocalStore() (datastore.DataStore, error) {


### PR DESCRIPTION
Fixing an earlier commit which needlessly registered
boltdb in allocator.go while it is needed only for tests.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>