### PR TITLE
 Make o/p of ipam DumpDatabase() consistent

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -3,6 +3,7 @@ package ipam
 import (
 	"fmt"
 	"net"
+	"sort"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
@@ -554,13 +555,18 @@ func (a *Allocator) getAddress(nw *net.IPNet, bitmask *bitseq.Handle, prefAddres
 func (a *Allocator) DumpDatabase() string {
 	a.Lock()
 	aspaces := make(map[string]*addrSpace, len(a.addrSpaces))
+	orderedAS := make([]string, 0, len(a.addrSpaces))
 	for as, aSpace := range a.addrSpaces {
+		orderedAS = append(orderedAS, as)
 		aspaces[as] = aSpace
 	}
 	a.Unlock()
 
+	sort.Strings(orderedAS)
+
 	var s string
-	for as, aSpace := range aspaces {
+	for _, as := range orderedAS {
+		aSpace := aspaces[as]
 		s = fmt.Sprintf("\n\n%s Config", as)
 		aSpace.Lock()
 		for k, config := range aSpace.subnets {


### PR DESCRIPTION
This fixes TestRetrieveFromStore which became flaky after recently ipam changes.

Signed-off-by: Alessandro Boch <aboch@docker.com>