### PR TITLE
Allow maximum possible VNI

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -22,7 +22,7 @@ const (
 	vethPrefix   = "veth"
 	vethLen      = 7
 	vxlanIDStart = 256
-	vxlanIDEnd   = 1000
+	vxlanIDEnd   = (1 << 24) - 1
 	vxlanPort    = 4789
 	vxlanVethMTU = 1450
 )


### PR DESCRIPTION
Right now there is an artificial limitation at 1000.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>