### PR TITLE
Fix flakiness in dnet_exec

### DIFF
--- a/test/integration/dnet/helpers.bash
+++ b/test/integration/dnet/helpers.bash
@@ -254,7 +254,7 @@ function dnet_cmd() {
 }
 
 function dnet_exec() {
-    docker exec -it ${1} bash -c "$2"
+    docker exec -it ${1} bash -c "trap \"echo SIGHUP\" SIGHUP; $2"
 }
 
 function runc() {


### PR DESCRIPTION
With docker 1.11 based dnet tests, the dnet_exec is sometimes exiting
with exit code 129 because the process is getting a SIGHUP. Although the
reason or source of the SIGHUP is unknown, it is making the tests flaky
because non-zero exit code. Fixed it by trapping SIGHUP inside the
container so that we can run the test code successfully.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>