### PR TITLE
On agent init, re-join on existing cluster networks

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -358,6 +358,8 @@ func (c *controller) agentInit(bindAddrOrInterface string) error {
 		return false
 	})
 
+	c.WalkNetworks(joinCluster)
+
 	return nil
 }
 

--- a/controller.go
+++ b/controller.go
@@ -639,13 +639,18 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 		return nil, err
 	}
 
-	if err = network.joinCluster(); err != nil {
-		log.Errorf("Failed to join network %s into agent cluster: %v", name, err)
-	}
-
-	network.addDriverWatches()
+	joinCluster(network)
 
 	return network, nil
+}
+
+var joinCluster NetworkWalker = func(nw Network) bool {
+	n := nw.(*network)
+	if err := n.joinCluster(); err != nil {
+		log.Errorf("Failed to join network %s (%s) into agent cluster: %v", n.Name(), n.ID(), err)
+	}
+	n.addDriverWatches()
+	return false
 }
 
 func (c *controller) reservePools() {


### PR DESCRIPTION
When worker leaves and re-join the cluster, make sure it re-joins the gossip for the existing cluster networks.

Related: https://github.com/docker/docker/issues/24463

Signed-off-by: Alessandro Boch <aboch@docker.com>