### PR TITLE
Retain deleted entries for longer time

### DIFF
--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/memberlist"
 )
 
-const reapInterval = 2 * time.Second
+const reapInterval = 30 * time.Second
 
 type logWriter struct{}
 

--- a/networkdb/delegate.go
+++ b/networkdb/delegate.go
@@ -130,6 +130,11 @@ func (nDB *NetworkDB) handleTableMessage(buf []byte, isBulkSync bool) {
 		return
 	}
 
+	// Ignore messages that this node generated.
+	if tEvent.NodeName == nDB.config.NodeName {
+		return
+	}
+
 	// Do not rebroadcast a bulk sync
 	if rebroadcast := nDB.handleTableEvent(&tEvent); rebroadcast && !isBulkSync {
 		var err error


### PR DESCRIPTION
When deleting entries or when learning about deleted entries remember
then for a longer time to avoid excessive delete duplicates in the
gossip cluster. Also added code changes to ignore event messages
originated from the source node so that it doesn't get added into the
rebroadcast queue.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>