### PR TITLE
WIP: Properly handle advertise address locality

### DIFF
--- a/drivers/overlay/encryption.go
+++ b/drivers/overlay/encryption.go
@@ -90,12 +90,15 @@ func (d *driver) checkEncryption(nid string, rIP net.IP, vxlanID uint32, isLocal
 
 	lIP := net.ParseIP(d.bindAddress)
 	aIP := net.ParseIP(d.advertiseAddress)
+	if d.advAddrIsLocal {
+		lIP = aIP
+	}
 	nodes := map[string]net.IP{}
 
 	switch {
 	case isLocal:
 		if err := d.peerDbNetworkWalk(nid, func(pKey *peerKey, pEntry *peerEntry) bool {
-			if !lIP.Equal(pEntry.vtep) {
+			if !aIP.Equal(pEntry.vtep) {
 				nodes[pEntry.vtep.String()] = pEntry.vtep
 			}
 			return false
@@ -413,6 +416,10 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 		delIdx = -1
 		lIP    = net.ParseIP(d.bindAddress)
 	)
+
+	if d.advAddrIsLocal {
+		lIP = net.ParseIP(d.advertiseAddress)
+	}
 
 	d.Lock()
 	// add new

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -37,6 +37,7 @@ type driver struct {
 	exitCh           chan chan struct{}
 	bindAddress      string
 	advertiseAddress string
+	advAddrIsLocal   bool
 	neighIP          string
 	config           map[string]interface{}
 	peerDb           peerNetworkMap
@@ -238,6 +239,13 @@ func (d *driver) nodeJoin(advertiseAddress, bindAddress string, self bool) {
 				d.Unlock()
 				return
 			}
+		}
+
+		if isLocal, iface := isAddressLocal(advertiseAddress); isLocal {
+			d.Lock()
+			d.advAddrIsLocal = true
+			d.Unlock()
+			logrus.Infof("Advertise address %s is local (%v)", advertiseAddress, iface)
 		}
 	}
 


### PR DESCRIPTION
- Current encryption code does not take into account the
  case where the advertise address is a local to the host

- Also check for advertise address when deriving the
  list of ipsec nodes

Signed-off-by: Alessandro Boch <aboch@docker.com>