### PR TITLE
Fix gossip network event overwriting self

### DIFF
--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -197,9 +197,14 @@ func (nDB *NetworkDB) gossip() {
 		broadcastQ := nDB.networks[nDB.config.NodeName][nid].tableBroadcasts
 		nDB.RUnlock()
 
+		if broadcastQ == nil {
+			logrus.Errorf("Invalid broadcastQ encountered while gossiping for network %s", nid)
+			continue
+		}
+
 		msgs := broadcastQ.GetBroadcasts(compoundOverhead, bytesAvail)
 		if len(msgs) == 0 {
-			break
+			continue
 		}
 
 		// Create a compound message

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -336,10 +336,6 @@ func (nDB *NetworkDB) WalkTable(tname string, fn func(string, string, []byte) bo
 func (nDB *NetworkDB) JoinNetwork(nid string) error {
 	ltime := nDB.networkClock.Increment()
 
-	if err := nDB.sendNetworkEvent(nid, networkJoin, ltime); err != nil {
-		return fmt.Errorf("failed to send leave network event for %s: %v", nid, err)
-	}
-
 	nDB.Lock()
 	nodeNetworks, ok := nDB.networks[nDB.config.NodeName]
 	if !ok {
@@ -355,6 +351,10 @@ func (nDB *NetworkDB) JoinNetwork(nid string) error {
 	}
 	nDB.networkNodes[nid] = append(nDB.networkNodes[nid], nDB.config.NodeName)
 	nDB.Unlock()
+
+	if err := nDB.sendNetworkEvent(nid, networkJoin, ltime); err != nil {
+		return fmt.Errorf("failed to send leave network event for %s: %v", nid, err)
+	}
 
 	logrus.Debugf("%s: joined network %s", nDB.config.NodeName, nid)
 	if _, err := nDB.bulkSync(nid, true); err != nil {


### PR DESCRIPTION
When a node joins a network it sends out a gossip event before it
updates it's own in-memory state. This can create a race where the node
gets the event back from a remote node before we update in-memory state
and we treat that as latest state. To avoid this race, always generate
the gossip after updating local state.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>