### PR TITLE
Decrement epCnt only after all cleanup

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -757,17 +757,6 @@ func (ep *endpoint) Delete(force bool) error {
 		}
 	}()
 
-	if err = n.getEpCnt().DecEndpointCnt(); err != nil && !force {
-		return err
-	}
-	defer func() {
-		if err != nil && !force {
-			if e := n.getEpCnt().IncEndpointCnt(); e != nil {
-				log.Warnf("failed to update network %s : %v", n.name, e)
-			}
-		}
-	}()
-
 	// unwatch for service records
 	n.getController().unWatchSvcRecord(ep)
 
@@ -776,6 +765,10 @@ func (ep *endpoint) Delete(force bool) error {
 	}
 
 	ep.releaseAddress()
+
+	if err := n.getEpCnt().DecEndpointCnt(); err != nil {
+		log.Warnf("failed to decrement endpoint coint for ep %s: %v", ep.ID(), err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Currently the endpoint count is being decremented before the driver
cleanup and more importantly before releasing the ip address. This is
racy as it creates a time window where we already have decremented the
endpoint count and so the network can be deleted now. But we haven't
released the IP address yet and the pool is already gone. Although there
is no harm done since the pool is already gone. it generates unnecessary
error message about not able to release the address. Also if the driver
cleanup fails we really should not decrement endpoint count.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>