### PR TITLE
User provided ndots shouldn't be ignored

### DIFF
--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -314,8 +314,15 @@ func (sb *sandbox) rebuildDNS() error {
 	dnsList = append(dnsList, resolvconf.GetNameservers(currRC.Content, types.IPv6)...)
 
 	// Resolver returns the options in the format resolv.conf expects
+	for _, option := range dnsOptionsList {
+		if strings.Contains(option, "ndots") {
+			goto build
+		}
+	}
+
 	dnsOptionsList = append(dnsOptionsList, sb.resolver.ResolverOptions()...)
 
+build:
 	_, err = resolvconf.Build(sb.config.resolvConfPath, dnsList, dnsSearchList, dnsOptionsList)
 	return err
 }


### PR DESCRIPTION
Related to [docker #26039](https://github.com/docker/docker/issues/26039)

If `--dns-opt ndots:#` is passed on docker run it will take precedence and `ndots:0` will not be added. What this means is, if domain or search options are available in the resolv.conf an unqualified name will get appended with the domain/search names. The query will still go through the Docker DNS server but will result in lookup failure (unless the network name itself is added as a search option) and get forwarded to external nameserver.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>