### PR TITLE
IPAM allocator to not accept a datastore update if already present

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -147,9 +147,11 @@ func (a *Allocator) initializeAddressSpace(as string, ds datastore.DataStore) er
 	}
 
 	a.Lock()
-	if _, ok := a.addrSpaces[as]; ok {
-		a.Unlock()
-		return types.ForbiddenErrorf("tried to add an axisting address space: %s", as)
+	if currAS, ok := a.addrSpaces[as]; ok {
+		if currAS.ds != nil {
+			a.Unlock()
+			return types.ForbiddenErrorf("a datastore is already configured for the address space %s", as)
+		}
 	}
 	a.addrSpaces[as] = &addrSpace{
 		subnets: map[SubnetKey]*PoolData{},


### PR DESCRIPTION
After #1119, IPAM driver needs to be updated to still block a datastore update for the address space if the address space already has a backing datastore.
Before it was enough to check for the address space presence, since it was getting initialized only if it had a backing datastore. Now this assumption is no longer true.

Signed-off-by: Alessandro Boch <aboch@docker.com>