### PR TITLE
Moving IPAM initalization out of drvRegistry into libnetwork core

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -193,6 +193,11 @@ func New(cfgOptions ...config.Option) (NetworkController, error) {
 			return nil, err
 		}
 	}
+
+	if err = initIPAMDrivers(drvRegistry, nil, c.getStore(datastore.GlobalScope)); err != nil {
+		return nil, err
+	}
+
 	c.drvRegistry = drvRegistry
 
 	if c.cfg != nil && c.cfg.Cluster.Watcher != nil {

--- a/drivers_ipam.go
+++ b/drivers_ipam.go
@@ -1,0 +1,23 @@
+package libnetwork
+
+import (
+	"github.com/docker/libnetwork/drvregistry"
+	"github.com/docker/libnetwork/ipamapi"
+	builtinIpam "github.com/docker/libnetwork/ipams/builtin"
+	nullIpam "github.com/docker/libnetwork/ipams/null"
+	remoteIpam "github.com/docker/libnetwork/ipams/remote"
+)
+
+func initIPAMDrivers(r *drvregistry.DrvRegistry, lDs, gDs interface{}) error {
+	for _, fn := range [](func(ipamapi.Callback, interface{}, interface{}) error){
+		builtinIpam.Init,
+		remoteIpam.Init,
+		nullIpam.Init,
+	} {
+		if err := fn(r, lDs, gDs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/drvregistry/drvregistry.go
+++ b/drvregistry/drvregistry.go
@@ -8,10 +8,6 @@ import (
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/libnetwork/types"
-
-	builtinIpam "github.com/docker/libnetwork/ipams/builtin"
-	nullIpam "github.com/docker/libnetwork/ipams/null"
-	remoteIpam "github.com/docker/libnetwork/ipams/remote"
 )
 
 type driverData struct {
@@ -62,10 +58,6 @@ func New(lDs, gDs interface{}, dfn DriverNotifyFunc, ifn IPAMNotifyFunc) (*DrvRe
 		ipamDrivers: make(ipamTable),
 		dfn:         dfn,
 		ifn:         ifn,
-	}
-
-	if err := r.initIPAMs(lDs, gDs); err != nil {
-		return nil, err
 	}
 
 	return r, nil
@@ -155,20 +147,6 @@ func (r *DrvRegistry) IPAMDefaultAddressSpaces(name string) (string, string, err
 	}
 
 	return i.defaultLocalAddressSpace, i.defaultGlobalAddressSpace, nil
-}
-
-func (r *DrvRegistry) initIPAMs(lDs, gDs interface{}) error {
-	for _, fn := range [](func(ipamapi.Callback, interface{}, interface{}) error){
-		builtinIpam.Init,
-		remoteIpam.Init,
-		nullIpam.Init,
-	} {
-		if err := fn(r, nil, gDs); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // RegisterDriver registers the network driver when it gets discovered.

--- a/drvregistry/drvregistry_test.go
+++ b/drvregistry/drvregistry_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/ipamapi"
+	builtinIpam "github.com/docker/libnetwork/ipams/builtin"
+	nullIpam "github.com/docker/libnetwork/ipams/null"
+	remoteIpam "github.com/docker/libnetwork/ipams/remote"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -90,9 +93,26 @@ func getNew(t *testing.T) *DrvRegistry {
 		t.Fatal(err)
 	}
 
+	err = initIPAMDrivers(reg, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	return reg
 }
 
+func initIPAMDrivers(r *DrvRegistry, lDs, gDs interface{}) error {
+	for _, fn := range [](func(ipamapi.Callback, interface{}, interface{}) error){
+		builtinIpam.Init,
+		remoteIpam.Init,
+		nullIpam.Init,
+	} {
+		if err := fn(r, lDs, gDs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 func TestNew(t *testing.T) {
 	getNew(t)
 }


### PR DESCRIPTION
Signed-off-by: Madhu Venugopal <madhu@docker.com>