### PR TITLE
Add sandbox method for task insertion to service LB and service disovery

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -74,6 +74,7 @@ type endpoint struct {
 	ingressPorts      []*PortConfig
 	dbIndex           uint64
 	dbExists          bool
+	serviceEnabled    bool
 	sync.Mutex
 }
 
@@ -303,6 +304,24 @@ func (ep *endpoint) isAnonymous() bool {
 	return ep.anonymous
 }
 
+// CompareAndSwap ep's serviceEnabled. If its in oldState, set it to newState
+// and return true.  If its not in oldState return false
+func (ep *endpoint) casServiceEnabled(oldState, newState bool) bool {
+	ep.Lock()
+	defer ep.Unlock()
+	if ep.serviceEnabled == oldState {
+		ep.serviceEnabled = newState
+		return true
+	}
+	return false
+}
+
+func (ep *endpoint) setServiceEnabled(state bool) {
+	ep.Lock()
+	defer ep.Unlock()
+	ep.serviceEnabled = state
+}
+
 func (ep *endpoint) needResolver() bool {
 	ep.Lock()
 	defer ep.Unlock()
@@ -498,10 +517,6 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 
 	if err = sb.populateNetworkResources(ep); err != nil {
 		return err
-	}
-
-	if e := ep.addToCluster(); e != nil {
-		log.Errorf("Could not update state for endpoint %s into cluster: %v", ep.Name(), e)
 	}
 
 	if sb.needDefaultGW() && sb.getEndpointInGWNetwork() == nil {

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -1216,6 +1216,14 @@ func (f *fakeSandbox) Endpoints() []libnetwork.Endpoint {
 	return nil
 }
 
+func (f *fakeSandbox) EnableService() error {
+	return nil
+}
+
+func (f *fakeSandbox) DisableService() error {
+	return nil
+}
+
 func TestExternalKey(t *testing.T) {
 	externalKeyTest(t, false)
 }

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -203,9 +203,10 @@ func (nDB *NetworkDB) getEntry(tname, nid, key string) (*entry, error) {
 // table, key) tuple and if the NetworkDB is part of the cluster
 // propogates this event to the cluster. It is an error to create an
 // entry for the same tuple for which there is already an existing
-// entry.
+// entry unless the current entry is deleting state.
 func (nDB *NetworkDB) CreateEntry(tname, nid, key string, value []byte) error {
-	if _, err := nDB.GetEntry(tname, nid, key); err == nil {
+	e, _ := nDB.getEntry(tname, nid, key)
+	if e != nil && !e.deleting {
 		return fmt.Errorf("cannot create entry as the entry in table %s with network id %s and key %s already exists", tname, nid, key)
 	}
 


### PR DESCRIPTION
Added a new sandbox API to add a task to the load balancer and service discovery. This can be used by the engine to make the task available only if the health check status is ok. It can also be used potentially by the swarm agent to gracefully pull a task from the backends and allow a grace period to drain the existing connections in the upgrade case.

This doesn't affect the driver plumbing. And the container can still discover other services in the network so that health check with dependency on other services can be supported.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>