### PR TITLE
Fix cleanup logic in case of ipv6 allocation failure

### DIFF
--- a/network.go
+++ b/network.go
@@ -1094,7 +1094,12 @@ func (n *network) ipamAllocate() error {
 		return nil
 	}
 
-	return n.ipamAllocateVersion(6, ipam)
+	err = n.ipamAllocateVersion(6, ipam)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (n *network) requestPoolHelper(ipam ipamapi.Ipam, addressSpace, preferredPool, subPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {


### PR DESCRIPTION
- When creating a network with both IPv4 and IPv6 subnets,
  if the allocation of the IPv6 pool fails, the already
  reserved IPv4 pool does not get released.

Signed-off-by: Alessandro Boch <aboch@docker.com>