### PR TITLE
Update ovmanager to support maximum vni

### DIFF
--- a/drivers/overlay/ovmanager/ovmanager.go
+++ b/drivers/overlay/ovmanager/ovmanager.go
@@ -20,7 +20,7 @@ import (
 const (
 	networkType  = "overlay"
 	vxlanIDStart = 256
-	vxlanIDEnd   = 1000
+	vxlanIDEnd   = (1 << 24) - 1
 )
 
 type networkTable map[string]*network


### PR DESCRIPTION
To support maximum possible overlay networks in swarm mode.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>