### PR TITLE
Notify agentInitDone after joining the cluster

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -183,17 +183,20 @@ func (c *controller) agentSetup() error {
 				}
 				return false
 			})
-
-			if c.agent != nil {
-				close(c.agentInitDone)
-			}
 		}
 	}
+
 	if remoteAddr != "" {
 		if err := c.agentJoin(remoteAddr); err != nil {
 			logrus.Errorf("Error in agentJoin : %v", err)
+			return nil
 		}
 	}
+
+	if c.agent != nil {
+		close(c.agentInitDone)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Currently the initDone notification is provided immediately after
initializing the cluster. This may be fine for the first manager. But
for all subsequent nodes which join the cluster we need to wait until
the node completes the joining to the gossip cluster inorder to
synchronize the gossip network clock with other nodes. If we don't have
uptodate clock the updates that this node provides to the cluster may be
discarded by the other nodes if they have entries which are yet to be
reaped but have a better clock.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>