### PR TITLE
Do not allow network creation if datastore is missing

### DIFF
--- a/sandbox_test.go
+++ b/sandbox_test.go
@@ -10,11 +10,7 @@ import (
 	"github.com/docker/libnetwork/testutils"
 )
 
-func createEmptyCtrlr() *controller {
-	return &controller{sandboxes: sandboxTable{}}
-}
-
-func getTestEnv(t *testing.T) (NetworkController, Network, Network) {
+func getTestEnv(t *testing.T, empty bool) (NetworkController, Network, Network) {
 	netType := "bridge"
 
 	option := options.Generic{
@@ -30,6 +26,10 @@ func getTestEnv(t *testing.T) (NetworkController, Network, Network) {
 	c, err := New(append(cfgOptions, config.OptionDriverConfig(netType, genericOption))...)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if empty {
+		return c, nil, nil
 	}
 
 	name1 := "test_nw_1"
@@ -58,7 +58,8 @@ func getTestEnv(t *testing.T) (NetworkController, Network, Network) {
 }
 
 func TestSandboxAddEmpty(t *testing.T) {
-	ctrlr := createEmptyCtrlr()
+	c, _, _ := getTestEnv(t, true)
+	ctrlr := c.(*controller)
 
 	sbx, err := ctrlr.NewSandbox("sandbox0")
 	if err != nil {
@@ -81,7 +82,7 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 		defer testutils.SetupTestOSContext(t)()
 	}
 
-	c, nw, _ := getTestEnv(t)
+	c, nw, _ := getTestEnv(t, false)
 	ctrlr := c.(*controller)
 
 	sbx, err := ctrlr.NewSandbox("sandbox1")
@@ -162,7 +163,7 @@ func TestSandboxAddSamePrio(t *testing.T) {
 		defer testutils.SetupTestOSContext(t)()
 	}
 
-	c, nw1, nw2 := getTestEnv(t)
+	c, nw1, nw2 := getTestEnv(t, false)
 
 	ctrlr := c.(*controller)
 

--- a/store.go
+++ b/store.go
@@ -221,8 +221,7 @@ func (n *network) getEndpointsFromStore() ([]*endpoint, error) {
 func (c *controller) updateToStore(kvObject datastore.KVObject) error {
 	cs := c.getStore(kvObject.DataScope())
 	if cs == nil {
-		log.Warnf("datastore for scope %s not initialized. kv object %s is not added to the store", kvObject.DataScope(), datastore.Key(kvObject.Key()...))
-		return nil
+		return fmt.Errorf("datastore for scope %q is not initialized ", kvObject.DataScope())
 	}
 
 	if err := cs.PutObjectAtomic(kvObject); err != nil {
@@ -238,8 +237,7 @@ func (c *controller) updateToStore(kvObject datastore.KVObject) error {
 func (c *controller) deleteFromStore(kvObject datastore.KVObject) error {
 	cs := c.getStore(kvObject.DataScope())
 	if cs == nil {
-		log.Debugf("datastore for scope %s not initialized. kv object %s is not deleted from datastore", kvObject.DataScope(), datastore.Key(kvObject.Key()...))
-		return nil
+		return fmt.Errorf("datastore for scope %q is not initialized ", kvObject.DataScope())
 	}
 
 retry:


### PR DESCRIPTION
- Earlier this was guaranteed by ipam driver intialization
  which was not creating a global address space if the
  global datastore was missing. Now that ipam address spaces
  can be initialized with no backing datastore, insert an
  explicit check in libnetwork, which should have been there
  regardless.

Signed-off-by: Alessandro Boch <aboch@docker.com>