### PR TITLE
Fix spurious overlay errors

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -550,7 +550,10 @@ func (n *network) addDriverWatches() {
 		}
 
 		c.agent.networkDB.WalkTable(tableName, func(nid, key string, value []byte) bool {
-			d.EventNotify(driverapi.Create, n.ID(), tableName, key, value)
+			if nid == n.ID() {
+				d.EventNotify(driverapi.Create, nid, tableName, key, value)
+			}
+
 			return false
 		})
 	}

--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -637,6 +637,10 @@ func (n *network) watchMiss(nlSock *nl.NetlinkSocket) {
 				continue
 			}
 
+			if !n.driver.isSerfAlive() {
+				continue
+			}
+
 			mac, IPmask, vtep, err := n.driver.resolvePeer(n.id, neigh.IP)
 			if err != nil {
 				logrus.Errorf("could not resolve peer %q: %v", neigh.IP, err)


### PR DESCRIPTION
Fixed certain spurious overlay errors which were not errors at all but
showing up everytime service tasks are started in the engine.

Also added a check to make sure a delete is valid by checking the
incoming endpoint id wih the one in peerdb just to make sure if the
delete from gossip is not stale.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>