### PR TITLE
Use controller methods for handling the encyrption keys from agent

### DIFF
--- a/cluster/provider.go
+++ b/cluster/provider.go
@@ -1,7 +1,5 @@
 package cluster
 
-import "github.com/docker/libnetwork/types"
-
 // Provider provides clustering config details
 type Provider interface {
 	IsManager() bool
@@ -9,6 +7,4 @@ type Provider interface {
 	GetListenAddress() string
 	GetRemoteAddress() string
 	ListenClusterEvents() <-chan struct{}
-	GetNetworkKeys() []*types.EncryptionKey
-	SetNetworkKeys([]*types.EncryptionKey)
 }


### PR DESCRIPTION
Instead of using Provider interface methods to get the encryption keys added a controller function that will be called by the daemon.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>