### PR TITLE
networkdb: fix data races in map access

### DIFF
--- a/networkdb/delegate.go
+++ b/networkdb/delegate.go
@@ -221,9 +221,11 @@ func (nDB *NetworkDB) handleBulkSync(buf []byte) {
 	}
 
 	var nodeAddr net.IP
+	nDB.RLock()
 	if node, ok := nDB.nodes[bsm.NodeName]; ok {
 		nodeAddr = node.Addr
 	}
+	nDB.RUnlock()
 
 	if err := nDB.bulkSyncNode(bsm.Networks, bsm.NodeName, false); err != nil {
 		logrus.Errorf("Error in responding to bulk sync from node %s: %v", nodeAddr, err)

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -371,7 +371,10 @@ func (nDB *NetworkDB) JoinNetwork(nid string) error {
 	nodeNetworks[nid] = &network{id: nid, ltime: ltime}
 	nodeNetworks[nid].tableBroadcasts = &memberlist.TransmitLimitedQueue{
 		NumNodes: func() int {
-			return len(nDB.networkNodes[nid])
+			nDB.RLock()
+			num := len(nDB.networkNodes[nid])
+			nDB.RUnlock()
+			return num
 		},
 		RetransmitMult: 4,
 	}


### PR DESCRIPTION
ping @mrjana @sanimej @aboch 
I think it might be worth to include this in 1.12.1 because map races could be fatal for a running program.