### PR TITLE
Cleanup ingress network and sandbox on leave

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -308,6 +308,24 @@ func (c *controller) clusterAgentInit() {
 			c.clusterConfigAvailable = false
 			c.agentInitDone = make(chan struct{})
 			c.Unlock()
+
+			if err := c.ingressSandbox.Delete(); err != nil {
+				log.Warnf("Could not delete ingress sandbox while leaving: %v", err)
+			}
+
+			c.ingressSandbox = nil
+
+			n, err := c.NetworkByName("ingress")
+			if err != nil {
+				log.Warnf("Could not find ingress network while leaving: %v", err)
+			}
+
+			if n != nil {
+				if err := n.Delete(); err != nil {
+					log.Warnf("Could not delete ingress network while leaving: %v", err)
+				}
+			}
+
 			c.agentClose()
 			return
 		}


### PR DESCRIPTION
When a node leaves the swarm cluster, we should cleanup the ingress
network and sandbox. This makes sure that when the next time the node
joins the swarm it will be able to update the cluster with the right
information.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>