### PR TITLE
Fix cross compilation issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ dockerargs = --privileged -v $(shell pwd):/go/src/github.com/docker/libnetwork -
 container_env = -e "INSIDECONTAINER=-incontainer=true"
 docker = docker run --rm -it ${dockerargs} $$EXTRA_ARGS ${container_env} ${build_image}
 ciargs = -e CIRCLECI -e "COVERALLS_TOKEN=$$COVERALLS_TOKEN" -e "INSIDECONTAINER=-incontainer=true"
-cidocker = docker run ${dockerargs} ${ciargs} ${container_env} ${build_image}
-CROSS_PLATFORMS = linux/amd64 linux/386 linux/arm windows/amd64 windows/386 solaris/amd64 solaris/386
+cidocker = docker run ${dockerargs} ${ciargs} $$EXTRA_ARGS ${container_env} ${build_image}
+CROSS_PLATFORMS = linux/amd64 linux/386 linux/arm windows/amd64
 
 all: ${build_image}.created build check integration-tests clean
 

--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/docker/pkg/reexec"
 
 	"github.com/Sirupsen/logrus"
-	psignal "github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/libnetwork"
 	"github.com/docker/libnetwork/api"
@@ -261,16 +260,6 @@ func (d *dnetConnection) dnetDaemon(cfgFile string) error {
 	setupDumpStackTrap()
 
 	return http.ListenAndServe(d.addr, r)
-}
-
-func setupDumpStackTrap() {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGUSR1)
-	go func() {
-		for range c {
-			psignal.DumpStacks()
-		}
-	}()
 }
 
 func handleSignals(controller libnetwork.NetworkController) {

--- a/cmd/dnet/dnet_linux.go
+++ b/cmd/dnet/dnet_linux.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	psignal "github.com/docker/docker/pkg/signal"
+)
+
+func setupDumpStackTrap() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGUSR1)
+	go func() {
+		for range c {
+			psignal.DumpStacks()
+		}
+	}()
+}

--- a/cmd/dnet/dnet_windows.go
+++ b/cmd/dnet/dnet_windows.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/signal"
+	"github.com/docker/docker/pkg/system"
+)
+
+// Copied over from docker/daemon/debugtrap_windows.go
+func setupDumpStackTrap() {
+	go func() {
+		sa := syscall.SecurityAttributes{
+			Length: 0,
+		}
+		ev := "Global\\docker-daemon-" + fmt.Sprint(os.Getpid())
+		if h, _ := system.CreateEvent(&sa, false, false, ev); h != 0 {
+			logrus.Debugf("Stackdump - waiting signal at %s", ev)
+			for {
+				syscall.WaitForSingleObject(h, syscall.INFINITE)
+				signal.DumpStacks()
+			}
+		}
+	}()
+}

--- a/netutils/utils_solaris.go
+++ b/netutils/utils_solaris.go
@@ -1,10 +1,11 @@
-// Package ipamutils provides utililty functions for ipam management
-package ipamutils
+package netutils
 
 // Solaris: TODO
 
 import (
 	"net"
+
+	"github.com/docker/libnetwork/ipamutils"
 )
 
 // ElectInterfaceAddresses looks for an interface on the OS with the specified name
@@ -17,7 +18,7 @@ func ElectInterfaceAddresses(name string) (*net.IPNet, []*net.IPNet, error) {
 		err   error
 	)
 
-	v4Net, err = FindAvailableNetwork(PredefinedBroadNetworks)
+	v4Net, err = FindAvailableNetwork(ipamutils.PredefinedBroadNetworks)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
- Fix circle-ci-cross target
- Remove unsupported os/arch targets (solaris cannot build yet because of cgo in term pkg)
- Fix dnet build for windows/amd64
- Fix a solaris build breakage (ipamutils -> netutils change)

With this change circle ci will now monitor build breakages over windows/amd64, besides linux over 386/amd64/arm

Signed-off-by: Alessandro Boch <aboch@docker.com>