### PR TITLE
On network creation, reset mangle rule

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -140,6 +140,13 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		return fmt.Errorf("failed to update data store for network %v: %v", n.id, err)
 	}
 
+	// Make sure no rule is on the way from any stale secure network
+	if !n.secure {
+		for _, vni := range vnis {
+			programMangle(vni, false)
+		}
+	}
+
 	if nInfo != nil {
 		if err := nInfo.TableEventRegister(ovPeerTable); err != nil {
 			return err


### PR DESCRIPTION
- When creating a non encrypted overlay network,
  make sure no encryption related mangle rule from
  stale network is on the way.

Signed-off-by: Alessandro Boch <aboch@docker.com>