### PR TITLE
Read veth stats from host

### DIFF
--- a/osl/sandbox_linux_test.go
+++ b/osl/sandbox_linux_test.go
@@ -181,14 +181,14 @@ func TestScanStatistics(t *testing.T) {
 	if err := scanInterfaceStats(data, "wlan0", i); err != nil {
 		t.Fatal(err)
 	}
-	if i.TxBytes != 1681390 || i.TxPackets != 7220 || i.RxBytes != 7787685 || i.RxPackets != 11141 {
+	if i.RxBytes != 1681390 || i.RxPackets != 7220 || i.TxBytes != 7787685 || i.TxPackets != 11141 {
 		t.Fatalf("Error scanning the statistics")
 	}
 
 	if err := scanInterfaceStats(data, "lxcbr0", i); err != nil {
 		t.Fatal(err)
 	}
-	if i.TxBytes != 9006 || i.TxPackets != 61 || i.RxBytes != 0 || i.RxPackets != 0 {
+	if i.RxBytes != 9006 || i.RxPackets != 61 || i.TxBytes != 0 || i.TxPackets != 0 {
 		t.Fatalf("Error scanning the statistics")
 	}
 }


### PR DESCRIPTION
There is no need to do a setns to the network namespace to collect the
stats of a veth.  You can read the host side of the veth pairs stats,
from the host, and all you have to do is swap the rx/tx because of what
side you are reading from.

This removes the need for libnetwork to do a `setns`, changing the
callers namespace and the need to `cat` the file.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>