### PR TITLE
Add driver endpoint after network endpoint update to store

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -1019,10 +1019,6 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 		}
 	}
 
-	if err = d.storeUpdate(endpoint); err != nil {
-		return fmt.Errorf("failed to save bridge endpoint %s to store: %v", endpoint.id[0:7], err)
-	}
-
 	return nil
 }
 
@@ -1183,6 +1179,10 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 	err = jinfo.SetGatewayIPv6(network.bridge.gatewayIPv6)
 	if err != nil {
 		return err
+	}
+
+	if err = d.storeUpdate(endpoint); err != nil {
+		return fmt.Errorf("failed to save bridge endpoint %s to store: %v", endpoint.id[0:7], err)
 	}
 
 	return nil

--- a/drivers/ipvlan/ipvlan_endpoint.go
+++ b/drivers/ipvlan/ipvlan_endpoint.go
@@ -52,10 +52,6 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 		}
 	}
 
-	if err := d.storeUpdate(ep); err != nil {
-		return fmt.Errorf("failed to save ipvlan endpoint %s to store: %v", ep.id[0:7], err)
-	}
-
 	n.addEndpoint(ep)
 
 	return nil

--- a/drivers/macvlan/macvlan_endpoint.go
+++ b/drivers/macvlan/macvlan_endpoint.go
@@ -57,10 +57,6 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 		}
 	}
 
-	if err := d.storeUpdate(ep); err != nil {
-		return fmt.Errorf("failed to save macvlan endpoint %s to store: %v", ep.id[0:7], err)
-	}
-
 	n.addEndpoint(ep)
 
 	return nil

--- a/drivers/overlay/ov_endpoint.go
+++ b/drivers/overlay/ov_endpoint.go
@@ -89,10 +89,6 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 
 	n.addEndpoint(ep)
 
-	if err := d.writeEndpointToStore(ep); err != nil {
-		return fmt.Errorf("failed to update overlay endpoint %s to local store: %v", ep.id[0:7], err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>

power down during stress test and restart make docker daemon can start again with failure
`FATA[0007] Error starting daemon: Error initializing network controller: could not delete the default bridge network: network 317f60e2165bc8bd65c6354fa2fe418ea24ad550ea403b642878627d4d0547db has active endpoint`.
because the network endpoint and the driver endpoint are inconsistent, the driver endpoint exist but network endpoint not.
we should add driver endpoint after network endpoint update to store to avoid orphan driver endpoint.

ping @aboch  @mavenugo 
I think this should be in 1.12