### PR TITLE
Make service LB work from self

### DIFF
--- a/service_linux.go
+++ b/service_linux.go
@@ -710,7 +710,7 @@ func fwMarker() {
 		os.Exit(4)
 	}
 
-	if len(ingressPorts) != 0 && addDelOpt == "-A" {
+	if addDelOpt == "-A" {
 		ruleParams := strings.Fields(fmt.Sprintf("-m ipvs --ipvs -j SNAT --to-source %s", os.Args[6]))
 		if !iptables.Exists("nat", "POSTROUTING", ruleParams...) {
 			rule := append(strings.Fields("-t nat -A POSTROUTING"), ruleParams...)


### PR DESCRIPTION
Make service loadbalancing to work from within one of the containers of
the service. Currently this only works when the loadbalancer selects the
current container. If another container of the same service is chosen,
the connection times out. This fix adds a SNAT rule to change the source
IP to the containers primary IP so that responses can be routed back to
this container.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>