### PR TITLE
Make osl sandbox basepath configurable using --exec-root configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/libnetwork/cluster"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/netlabel"
+	"github.com/docker/libnetwork/osl"
 )
 
 // Config encapsulates configurations of various Libnetwork components
@@ -194,6 +195,13 @@ func OptionDiscoveryAddress(address string) Option {
 func OptionDataDir(dataDir string) Option {
 	return func(c *Config) {
 		c.Daemon.DataDir = dataDir
+	}
+}
+
+// OptionExecRoot function returns an option setter for exec root folder
+func OptionExecRoot(execRoot string) Option {
+	return func(c *Config) {
+		osl.SetBasePath(execRoot)
 	}
 }
 

--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -21,7 +22,7 @@ import (
 	"github.com/vishvananda/netns"
 )
 
-const prefix = "/var/run/docker/netns"
+const defaultPrefix = "/var/run/docker"
 
 var (
 	once             sync.Once
@@ -30,6 +31,7 @@ var (
 	gpmWg            sync.WaitGroup
 	gpmCleanupPeriod = 60 * time.Second
 	gpmChan          = make(chan chan struct{})
+	prefix           = defaultPrefix
 )
 
 // The networkNamespace type is the linux implementation of the Sandbox
@@ -48,12 +50,21 @@ type networkNamespace struct {
 	sync.Mutex
 }
 
+// SetBasePath sets the base url prefix for the ns path
+func SetBasePath(path string) {
+	prefix = path
+}
+
 func init() {
 	reexec.Register("netns-create", reexecCreateNamespace)
 }
 
+func basePath() string {
+	return filepath.Join(prefix, "netns")
+}
+
 func createBasePath() {
-	err := os.MkdirAll(prefix, 0755)
+	err := os.MkdirAll(basePath(), 0755)
 	if err != nil {
 		panic("Could not create net namespace path directory")
 	}
@@ -142,7 +153,7 @@ func GenerateKey(containerID string) string {
 			indexStr string
 			tmpkey   string
 		)
-		dir, err := ioutil.ReadDir(prefix)
+		dir, err := ioutil.ReadDir(basePath())
 		if err != nil {
 			return ""
 		}
@@ -172,7 +183,7 @@ func GenerateKey(containerID string) string {
 		maxLen = len(containerID)
 	}
 
-	return prefix + "/" + containerID[:maxLen]
+	return basePath() + "/" + containerID[:maxLen]
 }
 
 // NewSandbox provides a new sandbox instance created in an os specific way

--- a/osl/namespace_unsupported.go
+++ b/osl/namespace_unsupported.go
@@ -10,3 +10,7 @@ func GC() {
 func GetSandboxForExternalKey(path string, key string) (Sandbox, error) {
 	return nil, nil
 }
+
+// SetBasePath sets the base url prefix for the ns path
+func SetBasePath(path string) {
+}

--- a/osl/namespace_windows.go
+++ b/osl/namespace_windows.go
@@ -37,3 +37,7 @@ func InitOSContext() func() {
 func SetupTestOSContext(t *testing.T) func() {
 	return func() {}
 }
+
+// SetBasePath sets the base url prefix for the ns path
+func SetBasePath(path string) {
+}

--- a/osl/sandbox_freebsd.go
+++ b/osl/sandbox_freebsd.go
@@ -38,3 +38,7 @@ func InitOSContext() func() {
 func SetupTestOSContext(t *testing.T) func() {
 	return func() {}
 }
+
+// SetBasePath sets the base url prefix for the ns path
+func SetBasePath(path string) {
+}


### PR DESCRIPTION

/var/run/docker/netns will still be the default location. But user will be able to override the basepath using --exec-root configuration

Signed-off-by: Madhu Venugopal <madhu@docker.com>