### PR TITLE
Fix external DNS responses > 512 bytes getting dropped

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -361,7 +361,10 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 
 			// Timeout has to be set for every IO operation.
 			extConn.SetDeadline(time.Now().Add(extIOTimeout))
-			co := &dns.Conn{Conn: extConn}
+			co := &dns.Conn{
+				Conn:    extConn,
+				UDPSize: uint16(maxSize),
+			}
 			defer co.Close()
 
 			// limits the number of outstanding concurrent queries.


### PR DESCRIPTION
Docker DNS server proxies external queries by sending it to the configured nameservers.  When sending the query UDP packet size defaults to 512 bytes. If the client has set the ENDS option reply and the reply is > 512 bytes it will get dropped by the DNS library.

When forwarding the query set the dns.Conn UDPSize to be that of the size from the client's EDNS option.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>