### PR TITLE
Make sure to not remove backends on stale notices

### DIFF
--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -463,6 +463,8 @@ func (epj *endpointJoinInfo) CopyTo(dstEpj *endpointJoinInfo) error {
 	dstEpj.disableGatewayService = epj.disableGatewayService
 	dstEpj.StaticRoutes = make([]*types.StaticRoute, len(epj.StaticRoutes))
 	copy(dstEpj.StaticRoutes, epj.StaticRoutes)
+	dstEpj.driverTableEntries = make([]*tableEntry, len(epj.driverTableEntries))
+	copy(dstEpj.driverTableEntries, epj.driverTableEntries)
 	dstEpj.gw = types.GetIPCopy(epj.gw)
 	dstEpj.gw = types.GetIPCopy(epj.gw6)
 	return nil


### PR DESCRIPTION
Sometimes you may get stale backend removal notices from gossip due to
some lingering state. If a stale backend notice is received and it is
already processed in this node ignore it rather than processing it.

Also fixing:
Ensure drivertable entries in joininfo is uptodate

The CopyTo function for joininfo is not copying the driver table entries
which then is missing when the endpoint is re-read for the store cache.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>