### PR TITLE
Set persist flag on the dummy network object during cleanup

### DIFF
--- a/sandbox_store.go
+++ b/sandbox_store.go
@@ -213,7 +213,7 @@ func (c *controller) sandboxCleanup() {
 			var ep *endpoint
 			if err != nil {
 				logrus.Errorf("getNetworkFromStore for nid %s failed while trying to build sandbox for cleanup: %v", eps.Nid, err)
-				n = &network{id: eps.Nid, ctrlr: c, drvOnce: &sync.Once{}}
+				n = &network{id: eps.Nid, ctrlr: c, drvOnce: &sync.Once{}, persist: true}
 				ep = &endpoint{id: eps.Eid, network: n, sandboxID: sbs.ID}
 			} else {
 				ep, err = n.getEndpointFromStore(eps.Eid)


### PR DESCRIPTION
During sandboxcleanup operation, a dummy object is created if the
kv-store is inaccessible during the daemon bootup. The dummy object is
used for local processing of sandbox/endpoint cleanup operation. But
unfortunately, since the persist flag was not set, the Skip()
functionality kicked-in when sandbox was written back to the store and
global endpoint was skipped to be tracked.  During a subsequent cleanup
operation, sandbox was removed and the global endpoint was left stale in
the kv-store.

The fix is to set the persist flag in the dummy object and that handles
the sandbox and endpoint states appropriately and endpoint object is
properly cleaned up when the KVStore becomes available.

Signed-off-by: Madhu Venugopal <madhu@docker.com>