### PR TITLE
make sure the user-provided bridge interface is a bridge

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -641,7 +641,10 @@ func (d *driver) createNetwork(config *networkConfiguration) error {
 	d.Unlock()
 
 	// Create or retrieve the bridge L3 interface
-	bridgeIface := newInterface(d.nlh, config)
+	bridgeIface, err := newInterface(d.nlh, config)
+	if err != nil {
+		return err
+	}
 	network.bridge = bridgeIface
 
 	// Verify the network configuration does not conflict with previously installed

--- a/drivers/bridge/interface.go
+++ b/drivers/bridge/interface.go
@@ -28,7 +28,7 @@ type bridgeInterface struct {
 // an already existing device identified by the configuration BridgeName field,
 // or the default bridge name when unspecified, but doesn't attempt to create
 // one when missing
-func newInterface(nlh *netlink.Handle, config *networkConfiguration) *bridgeInterface {
+func newInterface(nlh *netlink.Handle, config *networkConfiguration) (*bridgeInterface, error) {
 	var err error
 	i := &bridgeInterface{nlh: nlh}
 
@@ -41,8 +41,10 @@ func newInterface(nlh *netlink.Handle, config *networkConfiguration) *bridgeInte
 	i.Link, err = nlh.LinkByName(config.BridgeName)
 	if err != nil {
 		logrus.Debugf("Did not find any interface with name %s: %v", config.BridgeName, err)
+	} else if _, ok := i.Link.(*netlink.Bridge); !ok {
+		return nil, fmt.Errorf("existing interface %s is not a bridge", i.Link.Attrs().Name)
 	}
-	return i
+	return i, nil
 }
 
 // exists indicates if the existing bridge interface exists on the system.

--- a/drivers/bridge/interface_test.go
+++ b/drivers/bridge/interface_test.go
@@ -15,7 +15,12 @@ func TestInterfaceDefaultName(t *testing.T) {
 		t.Fatal(err)
 	}
 	config := &networkConfiguration{}
-	if _ = newInterface(nh, config); config.BridgeName != DefaultBridgeName {
+	_, err = newInterface(nh, config)
+	if err != nil {
+		t.Fatalf("newInterface() failed: %v", err)
+	}
+
+	if config.BridgeName != DefaultBridgeName {
 		t.Fatalf("Expected default interface name %q, got %q", DefaultBridgeName, config.BridgeName)
 	}
 }
@@ -27,7 +32,11 @@ func TestAddressesEmptyInterface(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	inf := newInterface(nh, &networkConfiguration{})
+	inf, err := newInterface(nh, &networkConfiguration{})
+	if err != nil {
+		t.Fatalf("newInterface() failed: %v", err)
+	}
+
 	addrv4, addrsv6, err := inf.addresses()
 	if err != nil {
 		t.Fatalf("Failed to get addresses of default interface: %v", err)


### PR DESCRIPTION
If someone creates a network with `-o com.docker.network.bridge.name=xxx` but "xxx" is not a bridge interface, we should show an error and let it fail.