### PR TITLE
Switch to golang 1.5.4

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.5.3
+FROM golang:1.5.4
 RUN apt-get update && apt-get -y install iptables
 
 RUN go get github.com/tools/godep \


### PR DESCRIPTION
Security fix for Go:
https://groups.google.com/forum/#!msg/golang-announce/9eqIHqaWvck/kXsfO0ogLAAJ

Note that for docker/docker, we're now in the process to switching to Go 1.6 (again), see https://github.com/docker/docker/pull/22840