### PR TITLE
overlay: fix data race in map access

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -664,17 +664,17 @@ func (d *driver) deleteNetwork(nid string) {
 
 func (d *driver) network(nid string) *network {
 	d.Lock()
-	networks := d.networks
+	n, ok := d.networks[nid]
 	d.Unlock()
-
-	n, ok := networks[nid]
 	if !ok {
 		n = d.getNetworkFromStore(nid)
 		if n != nil {
 			n.driver = d
 			n.endpoints = endpointTable{}
 			n.once = &sync.Once{}
-			networks[nid] = n
+			d.Lock()
+			d.networks[nid] = n
+			d.Unlock()
 		}
 	}
 


### PR DESCRIPTION
ping @mrjana @sanimej @aboch 
Fix is not ideal. It would be better to use per id Lock for such stuff. We have special package for that in docker.