### PR TITLE
Update service DB on deletion of containers in bridge networks

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -776,9 +776,7 @@ func (ep *endpoint) Delete(force bool) error {
 	}()
 
 	// unwatch for service records
-	if !n.getController().isAgent() {
-		n.getController().unWatchSvcRecord(ep)
-	}
+	n.getController().unWatchSvcRecord(ep)
 
 	if err = ep.deleteEndpoint(force); err != nil && !force {
 		return err


### PR DESCRIPTION
Related to [docker/docker #24800] (https://github.com/docker/docker/issues/24800)

This is a collateral from the service related changes in 1.12. 

On endpoint delete it should be ok to call unWatchSvcRecord in both swam and non-swarm mode. In swarm mode it can lead to two deleteSvcRecords calls; one from ep delete and one from EP table event handling. But the 2nd call will be a noop. This is similar to the add case where watchSvcRecord is called from CreateEndpoint.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>