### PR TITLE
Do not hold sandbox if not in distributed control

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -202,12 +202,14 @@ func (sb *sandbox) delete(force bool) error {
 	retain := false
 	for _, ep := range sb.getConnectedEndpoints() {
 		// gw network endpoint detach and removal are automatic
-		if ep.endpointInGWNetwork() {
+		if ep.endpointInGWNetwork() && !force {
 			continue
 		}
 		// Retain the sanbdox if we can't obtain the network from store.
 		if _, err := c.getNetworkFromStore(ep.getNetwork().ID()); err != nil {
-			retain = true
+			if c.isDistributedControl() {
+				retain = true
+			}
 			log.Warnf("Failed getting network for ep %s during sandbox %s delete: %v", ep.ID(), sb.ID(), err)
 			continue
 		}


### PR DESCRIPTION
When the libnetwork controller is not in distributed control mode avoid
retaining stale sandboxes when the network cannot be retrieved from
store. This ratining logic is only applicable for an independent k/v
store which manages libnetwork state. In such case the k/v store may be
temporarily unavailable so there is a need to retain the sandbox so that
the resource cleanup happens properly.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>