### PR TITLE
Reset agentInitDone channel when leaving a cluster

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -265,6 +265,7 @@ func (c *controller) clusterAgentInit() {
 					}
 				}
 			} else {
+				c.agentInitDone = make(chan struct{})
 				c.agentClose()
 			}
 		}


### PR DESCRIPTION
When leaving a cluster the agentInitDone should be re-initialized so tha
when a new cluster is initialized this is usable.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>