### PR TITLE
Make sure to notify watchers on node going away

### DIFF
--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -193,7 +193,10 @@ func (nDB *NetworkDB) reapNetworks() {
 }
 
 func (nDB *NetworkDB) reapTableEntries() {
-	var paths []string
+	var (
+		paths   []string
+		entries []*entry
+	)
 
 	now := time.Now()
 
@@ -209,12 +212,14 @@ func (nDB *NetworkDB) reapTableEntries() {
 		}
 
 		paths = append(paths, path)
+		entries = append(entries, entry)
 		return false
 	})
 	nDB.RUnlock()
 
 	nDB.Lock()
-	for _, path := range paths {
+	for i, path := range paths {
+		entry := entries[i]
 		params := strings.Split(path[1:], "/")
 		tname := params[0]
 		nid := params[1]
@@ -227,6 +232,8 @@ func (nDB *NetworkDB) reapTableEntries() {
 		if _, ok := nDB.indexes[byNetwork].Delete(fmt.Sprintf("/%s/%s/%s", nid, tname, key)); !ok {
 			logrus.Errorf("Could not delete entry in network %s with table name %s and key %s as it does not exist", nid, tname, key)
 		}
+
+		nDB.broadcaster.Write(makeEvent(opDelete, tname, nid, key, entry.value))
 	}
 	nDB.Unlock()
 }


### PR DESCRIPTION
When a node goes away we purge all the table entries that we learned
from that node but we don't notify the watchers about it. Made sure we
notify the watchers when this happens.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>