### PR TITLE
Allow user to set the overlay network's mtu

### DIFF
--- a/drivers/overlay/encryption.go
+++ b/drivers/overlay/encryption.go
@@ -550,7 +550,11 @@ func updateNodeKey(lIP, rIP net.IP, idxs []*spi, curKeys []*key, newIdx, priIdx,
 }
 
 func (n *network) maxMTU() int {
-	mtu := vxlanVethMTU
+	mtu := 1500
+	if n.mtu != 0 {
+		mtu = n.mtu
+	}
+	mtu -= vxlanEncap
 	if n.secure {
 		// In case of encryption account for the
 		// esp packet espansion and padding

--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -63,6 +63,7 @@ type network struct {
 	initErr   error
 	subnets   []*subnet
 	secure    bool
+	mtu       int
 	sync.Mutex
 }
 
@@ -113,6 +114,15 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		}
 		if _, ok := optMap[secureOption]; ok {
 			n.secure = true
+		}
+		if val, ok := optMap[netlabel.DriverMTU]; ok {
+			var err error
+			if n.mtu, err = strconv.Atoi(val); err != nil {
+				return fmt.Errorf("failed to parse %v: %v", val, err)
+			}
+			if n.mtu < 0 {
+				return fmt.Errorf("invalid MTU value: %v", n.mtu)
+			}
 		}
 	}
 
@@ -315,7 +325,7 @@ func networkOnceInit() {
 		return
 	}
 
-	err := createVxlan("testvxlan", 1)
+	err := createVxlan("testvxlan", 1, 0)
 	if err != nil {
 		logrus.Errorf("Failed to create testvxlan interface: %v", err)
 		return
@@ -459,7 +469,7 @@ func (n *network) setupSubnetSandbox(s *subnet, brName, vxlanName string) error 
 		return fmt.Errorf("bridge creation in sandbox failed for subnet %q: %v", s.subnetIP.String(), err)
 	}
 
-	err := createVxlan(vxlanName, n.vxlanID(s))
+	err := createVxlan(vxlanName, n.vxlanID(s), n.maxMTU())
 	if err != nil {
 		return err
 	}
@@ -732,6 +742,7 @@ func (n *network) Value() []byte {
 
 	m["secure"] = n.secure
 	m["subnets"] = netJSON
+	m["mtu"] = n.mtu
 	b, err = json.Marshal(m)
 	if err != nil {
 		return []byte{}
@@ -780,6 +791,9 @@ func (n *network) SetValue(value []byte) error {
 	if isMap {
 		if val, ok := m["secure"]; ok {
 			n.secure = val.(bool)
+		}
+		if val, ok := m["mtu"]; ok {
+			n.mtu = int(val.(float64))
 		}
 		bytes, err := json.Marshal(m["subnets"])
 		if err != nil {

--- a/drivers/overlay/ov_utils.go
+++ b/drivers/overlay/ov_utils.go
@@ -52,11 +52,11 @@ func createVethPair() (string, string, error) {
 	return name1, name2, nil
 }
 
-func createVxlan(name string, vni uint32) error {
+func createVxlan(name string, vni uint32, mtu int) error {
 	defer osl.InitOSContext()()
 
 	vxlan := &netlink.Vxlan{
-		LinkAttrs: netlink.LinkAttrs{Name: name},
+		LinkAttrs: netlink.LinkAttrs{Name: name, MTU: mtu},
 		VxlanId:   int(vni),
 		Learning:  true,
 		Port:      vxlanPort,

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -25,7 +25,7 @@ const (
 	vxlanIDStart = 256
 	vxlanIDEnd   = (1 << 24) - 1
 	vxlanPort    = 4789
-	vxlanVethMTU = 1450
+	vxlanEncap   = 50
 	secureOption = "encrypted"
 )
 


### PR DESCRIPTION
- Being a driver specific flag, user needs to
  account for vxlan and, if enabled, ipsec overhead
- Default MTU remains 1500 bytes

Fixes #1021 
Fixes #1330 

Signed-off-by: Alessandro Boch <aboch@docker.com>