### PR TITLE
Avoid k/v store endpoint update in swarm mode

### DIFF
--- a/store.go
+++ b/store.go
@@ -346,6 +346,10 @@ func (c *controller) networkWatchLoop(nw *netWatch, ep *endpoint, ecCh <-chan da
 }
 
 func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoint) {
+	if !c.isDistributedControl() && ep.getNetwork().driverScope() == datastore.GlobalScope {
+		return
+	}
+
 	c.Lock()
 	nw, ok := nmap[ep.getNetwork().ID()]
 	c.Unlock()
@@ -400,6 +404,10 @@ func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoi
 }
 
 func (c *controller) processEndpointDelete(nmap map[string]*netWatch, ep *endpoint) {
+	if !c.isDistributedControl() && ep.getNetwork().driverScope() == datastore.GlobalScope {
+		return
+	}
+
 	c.Lock()
 	nw, ok := nmap[ep.getNetwork().ID()]
 


### PR DESCRIPTION
Avoid the whole store endpoint update logic when running in swarm mode
and the endpoint is part of a global scope network. Currently there is
no store update that is happening for global scope networks in swarm
mode, but this code path will delete the svcRecords database when the
last endpoint on the network is removed which is something that is not
required.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>