### PR TITLE
Allow reattempt of overlay network sbox join

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -90,7 +90,20 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 		}
 	}
 
-	d.restoreEndpoints()
+	if err := d.restoreEndpoints(); err != nil {
+		logrus.Warnf("Failure during overlay endpoints restore: %v", err)
+	}
+
+	// If an error happened when the network join the sandbox during the endpoints restore
+	// we should reset it now along with the once variable, so that subsequent endpoint joins
+	// outside of the restore path can potentially fix the network join and succeed.
+	for nid, n := range d.networks {
+		if n.initErr != nil {
+			logrus.Infof("resetting init error and once variable for network %s after unsuccesful endpoint restore: %v", nid, n.initErr)
+			n.initErr = nil
+			n.once = &sync.Once{}
+		}
+	}
 
 	return dc.RegisterDriver(networkType, d, c)
 }


### PR DESCRIPTION
- if failure happened during restore endpoint phase

Related to https://github.com/docker/docker/issues/25215

Signed-off-by: Alessandro Boch <aboch@docker.com>