### PR TITLE
Purge vniTbl after cleaning up network sandbox

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -475,6 +475,19 @@ func (n *network) cleanupStaleSandboxes() {
 				deleteVxlanByVNI(path, 0)
 				syscall.Unmount(path, syscall.MNT_DETACH)
 				os.Remove(path)
+
+				// Now that we have destroyed this
+				// sandbox, remove all references to
+				// it in vniTbl so that we don't
+				// inadvertently destroy the sandbox
+				// created in this life.
+				networkMu.Lock()
+				for vni, tblPath := range vniTbl {
+					if tblPath == path {
+						delete(vniTbl, vni)
+					}
+				}
+				networkMu.Unlock()
 			}
 
 			return nil


### PR DESCRIPTION
If we cleaned up a stale network sandbox and an entry for that exists in
vniTbl, then purge it from vniTbl. Otherwise when a new vxlan for that
vni is added to the network, we might destroy the network sandbox
created in the current life.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>