### PR TITLE
Reset the encryption keys on swarm leave

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -328,7 +328,10 @@ func (c *controller) agentClose() {
 	c.agent.epTblCancel()
 
 	c.agent.networkDB.Close()
+
+	c.Lock()
 	c.agent = nil
+	c.Unlock()
 }
 
 func (n *network) isClusterEligible() bool {

--- a/controller.go
+++ b/controller.go
@@ -307,13 +307,16 @@ func (c *controller) clusterAgentInit() {
 			c.Lock()
 			c.clusterConfigAvailable = false
 			c.agentInitDone = make(chan struct{})
+			c.keys = nil
 			c.Unlock()
 
 			if err := c.ingressSandbox.Delete(); err != nil {
 				log.Warnf("Could not delete ingress sandbox while leaving: %v", err)
 			}
 
+			c.Lock()
 			c.ingressSandbox = nil
+			c.Unlock()
 
 			n, err := c.NetworkByName("ingress")
 			if err != nil {


### PR DESCRIPTION
On a swarm leave controller's keys should be reset. Otherwise a node joining back after few key rotations will end up incorrect Primary key.  Right now this is not an issue because in the sequence of events keys are received first before the agent is setup. So the the received keys are [stored](https://github.com/docker/libnetwork/blob/master/controller.go#L281) instead of triggering a key rotation. But the correct behavior should be to reset the keys. Also added lock in couple of places.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>