### PR TITLE
Fix bitseq.SetAnyInRange

### DIFF
--- a/bitseq/sequence.go
+++ b/bitseq/sequence.go
@@ -197,7 +197,7 @@ func (h *Handle) getCopy() *Handle {
 
 // SetAnyInRange atomically sets the first unset bit in the specified range in the sequence and returns the corresponding ordinal
 func (h *Handle) SetAnyInRange(start, end uint64) (uint64, error) {
-	if end-start <= 0 || end >= h.bits {
+	if end < start || end >= h.bits {
 		return invalidPos, fmt.Errorf("invalid bit range [%d, %d]", start, end)
 	}
 	if h.Unselected() == 0 {

--- a/bitseq/sequence_test.go
+++ b/bitseq/sequence_test.go
@@ -639,10 +639,6 @@ func TestSetInRange(t *testing.T) {
 		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
 	}
 
-	if o, err := hnd.SetAnyInRange(5, 5); err == nil {
-		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
-	}
-
 	if o, err := hnd.SetAnyInRange(0, numBits); err == nil {
 		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
 	}
@@ -690,6 +686,11 @@ func TestSetInRange(t *testing.T) {
 
 	if _, err := hnd.SetAnyInRange(0, numBits-1); err != nil {
 		t.Fatalf("Unexpected failure: %v", err)
+	}
+
+	// set one bit using the set range with 1 bit size range
+	if _, err := hnd.SetAnyInRange(uint64(163*blockLen-1), uint64(163*blockLen-1)); err != nil {
+		t.Fatal(err)
 	}
 
 	// create a non multiple of 32 mask


### PR DESCRIPTION
- Size 1 range is a valid input
- Validation check was incorrect anyway given unsigned operands

Related to https://github.com/docker/docker/issues/23980

This allows:
```
$ docker network create --subnet=2.2.2.0/24 --gateway=2.2.2.254 --ip-range=2.2.2.100/32 abcd
d65e374fe18a88e1693aaca243f58682a8d160c853df7b54ab54ee284e8bd181
$ docker run --rm --network abcd busybox ifconfig eth0
eth0      Link encap:Ethernet  HWaddr 02:42:02:02:02:64  
          inet addr:2.2.2.100  Bcast:0.0.0.0  Mask:255.255.255.0
          inet6 addr: fe80::42:2ff:fe02:264/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:2 errors:0 dropped:0 overruns:0 frame:0
          TX packets:1 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0 
          RX bytes:180 (180.0 B)  TX bytes:90 (90.0 B)

$ 
```