### PR TITLE
Properly purge node networks when node goes away

### DIFF
--- a/networkdb/event_delegate.go
+++ b/networkdb/event_delegate.go
@@ -14,6 +14,7 @@ func (e *eventDelegate) NotifyJoin(n *memberlist.Node) {
 
 func (e *eventDelegate) NotifyLeave(n *memberlist.Node) {
 	e.nDB.deleteNodeTableEntries(n.Name)
+	e.nDB.deleteNetworkNodeEntries(n.Name)
 	e.nDB.Lock()
 	delete(e.nDB.nodes, n.Name)
 	e.nDB.Unlock()


### PR DESCRIPTION
When a node goes away purge all the network attachments from the node
and make sure we don't attempt bulk syncing to that node once removed.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>