### PR TITLE
added mutex on read from controller.svcRecords map

### DIFF
--- a/network.go
+++ b/network.go
@@ -1105,8 +1105,12 @@ func (n *network) getSvcRecords(ep *endpoint) []etchosts.Record {
 	}
 
 	var recs []etchosts.Record
-	sr, _ := n.ctrlr.svcRecords[n.id]
+
 	epName := ep.Name()
+
+	n.ctrlr.Lock()
+	sr, _ := n.ctrlr.svcRecords[n.id]
+	n.ctrlr.Unlock()
 
 	for h, ip := range sr.svcMap {
 		if strings.Split(h, ".")[0] == epName {

--- a/sandbox.go
+++ b/sandbox.go
@@ -413,7 +413,12 @@ func (sb *sandbox) ResolveIP(ip string) string {
 	for _, ep := range sb.getConnectedEndpoints() {
 		n := ep.getNetwork()
 
-		sr, ok := n.getController().svcRecords[n.ID()]
+		c := n.getController()
+
+		c.Lock()
+		sr, ok := c.svcRecords[n.ID()]
+		c.Unlock()
+
 		if !ok {
 			continue
 		}
@@ -454,7 +459,12 @@ func (sb *sandbox) ResolveService(name string) ([]*net.SRV, []net.IP, error) {
 	for _, ep := range sb.getConnectedEndpoints() {
 		n := ep.getNetwork()
 
-		sr, ok := n.getController().svcRecords[n.ID()]
+		c := n.getController()
+
+		c.Lock()
+		sr, ok := c.svcRecords[n.ID()]
+		c.Unlock()
+
 		if !ok {
 			continue
 		}

--- a/sandbox.go
+++ b/sandbox.go
@@ -575,7 +575,11 @@ func (sb *sandbox) resolveName(req string, networkName string, epList []*endpoin
 			ep.Unlock()
 		}
 
-		sr, ok := n.getController().svcRecords[n.ID()]
+		c := n.getController()
+		c.Lock()
+		sr, ok := c.svcRecords[n.ID()]
+		c.Unlock()
+
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
We'r got some problem with docker 1.12-rc-4:

```
fatal error: concurrent map read and map write

goroutine 3426519 [running]:
runtime.throw(0x1fb2020, 0x21)
	/usr/local/go/src/runtime/panic.go:547 +0x90 fp=0xc8224355a0 sp=0xc822435588
runtime.mapaccess2_faststr(0x175d060, 0xc82098e570, 0xc821193f20, 0xf, 0xc820c73748, 0x6fc601)
	/usr/local/go/src/runtime/hashmap_fast.go:307 +0x5b fp=0xc822435600 sp=0xc8224355a0
github.com/docker/libnetwork.(*sandbox).resolveName(0xc8215703c0, 0xc821193f20, 0xf, 0x1dc7b28, 0x0, 0xc821b88268, 0x1, 0x1, 0x1dd7200, 0x1, ...)
	/go/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/sandbox.go:585 +0x383 fp=0xc8224356f0 sp=0xc822435600
github.com/docker/libnetwork.(*sandbox).ResolveName(0xc8215703c0, 0xc821193f20, 0xf, 0x1, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/sandbox.go:533 +0x5d7 fp=0xc8224358b0 sp=0xc8224356f0
github.com/docker/libnetwork.(*resolver).handleIPQuery(0xc8214d2a00, 0xc821193f20, 0x10, 0xc8214d18c0, 0x1, 0x21de874, 0x0, 0x0)
	/go/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/resolver.go:243 +0x6f fp=0xc822435ac8 sp=0xc8224358b0
github.com/docker/libnetwork.(*resolver).ServeDNS(0xc8214d2a00, 0x7f9a49c67b60, 0xc820908460, 0xc8214d18c0)
	/go/src/github.com/docker/docker/vendor/src/github.com/docker/libnetwork/resolver.go:368 +0x162 fp=0xc822435d98 sp=0xc822435ac8
github.com/miekg/dns.(*Server).serve(0xc821fb1ee0, 0x7f9a481c2898, 0xc821d8e990, 0x7f9a4829aab8, 0xc8214d2a00, 0xc820baca00, 0x21, 0x200, 0xc8203908e0, 0xc821c04dc0, ...)
	/go/src/github.com/docker/docker/vendor/src/github.com/miekg/dns/server.go:535 +0x7c8 fp=0xc822435f48 sp=0xc822435d98
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1998 +0x1 fp=0xc822435f50 sp=0xc822435f48
created by github.com/miekg/dns.(*Server).serveUDP
	/go/src/github.com/docker/docker/vendor/src/github.com/miekg/dns/server.go:489 +0x3d5

... hungred of goroutines ...
```

I'm added simple mutex to protect controller.svcRecords map from concurrent read/write. In other places this map already protected by same mutex.