### PR TITLE
Allow to program Endpoint link-local addresses

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -832,11 +832,25 @@ func EndpointOptionGeneric(generic map[string]interface{}) EndpointOption {
 	}
 }
 
+var (
+	linkLocalMask     = net.CIDRMask(16, 32)
+	linkLocalMaskIPv6 = net.CIDRMask(64, 128)
+)
+
 // CreateOptionIpam function returns an option setter for the ipam configuration for this endpoint
-func CreateOptionIpam(ipV4, ipV6 net.IP, ipamOptions map[string]string) EndpointOption {
+func CreateOptionIpam(ipV4, ipV6 net.IP, llIPs []net.IP, ipamOptions map[string]string) EndpointOption {
 	return func(ep *endpoint) {
 		ep.prefAddress = ipV4
 		ep.prefAddressV6 = ipV6
+		if len(llIPs) != 0 {
+			for _, ip := range llIPs {
+				nw := &net.IPNet{IP: ip, Mask: linkLocalMask}
+				if ip.To4() == nil {
+					nw.Mask = linkLocalMaskIPv6
+				}
+				ep.iface.llAddrs = append(ep.iface.llAddrs, nw)
+			}
+		}
 		ep.ipamOptions = ipamOptions
 	}
 }

--- a/network.go
+++ b/network.go
@@ -801,6 +801,12 @@ func (n *network) CreateEndpoint(name string, options ...EndpointOption) (Endpoi
 
 	ep.processOptions(options...)
 
+	for _, llIPNet := range ep.Iface().LinkLocalAddresses() {
+		if !llIPNet.IP.IsLinkLocalUnicast() {
+			return nil, types.BadRequestErrorf("invalid link local IP address: %v", llIPNet.IP)
+		}
+	}
+
 	if opt, ok := ep.generic[netlabel.MacAddress]; ok {
 		if mac, ok := opt.(net.HardwareAddr); ok {
 			ep.iface.mac = mac

--- a/osl/options_linux.go
+++ b/osl/options_linux.go
@@ -60,6 +60,12 @@ func (n *networkNamespace) AddressIPv6(addr *net.IPNet) IfaceOption {
 	}
 }
 
+func (n *networkNamespace) LinkLocalAddresses(list []*net.IPNet) IfaceOption {
+	return func(i *nwIface) {
+		i.llAddrs = list
+	}
+}
+
 func (n *networkNamespace) Routes(routes []*net.IPNet) IfaceOption {
 	return func(i *nwIface) {
 		i.routes = routes

--- a/osl/sandbox.go
+++ b/osl/sandbox.go
@@ -85,6 +85,9 @@ type IfaceOptionSetter interface {
 	// Address returns an option setter to set IPv6 address.
 	AddressIPv6(*net.IPNet) IfaceOption
 
+	// LinkLocalAddresses returns an option setter to set the link-local IP addresses.
+	LinkLocalAddresses([]*net.IPNet) IfaceOption
+
 	// Master returns an option setter to set the master interface if any for this
 	// interface. The master interface name should refer to the srcname of a
 	// previously added interface of type bridge.
@@ -137,6 +140,9 @@ type Interface interface {
 
 	// IPv6 address for the interface.
 	AddressIPv6() *net.IPNet
+
+	// LinkLocalAddresses returns the link-local IP addresses assigned to the interface.
+	LinkLocalAddresses() []*net.IPNet
 
 	// IP routes for the interface.
 	Routes() []*net.IPNet

--- a/sandbox.go
+++ b/sandbox.go
@@ -721,6 +721,9 @@ func (sb *sandbox) populateNetworkResources(ep *endpoint) error {
 		if i.addrv6 != nil && i.addrv6.IP.To16() != nil {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().AddressIPv6(i.addrv6))
 		}
+		if len(i.llAddrs) != 0 {
+			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().LinkLocalAddresses(i.llAddrs))
+		}
 		if i.mac != nil {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().MacAddress(i.mac))
 		}


### PR DESCRIPTION
```
~$ docker network create nw1
c5be8936aecc7b276f22a9f3f2f441ef1c33811417d56f044ce6ac2a7a0649dc
~$ docker network create nw2
d05ddc77d6132193988dc0f01beb5fb6dbe2e5119c8595ecce4dda4373fb2e9a
~$ 
~$ docker run -d --name c0 --link-local-ip 169.254.1.1 --net nw1 alpine top
23631c5fc3349176b2dd3edc92b5a442751406edc9cacc5f1ebaf5367da1955f
~$ docker network connect --link-local-ip 169.254.2.2 --link-local-ip fe80::169:254:2:2 nw2 c0
~$ 
~$ docker exec c0 ip addr show eth0 | grep 169
    inet 169.254.1.1/16 scope global eth0
~$ docker exec c0 ip addr show eth1 | grep 169
    inet 169.254.2.2/16 scope global eth1
    inet6 fe80::169:254:2:2/64 scope link 
~$ 
~$ docker stop c0 && docker start c0
c0
c0
~$ docker exec c0 ip addr show eth0 | grep 169
    inet 169.254.1.1/16 scope global eth0
~$ docker exec c0 ip addr show eth1 | grep 169
    inet 169.254.2.2/16 scope global eth1
    inet6 fe80::169:254:2:2/64 scope link 
~$ 
~$ docker run --link-local-ip 192.168.4.4 --net nw1 alpine ifconfig
docker: Error response from daemon: invalid link local IP address: 192.168.4.4.


```

Signed-off-by: Alessandro Boch <aboch@docker.com>