### PR TITLE
Check for isAgent() outside the network lock to avoid deadlocks

### DIFF
--- a/network.go
+++ b/network.go
@@ -702,12 +702,13 @@ func (n *network) driver(load bool) (driverapi.Driver, error) {
 	}
 
 	c := n.getController()
+	isAgent := c.isAgent()
 	n.Lock()
 	// If load is not required, driver, cap and err may all be nil
 	if cap != nil {
 		n.scope = cap.DataScope
 	}
-	if c.isAgent() || n.dynamic {
+	if isAgent || n.dynamic {
 		// If we are running in agent mode then all networks
 		// in libnetwork are local scope regardless of the
 		// backing driver.


### PR DESCRIPTION
Signed-off-by: Madhu Venugopal <madhu@docker.com>