### PR TITLE
don't add /etc/hosts record if container's ip is empty (--net=none)

### DIFF
--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -90,6 +90,10 @@ func (sb *sandbox) buildHostsFile() error {
 func (sb *sandbox) updateHostsFile(ifaceIP string) error {
 	var mhost string
 
+	if ifaceIP == "" {
+		return nil
+	}
+
 	if sb.config.originHostsPath != "" {
 		return nil
 	}


### PR DESCRIPTION
fix for #1146.

When started with --net=none, there is an invalid entry in /etc/hosts with empty ip. This fix is adding a validation if IP is empty and skips the operation if necessary.