### PR TITLE
Moving the UDS file out of /var/lib/docker and into /run/

### DIFF
--- a/sandbox_externalkey_unix.go
+++ b/sandbox_externalkey_unix.go
@@ -15,7 +15,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
-const udsBase = "/var/lib/docker/network/files/"
+const udsBase = "/run/docker/libnetwork/"
 const success = "success"
 
 // processSetKeyReexec is a private function that must be called only on an reexec path


### PR DESCRIPTION
the UDS sock is an unique file and the lifetime of it is until the
docker daemon dies (gracefully). Hence there is no need for it to be
under /var/lib and not mandatory to be configurable either.

Signed-off-by: Madhu Venugopal <madhu@docker.com>