### PR TITLE
Revert "Add sandbox API for task insertion to service LB and service discovery"

### DIFF
--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -1216,14 +1216,6 @@ func (f *fakeSandbox) Endpoints() []libnetwork.Endpoint {
 	return nil
 }
 
-func (f *fakeSandbox) EnableService() error {
-	return nil
-}
-
-func (f *fakeSandbox) DisableService() error {
-	return nil
-}
-
 func TestExternalKey(t *testing.T) {
 	externalKeyTest(t, false)
 }

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -203,10 +203,9 @@ func (nDB *NetworkDB) getEntry(tname, nid, key string) (*entry, error) {
 // table, key) tuple and if the NetworkDB is part of the cluster
 // propogates this event to the cluster. It is an error to create an
 // entry for the same tuple for which there is already an existing
-// entry unless the current entry is deleting state.
+// entry.
 func (nDB *NetworkDB) CreateEntry(tname, nid, key string, value []byte) error {
-	e, _ := nDB.getEntry(tname, nid, key)
-	if e != nil && !e.deleting {
+	if _, err := nDB.GetEntry(tname, nid, key); err == nil {
 		return fmt.Errorf("cannot create entry as the entry in table %s with network id %s and key %s already exists", tname, nid, key)
 	}
 

--- a/sandbox.go
+++ b/sandbox.go
@@ -50,12 +50,6 @@ type Sandbox interface {
 	ResolveService(name string) ([]*net.SRV, []net.IP, error)
 	// Endpoints returns all the endpoints connected to the sandbox
 	Endpoints() []Endpoint
-	// EnableService  makes a managed container's service available by adding the
-	// endpoint to the service load balancer and service discovery
-	EnableService() error
-	// DisableService removes a managed contianer's endpoints from the load balancer
-	// and service discovery
-	DisableService() error
 }
 
 // SandboxOption is an option setter function type used to pass various options to
@@ -723,30 +717,6 @@ func (sb *sandbox) SetKey(basePath string) error {
 	for _, ep := range sb.getConnectedEndpoints() {
 		if err = sb.populateNetworkResources(ep); err != nil {
 			return err
-		}
-	}
-	return nil
-}
-
-func (sb *sandbox) EnableService() error {
-	for _, ep := range sb.getConnectedEndpoints() {
-		if ep.casServiceEnabled(false, true) {
-			if e := ep.addToCluster(); e != nil {
-				ep.setServiceEnabled(false)
-				return fmt.Errorf("could not update state for endpoint %s into cluster: %v", ep.Name(), e)
-			}
-		}
-	}
-	return nil
-}
-
-func (sb *sandbox) DisableService() error {
-	for _, ep := range sb.getConnectedEndpoints() {
-		if ep.casServiceEnabled(true, false) {
-			if e := ep.deleteFromCluster(); e != nil {
-				ep.setServiceEnabled(true)
-				return fmt.Errorf("could not delete state for endpoint %s from cluster: %v", ep.Name(), e)
-			}
 		}
 	}
 	return nil


### PR DESCRIPTION
This reverts commit 2fb2fd20c7aea931a388d61c4994fc76c581957a.

This change was to support container health aware LB and graceful rolling upgrade. Without the docker and swarmkit changes for these features libnetwork can't be vendored in. Hence reverting it now and will be included when the docker/swarmkit changes are complete. cc @dongluochen 