### PR TITLE
Fix crash when remote plugin returns empty address string

### DIFF
--- a/ipamapi/contract.go
+++ b/ipamapi/contract.go
@@ -46,6 +46,7 @@ var (
 	ErrOverlapPool         = types.ForbiddenErrorf("Address pool overlaps with existing pool on this address space")
 	ErrNoAvailablePool     = types.NoServiceErrorf("No available pool")
 	ErrNoAvailableIPs      = types.NoServiceErrorf("No available addresses on this pool")
+	ErrNoIPReturned        = types.NoServiceErrorf("No address returned")
 	ErrIPAlreadyAllocated  = types.ForbiddenErrorf("Address already in use")
 	ErrIPOutOfRange        = types.BadRequestErrorf("Requested address is out of range")
 	ErrPoolOverlap         = types.ForbiddenErrorf("Pool overlaps with other one on this address space")

--- a/ipams/remote/remote.go
+++ b/ipams/remote/remote.go
@@ -111,6 +111,8 @@ func (a *allocator) RequestAddress(poolID string, address net.IP, options map[st
 	}
 	if res.Address != "" {
 		retAddress, err = types.ParseCIDR(res.Address)
+	} else {
+		return nil, nil, ipamapi.ErrNoIPReturned
 	}
 	return retAddress, res.Data, err
 }


### PR DESCRIPTION
If a remote plugin returns an empty string in response to RequestAddress(),
the internal helper will return nil which will crash libnetwork in several
places.

Treat an empty string as a new error ipamapi.ErrNoIPReturned.

Signed-off-by: Thomas Graf <tgraf@suug.ch>