### PR TITLE
Protect cap access in driver()

### DIFF
--- a/network.go
+++ b/network.go
@@ -665,7 +665,10 @@ func (n *network) driver(load bool) (driverapi.Driver, error) {
 
 	c := n.getController()
 	n.Lock()
-	n.scope = cap.DataScope
+	// If load is not required, driver, cap and err may all be nil
+	if cap != nil {
+		n.scope = cap.DataScope
+	}
 	if c.cfg.Daemon.IsAgent {
 		// If we are running in agent mode then all networks
 		// in libnetwork are local scope regardless of the


### PR DESCRIPTION
During resource cleanup driver resolution does not require the loading of the driver.
If the driver is not yet registered, `driverResolution()` is programmed to not fail and return a nil driver, cap and error. Calling code is therefore expected to gracefully handle this situation.


Signed-off-by: Alessandro Boch <aboch@docker.com>