### PR TITLE
Do not bulk sync state which is getting deleted

### DIFF
--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -397,6 +397,12 @@ func (nDB *NetworkDB) bulkSyncNode(networks []string, node string, unsolicited b
 				return false
 			}
 
+			// Do not bulk sync state which is in the
+			// process of getting deleted.
+			if entry.deleting {
+				return false
+			}
+
 			params := strings.Split(path[1:], "/")
 			tEvent := TableEvent{
 				Type:      TableEventTypeCreate,


### PR DESCRIPTION
Bulk sync should not sync state which is getting deleted

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>