### PR TITLE
Adding null driver support for libnetwork on Solaris

### DIFF
--- a/drivers_solaris.go
+++ b/drivers_solaris.go
@@ -1,5 +1,11 @@
 package libnetwork
 
+import (
+	"github.com/docker/libnetwork/drivers/null"
+)
+
 func getInitializers() []initializer {
-	return []initializer{}
+	return []initializer{
+		{null.Init, "null"},
+	}
 }


### PR DESCRIPTION
This PR is targeting to add null driver support support for libnetwork on Solaris.
The code changes for this PR are stable and open to review. The PR has been tested on Linux as well.

Signed-off-by: Puneet Pruthi <puneetpruthi@gmail.com>