### PR TITLE
Fix IPv6 address pool request for network.enableIPv6=true

### DIFF
--- a/network.go
+++ b/network.go
@@ -1235,7 +1235,7 @@ func (n *network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {
 	}
 
 	if len(*cfgList) == 0 {
-		if ipVer == 6 {
+		if ipVer == 6 && !n.enableIPv6 {
 			return nil
 		}
 		*cfgList = []*IpamConf{{}}


### PR DESCRIPTION
If a user creates a network with `--ipv6`, no IPv6 address pool is requested from the IPAM driver unless at least one ipamV6Config element is already configured. Configuring a nework with `--ipv6` should be enough to trigger the allocation of an IPv6 address from the driver.