### PR TITLE
Avoid double close of agentInitDone

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -193,9 +193,12 @@ func (c *controller) agentSetup() error {
 		}
 	}
 
-	if c.agent != nil {
+	c.Lock()
+	if c.agent != nil && c.agentInitDone != nil {
 		close(c.agentInitDone)
+		c.agentInitDone = nil
 	}
+	c.Unlock()
 
 	return nil
 }

--- a/controller.go
+++ b/controller.go
@@ -347,7 +347,13 @@ func (c *controller) clusterAgentInit() {
 // AgentInitWait waits for agent initialization to be completed in the
 // controller.
 func (c *controller) AgentInitWait() {
-	<-c.agentInitDone
+	c.Lock()
+	agentInitDone := c.agentInitDone
+	c.Unlock()
+
+	if agentInitDone != nil {
+		<-agentInitDone
+	}
 }
 
 func (c *controller) makeDriverConfig(ntype string) map[string]interface{} {


### PR DESCRIPTION
Avoid by reinitializing the channel immediately after closing the
channel within a lock. Also change the wait code to cache the channel in
stack be retrieving it from controller and wait on the stack copy of the
channel.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>