### PR TITLE
for fix CI tools/cmd/vet has been deleted

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,6 @@ machine:
 dependencies:
   override:
     - sudo apt-get update; sudo apt-get install -y iptables zookeeperd 
-    - go get golang.org/x/tools/cmd/vet
     - go get golang.org/x/tools/cmd/goimports
     - go get golang.org/x/tools/cmd/cover
     - go get github.com/tools/godep


### PR DESCRIPTION
Related to #1089
fail to ```go get golang.org/x/tools/cmd/vet``` in Circle Ci test.
For Circle Ci test, must fix not only Dockerfile.build but also  circileci.yml.

Signed-off-by: YujiOshima <yuji.oshima0x3fd@gmail.com>