### PR TITLE
Fix update endpoint count to store

### DIFF
--- a/endpoint_cnt.go
+++ b/endpoint_cnt.go
@@ -113,6 +113,9 @@ func (ec *endpointCnt) updateStore() error {
 	if store == nil {
 		return fmt.Errorf("store not found for scope %s on endpoint count update", ec.DataScope())
 	}
+	// make a copy of count and n to avoid being overwritten by store.GetObject
+	count := ec.EndpointCnt()
+	n := ec.n
 	for {
 		if err := ec.n.getController().updateToStore(ec); err == nil || err != datastore.ErrKeyModified {
 			return err
@@ -120,6 +123,10 @@ func (ec *endpointCnt) updateStore() error {
 		if err := store.GetObject(datastore.Key(ec.Key()...), ec); err != nil {
 			return fmt.Errorf("could not update the kvobject to latest on endpoint count update: %v", err)
 		}
+		ec.Lock()
+		ec.Count = count
+		ec.n = n
+		ec.Unlock()
 	}
 }
 

--- a/endpoint_cnt.go
+++ b/endpoint_cnt.go
@@ -143,7 +143,9 @@ retry:
 	if inc {
 		ec.Count++
 	} else {
-		ec.Count--
+		if ec.Count > 0 {
+			ec.Count--
+		}
 	}
 	ec.Unlock()
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>
power down during docker stress test and restart, we encounter this error:
`INFO[0008] Fixing inconsistent endpoint_cnt for network bridge. Expected=0, Actual=1
DEBU[0008] starting clean shutdown of all containers...
DEBU[0008] Cleaning up old mountid : start.
DEBU[0008] Cleaning up old mountid : done.
FATA[0008] Error starting daemon: Error initializing network controller: could not delete the default bridge network: network bridge has active endpoints`
and user bolt cli shows that:
`# ./bolt get /var/lib/docker/network/files/local-kv.db libnetwork docker/network/v1.0/endpoint_count/1b331173f5d4ab654afa2f8d659e263ff89f11bfc1a943ab5ac582333a681241/
{"Count":18446744073709551593}`

I debug and found that, during endpoint_cnt updating to store, https://github.com/docker/libnetwork/blob/master/endpoint_cnt.go#L117 will failed with `ErrKeyModified` at first time and will go to `https://github.com/docker/libnetwork/blob/master/endpoint_cnt.go#L120` and this will change the value of `ec.Count` because `store.GetObject` will get the value from the cache, but the we doesn't add the value to cache because https://github.com/docker/libnetwork/blob/master/endpoint_cnt.go#L117 failed (https://github.com/docker/libnetwork/blob/master/datastore/datastore.go#L409)

ping @aboch  @mavenugo 