### PR TITLE
Check for advertise IP when deriving ipsec nodes

### DIFF
--- a/drivers/overlay/encryption.go
+++ b/drivers/overlay/encryption.go
@@ -95,7 +95,7 @@ func (d *driver) checkEncryption(nid string, rIP net.IP, vxlanID uint32, isLocal
 	switch {
 	case isLocal:
 		if err := d.peerDbNetworkWalk(nid, func(pKey *peerKey, pEntry *peerEntry) bool {
-			if !lIP.Equal(pEntry.vtep) {
+			if !aIP.Equal(pEntry.vtep) {
 				nodes[pEntry.vtep.String()] = pEntry.vtep
 			}
 			return false


### PR DESCRIPTION
- We need to compare the node notification IP with
  the advertise address otherwise when the advertise
  address is different from the local address (this
  is for the public address outside of the host
  that maps 1-to-1 to the local private address)
  the local IP will be acocunted as an ipsec host
  and extra states will be programmed for it.

Signed-off-by: Alessandro Boch <aboch@docker.com>