### PR TITLE
Fix a panic introduced by #1389

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -567,7 +567,10 @@ func (sb *sandbox) ResolveName(name string, ipType int) ([]net.IP, bool) {
 	newList := []*endpoint{}
 	if !sb.controller.isDistributedControl() {
 		newList = append(newList, getDynamicNwEndpoints(epList)...)
-		newList = append(newList, getIngressNwEndpoint(epList))
+		ingressEP := getIngressNwEndpoint(epList)
+		if ingressEP != nil {
+			newList = append(newList, ingressEP)
+		}
 		newList = append(newList, getLocalNwEndpoints(epList)...)
 		epList = newList
 	}


### PR DESCRIPTION
If the sandbox doesn't have any EP in ingress network nil was getting added to the epList and resulting in a panic.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>