### PR TITLE
Do not plumb local peers as remote peers

### DIFF
--- a/drivers/overlay/joinleave.go
+++ b/drivers/overlay/joinleave.go
@@ -138,6 +138,12 @@ func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key stri
 		return
 	}
 
+	// Ignore local peers. We already know about them and they
+	// should not be added to vxlan fdb.
+	if peer.TunnelEndpointIP == d.bindAddress {
+		return
+	}
+
 	addr, err := types.ParseCIDR(peer.EndpointIP)
 	if err != nil {
 		log.Errorf("Invalid peer IP %s received in event notify", peer.EndpointIP)


### PR DESCRIPTION
In the current implementation, the local peers are being added as remote
peers so gets added to the vxlan neighbor and fdb table. This causes the
local forwarding to get stuck for a few seconds after the bridge mac
table entries for the local peers get aged out. This PR fixes the
problem.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>