### PR TITLE
Add ingress load balancer

### DIFF
--- a/agent.proto
+++ b/agent.proto
@@ -11,10 +11,56 @@ option (gogoproto.gostring_all) = true;
 option (gogoproto.sizer_all) = true;
 option (gogoproto.goproto_stringer_all) = false;
 
+// EndpointRecord specifies all the endpoint specific information that
+// needs to gossiped to nodes participating in the network.
 message EndpointRecord {
+	// Name of the endpoint
 	string name = 1;
+
+	// Service name of the service to which this endpoint belongs.
 	string service_name = 2;
+
+	// Service ID of the service to which this endpoint belongs.
 	string service_id = 3 [(gogoproto.customname) = "ServiceID"];
+
+	// Virtual IP of the service to which this endpoint belongs.
 	string virtual_ip = 4 [(gogoproto.customname) = "VirtualIP"];
+
+	// IP assigned to this endpoint.
 	string endpoint_ip = 5 [(gogoproto.customname) = "EndpointIP"];
+
+	// IngressPorts exposed by the service to which this endpoint belongs.
+	repeated PortConfig ingress_ports = 6;
+}
+
+// PortConfig specifies an exposed port which can be
+// addressed using the given name. This can be later queried
+// using a service discovery api or a DNS SRV query. The node
+// port specifies a port that can be used to address this
+// service external to the cluster by sending a connection
+// request to this port to any node on the cluster.
+message PortConfig {
+	enum Protocol {
+		option (gogoproto.goproto_enum_prefix) = false;
+
+		TCP = 0 [(gogoproto.enumvalue_customname) = "ProtocolTCP"];
+		UDP = 1 [(gogoproto.enumvalue_customname) = "ProtocolUDP"];
+	}
+
+	// Name for the port. If provided the port information can
+	// be queried using the name as in a DNS SRV query.
+	string name = 1;
+
+	// Protocol for the port which is exposed.
+	Protocol protocol = 2;
+
+	// The port which the application is exposing and is bound to.
+	uint32 port = 3;
+
+	// NodePort specifies the port on which the service is
+	// exposed on all nodes on the cluster. If not specified an
+	// arbitrary port in the node port range is allocated by the
+	// system. If specified it should be within the node port
+	// range and it should be available.
+	uint32 node_port = 4;
 }

--- a/ipvs/netlink.go
+++ b/ipvs/netlink.go
@@ -7,10 +7,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"os/exec"
+	"strings"
 	"sync"
 	"syscall"
 	"unsafe"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
 )
@@ -55,6 +58,10 @@ func (f *ipvsFlags) Len() int {
 func setup() {
 	ipvsOnce.Do(func() {
 		var err error
+		if out, err := exec.Command("modprobe", "-va", "ip_vs").CombinedOutput(); err != nil {
+			logrus.Warnf("Running modprobe nf_nat failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+		}
+
 		ipvsFamily, err = getIPVSFamily()
 		if err != nil {
 			panic("could not get ipvs family")

--- a/network.go
+++ b/network.go
@@ -185,6 +185,7 @@ type network struct {
 	drvOnce      *sync.Once
 	internal     bool
 	inDelete     bool
+	ingress      bool
 	driverTables []string
 	sync.Mutex
 }
@@ -326,6 +327,7 @@ func (n *network) CopyTo(o datastore.KVObject) error {
 	dstN.drvOnce = n.drvOnce
 	dstN.internal = n.internal
 	dstN.inDelete = n.inDelete
+	dstN.ingress = n.ingress
 
 	// copy labels
 	if dstN.labels == nil {
@@ -432,6 +434,7 @@ func (n *network) MarshalJSON() ([]byte, error) {
 	}
 	netMap["internal"] = n.internal
 	netMap["inDelete"] = n.inDelete
+	netMap["ingress"] = n.ingress
 	return json.Marshal(netMap)
 }
 
@@ -522,6 +525,9 @@ func (n *network) UnmarshalJSON(b []byte) (err error) {
 	if v, ok := netMap["inDelete"]; ok {
 		n.inDelete = v.(bool)
 	}
+	if v, ok := netMap["ingress"]; ok {
+		n.ingress = v.(bool)
+	}
 	// Reconcile old networks with the recently added `--ipv6` flag
 	if !n.enableIPv6 {
 		n.enableIPv6 = len(n.ipamV6Info) > 0
@@ -550,6 +556,14 @@ func NetworkOptionGeneric(generic map[string]interface{}) NetworkOption {
 		for k, v := range generic {
 			n.generic[k] = v
 		}
+	}
+}
+
+// NetworkOptionIngress returns an option setter to indicate if a network is
+// an ingress network.
+func NetworkOptionIngress() NetworkOption {
+	return func(n *network) {
+		n.ingress = true
 	}
 }
 

--- a/sandbox.go
+++ b/sandbox.go
@@ -84,6 +84,7 @@ type sandbox struct {
 	dbExists      bool
 	isStub        bool
 	inDelete      bool
+	ingress       bool
 	sync.Mutex
 }
 
@@ -1010,6 +1011,14 @@ func OptionPortMapping(portBindings []types.PortBinding) SandboxOption {
 		pbs := make([]types.PortBinding, len(portBindings))
 		copy(pbs, portBindings)
 		sb.config.generic[netlabel.PortMap] = pbs
+	}
+}
+
+// OptionIngress function returns an option setter for marking a
+// sandbox as the controller's ingress sandbox.
+func OptionIngress() SandboxOption {
+	return func(sb *sandbox) {
+		sb.ingress = true
 	}
 }
 

--- a/service.go
+++ b/service.go
@@ -19,6 +19,10 @@ type service struct {
 	// Map of loadbalancers for the service one-per attached
 	// network. It is keyed with network ID.
 	loadBalancers map[string]*loadBalancer
+
+	// List of ingress ports exposed by the service
+	ingressPorts []*PortConfig
+
 	sync.Mutex
 }
 
@@ -29,4 +33,7 @@ type loadBalancer struct {
 	// Map of backend IPs backing this loadbalancer on this
 	// network. It is keyed with endpoint ID.
 	backEnds map[string]net.IP
+
+	// Back pointer to service to which the loadbalancer belongs.
+	service *service
 }

--- a/service_unsupported.go
+++ b/service_unsupported.go
@@ -7,11 +7,11 @@ import (
 	"net"
 )
 
-func (c *controller) addServiceBinding(name, sid, nid, eid string, vip net.IP, ip net.IP) error {
+func (c *controller) addServiceBinding(name, sid, nid, eid string, vip net.IP, ingressPorts []*PortConfig, ip net.IP) error {
 	return fmt.Errorf("not supported")
 }
 
-func (c *controller) rmServiceBinding(name, sid, nid, eid string, vip net.IP, ip net.IP) error {
+func (c *controller) rmServiceBinding(name, sid, nid, eid string, vip net.IP, ingressPorts []*PortConfig, ip net.IP) error {
 	return fmt.Errorf("not supported")
 }
 


### PR DESCRIPTION
Ingress load balancer is achieved via a service sandbox which acts as
the proxy to translate incoming node port requests and mapping that to a
service entry. Once the right service is identified, the same internal
loadbalancer implementation is used to load balance to the right backend
instance.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>