### PR TITLE
Make getSvcRecords() more robust

### DIFF
--- a/network.go
+++ b/network.go
@@ -1099,14 +1099,22 @@ func (n *network) getSvcRecords(ep *endpoint) []etchosts.Record {
 	n.Lock()
 	defer n.Unlock()
 
+	if ep == nil {
+		return nil
+	}
+
 	var recs []etchosts.Record
 	sr, _ := n.ctrlr.svcRecords[n.id]
+	epName := ep.Name()
 
 	for h, ip := range sr.svcMap {
-		if ep != nil && strings.Split(h, ".")[0] == ep.Name() {
+		if strings.Split(h, ".")[0] == epName {
 			continue
 		}
-
+		if len(ip) == 0 {
+			log.Warnf("Found empty list of IP addresses for service %s on network %s (%s)", h, n.Name(), n.ID())
+			continue
+		}
 		recs = append(recs, etchosts.Record{
 			Hosts: h,
 			IP:    ip[0].String(),


### PR DESCRIPTION
Reported during docker testing:
```
panic: runtime error: index out of range
goroutine 24782 [running]:
panic(0x1aba540, 0xc82000c040)
/usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/docker/libnetwork.(*network).getSvcRecords(0xc8214cc280, 0xc821742dc0, 0x0, 0x0, 0x0)
/go/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/network.go:1112 +0x45a
github.com/docker/libnetwork.(*endpoint).sbLeave(0xc821742dc0, 0xc821916d20, 0xc821916d00, 0x0, 0x0, 0x0, 0x0, 0x0)
/go/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/endpoint.go:690 +0x1140
github.com/docker/libnetwork.(*endpoint).Leave(0xc821940000, 0x7f48aa277da0, 0xc821916d20, 0x0, 0x0, 0x0, 0x0, 0x0)
/go/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/endpoint.go:616 +0x1e9
github.com/docker/libnetwork.(*sandbox).delete(0xc821916d20, 0xc82144bb00, 0x0, 0x0)
/go/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/sandbox.go:215 +0xaff
github.com/docker/libnetwork.(*sandbox).Delete(0xc821916d20, 0x0, 0x0)
/go/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/sandbox.go:178 +0x32
github.com/docker/docker/daemon.(*Daemon).releaseNetwork(0xc82035fa00, 0xc8219165a0)
/go/src/github.com/docker/docker/daemon/container_operations.go:744 +0x51c
github.com/docker/docker/daemon.(*Daemon).Cleanup(0xc82035fa00, 0xc8219165a0)
/go/src/github.com/docker/docker/daemon/start.go:172 +0x53
github.com/docker/docker/daemon.(*Daemon).StateChanged(0xc82035fa00, 0xc8215b2a00, 0x40, 0xc821a2c1e4, 0x4, 0x100000000, 0x0, 0x0, 0x0, 0x0, ...)
/go/src/github.com/docker/docker/daemon/monitor.go:41 +0x629
github.com/docker/docker/libcontainerd.(*container).handleEvent.func2()
/go/src/github.com/docker/docker/libcontainerd/container_linux.go:202 +0x9e
github.com/docker/docker/libcontainerd.(*queue).append.func1(0xc820f84c00, 0x0, 0xc8213e2d20, 0xc821398780)
/go/src/github.com/docker/docker/libcontainerd/queue_linux.go:26 +0x47
created by github.com/docker/docker/libcontainerd.(*queue).append
/go/src/github.com/docker/docker/libcontainerd/queue_linux.go:28 +0x1da
```

Not sure whether it is a valid scenario, but seems reasonable to make the function more resilient and check on the list length before accessing the first element.


Signed-off-by: Alessandro Boch <aboch@docker.com>