### PR TITLE
Do not error on non NodeDiscovery type messages in remote driver

### DIFF
--- a/drivers/remote/driver.go
+++ b/drivers/remote/driver.go
@@ -294,7 +294,7 @@ func (d *driver) Type() string {
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	if dType != discoverapi.NodeDiscovery {
-		return fmt.Errorf("Unknown discovery type : %v", dType)
+		return nil
 	}
 	notif := &api.DiscoveryNotification{
 		DiscoveryType: dType,
@@ -306,7 +306,7 @@ func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) 
 // DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
 func (d *driver) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
 	if dType != discoverapi.NodeDiscovery {
-		return fmt.Errorf("Unknown discovery type : %v", dType)
+		return nil
 	}
 	notif := &api.DiscoveryNotification{
 		DiscoveryType: dType,


### PR DESCRIPTION
- Only NodeDiscovery type messages are meant to be sent to remote drivers.
  Other notifications should be treated as no op in remote.go.

Fixes #1296 

Signed-off-by: Alessandro Boch <aboch@docker.com>