### PR TITLE
Properly cleanup ingress sandbox in controller

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -245,6 +245,9 @@ func (sb *sandbox) delete(force bool) error {
 	}
 
 	c.Lock()
+	if sb.ingress {
+		c.ingressSandbox = nil
+	}
 	delete(c.sandboxes, sb.ID())
 	c.Unlock()
 


### PR DESCRIPTION
When ingress sandbox is removed, properly cleanup the reference in the
controller.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>