### PR TITLE
Drop queries in root domain when ndots is set

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -86,6 +86,7 @@ type sandbox struct {
 	isStub             bool
 	inDelete           bool
 	ingress            bool
+	ndotsSet           bool
 	sync.Mutex
 }
 


### PR DESCRIPTION
Related to [docker #26039](https://github.com/docker/docker/issues/26039)

PR #1435 addresses this issue by passing the user provided ndots value to the resolv.conf. [One concern](https://github.com/docker/libnetwork/pull/1435#issuecomment-245988800) with this approach is that it results in inconsistent UX. This PR addresses the issue differently; if the user passes a `ndots` option unqualified queries will not be forwarded in the root domain. This would allow the client resolver to try with the search domains attached.
 
Signed-off-by: Santhosh Manohar <santhosh@docker.com>