### PR TITLE
Revert "add s390x arch build info at the netlink_deprecated_linux bri…

### DIFF
--- a/drivers/bridge/netlink_deprecated_linux_notarm.go
+++ b/drivers/bridge/netlink_deprecated_linux_notarm.go
@@ -1,4 +1,4 @@
-// +build !arm,!ppc64,!ppc64le,!s390x
+// +build !arm,!ppc64,!ppc64le
 
 package bridge
 

--- a/drivers/bridge/netlink_deprecated_linux_s390x.go
+++ b/drivers/bridge/netlink_deprecated_linux_s390x.go
@@ -1,7 +1,0 @@
-// +build s390x
-
-package bridge
-
-func ifrDataByte(b byte) uint8 {
-	return uint8(b)
-}


### PR DESCRIPTION
Revert "add s390x arch build info at the netlink_deprecated_linux bridge driver"
    
This reverts commit 8c72dab7167dc934e9dd57d773331fb15fa6a27d.

  * PR docker/libnetwork#1198
    
The original commit breaks s390x, for example Docker build fails:
    
  * docker/docker#26440

As discussed in the above issue:

>  Even though char is unsigned by default on s390x, (gcc)go forces the type
>  of RawSockaddr.Data to be signed.

>  It makes no practical difference if these fields are signed or unsigned,
>  it's just an API issue.

 > The (assumed) reason for the original commit:

 > For a while RawSockaddr.Data was unsigned during development of the gcc
 > s390x port (not in an upstream release though). Probably the patch has
 > been developed in this time frame.

Suggested-by: Michael Munday
Signed-off-by: Michael Holzheu <<holzheu@linux.vnet.ibm.com>>