### PR TITLE
Ensure add newly joined node to networknodes

### DIFF
--- a/networkdb/delegate.go
+++ b/networkdb/delegate.go
@@ -53,6 +53,7 @@ func (nDB *NetworkDB) handleNetworkEvent(nEvent *NetworkEvent) bool {
 			n.leaveTime = time.Now()
 		}
 
+		nDB.addNetworkNode(nEvent.NetworkID, nEvent.NodeName)
 		return true
 	}
 
@@ -66,7 +67,7 @@ func (nDB *NetworkDB) handleNetworkEvent(nEvent *NetworkEvent) bool {
 		ltime: nEvent.LTime,
 	}
 
-	nDB.networkNodes[nEvent.NetworkID] = append(nDB.networkNodes[nEvent.NetworkID], nEvent.NodeName)
+	nDB.addNetworkNode(nEvent.NetworkID, nEvent.NodeName)
 	return true
 }
 

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -453,6 +453,20 @@ func (nDB *NetworkDB) LeaveNetwork(nid string) error {
 	return nil
 }
 
+// addNetworkNode adds the node to the list of nodes which participate
+// in the passed network only if it is not already present. Caller
+// should hold the NetworkDB lock while calling this
+func (nDB *NetworkDB) addNetworkNode(nid string, nodeName string) {
+	nodes := nDB.networkNodes[nid]
+	for _, node := range nodes {
+		if node == nodeName {
+			return
+		}
+	}
+
+	nDB.networkNodes[nid] = append(nDB.networkNodes[nid], nodeName)
+}
+
 // Deletes the node from the list of nodes which participate in the
 // passed network. Caller should hold the NetworkDB lock while calling
 // this


### PR DESCRIPTION
In cases a node left the cluster and quickly rejoined before the node
entry is expired by other nodes in the cluster, when the node rejoins we
fail to add it to the quick lookup database. Fixed it.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>