### PR TITLE
Cleanup service bindings when leaving cluster

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -310,6 +310,16 @@ func (c *controller) clusterAgentInit() {
 			c.keys = nil
 			c.Unlock()
 
+			// We are leaving the cluster. Make sure we
+			// close the gossip so that we stop all
+			// incoming gossip updates before cleaning up
+			// any remaining service bindings. But before
+			// deleting the networks since the networks
+			// should still be present when cleaning up
+			// service bindings
+			c.agentClose()
+			c.cleanupServiceBindings("")
+
 			if err := c.ingressSandbox.Delete(); err != nil {
 				log.Warnf("Could not delete ingress sandbox while leaving: %v", err)
 			}
@@ -329,7 +339,6 @@ func (c *controller) clusterAgentInit() {
 				}
 			}
 
-			c.agentClose()
 			return
 		}
 	}

--- a/service.go
+++ b/service.go
@@ -45,6 +45,9 @@ type service struct {
 	// List of ingress ports exposed by the service
 	ingressPorts portConfigs
 
+	// Service aliases
+	aliases []string
+
 	sync.Mutex
 }
 

--- a/service_unsupported.go
+++ b/service_unsupported.go
@@ -7,6 +7,9 @@ import (
 	"net"
 )
 
+func (c *controller) cleanupServiceBindings(nid string) {
+}
+
 func (c *controller) addServiceBinding(name, sid, nid, eid string, vip net.IP, ingressPorts []*PortConfig, aliases []string, ip net.IP) error {
 	return fmt.Errorf("not supported")
 }


### PR DESCRIPTION
When leaving the entire gossip cluster or when leaving a network
specific gossip cluster, we may not have had a chance to cleanup service
bindings by way of gossip updates due to premature closure of gossip
channel. Make sure to cleanup all service bindings since we are not
participating in the cluster any more.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>