### PR TITLE
Make the overlay network vxlan ports and gossip port configurable

### DIFF
--- a/drivers/overlay/labels.go
+++ b/drivers/overlay/labels.go
@@ -1,0 +1,8 @@
+package overlay
+
+import "github.com/docker/libnetwork/netlabel"
+
+const (
+	// VxlanPortLabel Overlay network vxlan interface port label
+	VxlanPortLabel = netlabel.DriverPrefix + ".overlay.vxlan.port"
+)

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -5,6 +5,7 @@ package overlay
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"sync"
 
 	"github.com/Sirupsen/logrus"
@@ -24,9 +25,12 @@ const (
 	vethLen      = 7
 	vxlanIDStart = 256
 	vxlanIDEnd   = (1 << 24) - 1
-	vxlanPort    = 4789
 	vxlanEncap   = 50
 	secureOption = "encrypted"
+)
+
+var (
+	vxlanPort = int(4789)
 )
 
 var initVxlanIdm = make(chan (bool), 1)
@@ -89,6 +93,14 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 		d.localStore, err = datastore.NewDataStoreFromConfig(dsc)
 		if err != nil {
 			return types.InternalErrorf("failed to initialize local data store: %v", err)
+		}
+	}
+
+	if port, ok := config[VxlanPortLabel]; ok {
+		if val, found := port.(string); found {
+			if intVal, err := strconv.ParseInt(val, 10, 32); err == nil {
+				vxlanPort = int(intVal)
+			}
 		}
 	}
 

--- a/netlabel/labels.go
+++ b/netlabel/labels.go
@@ -53,6 +53,9 @@ const (
 
 	// ContainerIfacePrefix can be used to override the interface prefix used inside the container
 	ContainerIfacePrefix = Prefix + ".container_iface_prefix"
+
+	// GossipAdvertisePort constant represents the gossip advertise port
+	GossipAdvertisePort = Prefix + ".gossip_advertise_port"
 )
 
 var (


### PR DESCRIPTION
I found some switch will intercept the 4789/udp package. Then the cross host overlay containers cannot communicate with others. So I push this PR to make the overlay network ports configurable.
