### PR TITLE
Reset endpoint port info on connectivity revoke in bridge driver

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -1245,6 +1245,9 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 		logrus.Warn(err)
 	}
 
+	endpoint.extConnConfig = nil
+	endpoint.portMapping = nil
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Alessandro Boch <aboch@docker.com>