### PR TITLE
Remove driver endpoints on network deleting

### DIFF
--- a/drivers/macvlan/macvlan_network.go
+++ b/drivers/macvlan/macvlan_network.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netlabel"
+	"github.com/docker/libnetwork/ns"
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/osl"
 	"github.com/docker/libnetwork/types"
@@ -149,6 +150,15 @@ func (d *driver) DeleteNetwork(nid string) error {
 						n.config.Parent, err)
 				}
 			}
+		}
+	}
+	for _, ep := range n.endpoints {
+		if link, err := ns.NlHandle().LinkByName(ep.srcName); err == nil {
+			ns.NlHandle().LinkDel(link)
+		}
+
+		if err := d.storeDelete(ep); err != nil {
+			logrus.Warnf("Failed to remove macvlan endpoint %s from store: %v", ep.id[0:7], err)
 		}
 	}
 	// delete the *network

--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -182,6 +182,18 @@ func (d *driver) DeleteNetwork(nid string) error {
 		return fmt.Errorf("could not find network with id %s", nid)
 	}
 
+	for _, ep := range n.endpoints {
+		if ep.ifName != "" {
+			if link, err := ns.NlHandle().LinkByName(ep.ifName); err != nil {
+				ns.NlHandle().LinkDel(link)
+			}
+		}
+
+		if err := d.deleteEndpointFromStore(ep); err != nil {
+			logrus.Warnf("Failed to delete overlay endpoint %s from local store: %v", ep.id[0:7], err)
+		}
+
+	}
 	d.deleteNetwork(nid)
 
 	vnis, err := n.releaseVxlanID()


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>

On driver deleting network, we should also remove the endpoints belong to it if
there are endpoints remain, or else the endpoints in the store would never been removed.
ping @aboch 