### PR TITLE
Cleanup networkdb state when the network is deleted locally

### DIFF
--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -305,7 +305,10 @@ func (nDB *NetworkDB) gossip() {
 func (nDB *NetworkDB) bulkSyncTables() {
 	var networks []string
 	nDB.RLock()
-	for nid := range nDB.networks[nDB.config.NodeName] {
+	for nid, network := range nDB.networks[nDB.config.NodeName] {
+		if network.leaving {
+			continue
+		}
 		networks = append(networks, nid)
 	}
 	nDB.RUnlock()

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -398,7 +398,8 @@ func (nDB *NetworkDB) JoinNetwork(nid string) error {
 // this event across the cluster. This triggers this node leaving the
 // sub-cluster of this network and as a result will no longer
 // participate in the network-scoped gossip and bulk sync for this
-// network.
+// network. Also remove all the table entries for this network from
+// networkdb
 func (nDB *NetworkDB) LeaveNetwork(nid string) error {
 	ltime := nDB.networkClock.Increment()
 	if err := nDB.sendNetworkEvent(nid, NetworkEventTypeLeave, ltime); err != nil {
@@ -407,6 +408,36 @@ func (nDB *NetworkDB) LeaveNetwork(nid string) error {
 
 	nDB.Lock()
 	defer nDB.Unlock()
+	var (
+		paths   []string
+		entries []*entry
+	)
+
+	nwWalker := func(path string, v interface{}) bool {
+		entry, ok := v.(*entry)
+		if !ok {
+			return false
+		}
+		paths = append(paths, path)
+		entries = append(entries, entry)
+		return false
+	}
+
+	nDB.indexes[byNetwork].WalkPrefix(fmt.Sprintf("/%s", nid), nwWalker)
+	for _, path := range paths {
+		params := strings.Split(path[1:], "/")
+		tname := params[1]
+		key := params[2]
+
+		if _, ok := nDB.indexes[byTable].Delete(fmt.Sprintf("/%s/%s/%s", tname, nid, key)); !ok {
+			logrus.Errorf("Could not delete entry in table %s with network id %s and key %s as it does not exist", tname, nid, key)
+		}
+
+		if _, ok := nDB.indexes[byNetwork].Delete(fmt.Sprintf("/%s/%s/%s", nid, tname, key)); !ok {
+			logrus.Errorf("Could not delete entry in network %s with table name %s and key %s as it does not exist", nid, tname, key)
+		}
+	}
+
 	nodeNetworks, ok := nDB.networks[nDB.config.NodeName]
 	if !ok {
 		return fmt.Errorf("could not find self node for network %s while trying to leave", nid)


### PR DESCRIPTION
Fixes https://github.com/docker/libnetwork/issues/1387

When a worker node doesn't have any more tasks on a network, the network gets deleted and the service db for that network also gets removed. When a task on that network starts again service records should be populated again. This wasn't happening correctly because the earlier state in the networkdb wasn't fully cleaned up. Changes to address this are..
- cleanup the network db state when a network is removed on a node
- while the network is in the going away state do not include the state for this network in the bulksync
- also, do not process the table events coming from the peers for this network.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>