### PR TITLE
portmapper: touch iptables only for IPv4

### DIFF
--- a/portmapper/mapper.go
+++ b/portmapper/mapper.go
@@ -134,16 +134,20 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 	}
 
 	containerIP, containerPort := getIPAndPort(m.container)
-	if err := pm.forward(iptables.Append, m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort); err != nil {
-		return nil, err
+	if hostIP.To4() != nil {
+		if err := pm.forward(iptables.Append, m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort); err != nil {
+			return nil, err
+		}
 	}
 
 	cleanup := func() error {
 		// need to undo the iptables rules before we return
 		m.userlandProxy.Stop()
-		pm.forward(iptables.Delete, m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort)
-		if err := pm.Allocator.ReleasePort(hostIP, m.proto, allocatedHostPort); err != nil {
-			return err
+		if hostIP.To4() != nil {
+			pm.forward(iptables.Delete, m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort)
+			if err := pm.Allocator.ReleasePort(hostIP, m.proto, allocatedHostPort); err != nil {
+				return err
+			}
 		}
 
 		return nil


### PR DESCRIPTION
split out of https://github.com/docker/docker/pull/20315
in order to fix https://github.com/docker/docker/issues/11518

Signed-off-by: Michael Stapelberg <stapelberg@google.com>