### PR TITLE
Do not create network entry for the local node in the db based on peer's state sync.

### DIFF
--- a/networkdb/delegate.go
+++ b/networkdb/delegate.go
@@ -25,6 +25,10 @@ func (nDB *NetworkDB) handleNetworkEvent(nEvent *NetworkEvent) bool {
 	nDB.Lock()
 	defer nDB.Unlock()
 
+	if nEvent.NodeName == nDB.config.NodeName {
+		return false
+	}
+
 	nodeNetworks, ok := nDB.networks[nEvent.NodeName]
 	if !ok {
 		// We haven't heard about this node at all.  Ignore the leave


### PR DESCRIPTION
Fixes
https://github.com/docker/libnetwork/issues/1363

Easier way to repro: 
- 1 manager and 1 worker in the cluster. 
- A service with a task running in the worker. 
- restart the daemon in the worker.

When we do the cluster init in the worker it joins the manager. In the process there is a state sync which downloads the full networks state from the peer. Since the worker had a task on the network update from the peer will indicate the worker node being part of the network. But on daemon restart the task would have been rescheduled elsewhere and hence the worker node doesn't have any tasks on the network anymore. Since we already created the network for this node in the network db the error `Invalid broadcastQ` will show up on every gossip interval which is 200 ms.

Fix is to not create the network entry in the db for the local node based on handleNetworkEvent. Rather it should happen from JoinNetwork() if a task gets placed on this node the first time. This avoids the error messages. 

Ideally we should also remove a remote node and network mappings in the networkdb when it goes through a daemon restart (and tasks getting moved out of that node). But a deamon restart will be quick and it won't trigger a gossip cluster leave. This needs to be evaulated. cc @mrjana 

Signed-off-by: Santhosh Manohar <santhosh@docker.com>