### PR TITLE
Relax SRV name validation and fix external SRV query handling

### DIFF
--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -411,10 +411,10 @@ func TestSRVServiceQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Try resolving a service name with invalid protocol, should fail..
-	_, _, err = ep.Info().Sandbox().ResolveService("_http._icmp.web.swarm")
-	if err == nil {
-		t.Fatal(err)
+	// Service name with invalid protocol name. Should fail without error
+	_, ip, err = ep.Info().Sandbox().ResolveService("_http._icmp.web.swarm")
+	if len(ip) != 0 {
+		t.Fatal("Valid response for invalid service name")
 	}
 }
 

--- a/resolver.go
+++ b/resolver.go
@@ -255,6 +255,9 @@ func (r *resolver) handleSRVQuery(svc string, query *dns.Msg) (*dns.Msg, error) 
 	if err != nil {
 		return nil, err
 	}
+	if len(srv) == 0 {
+		return nil, nil
+	}
 	if len(srv) != len(ip) {
 		return nil, fmt.Errorf("invalid reply for SRV query %s", svc)
 	}

--- a/sandbox.go
+++ b/sandbox.go
@@ -444,16 +444,16 @@ func (sb *sandbox) ResolveService(name string) ([]*net.SRV, []net.IP, error) {
 
 	log.Debugf("Service name To resolve: %v", name)
 
+	// There are DNS implementaions that allow SRV queries for names not in
+	// the format defined by RFC 2782. Hence specific validations checks are
+	// not done
 	parts := strings.Split(name, ".")
 	if len(parts) < 3 {
-		return nil, nil, fmt.Errorf("invalid service name, %s", name)
+		return nil, nil, nil
 	}
 
 	portName := parts[0]
 	proto := parts[1]
-	if proto != "_tcp" && proto != "_udp" {
-		return nil, nil, fmt.Errorf("invalid protocol in service, %s", name)
-	}
 	svcName := strings.Join(parts[2:], ".")
 
 	for _, ep := range sb.getConnectedEndpoints() {


### PR DESCRIPTION
Service name for SRV query had a strict check as defined by RFC 2782. This doesn't work for implementations which allow SRV names that not in the 2782 format.

Also fixed the issue of external SRV queries not getting forwarded to the external resolvers.

related to [docker #25534] (https://github.com/docker/docker/issues/25534)

Signed-off-by: Santhosh Manohar <santhosh@docker.com>