### PR TITLE
Check if IPv6 is enabled before restoring the network pools

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -753,9 +753,11 @@ func (c *controller) reservePools() {
 				c.Gateway = n.ipamV4Info[i].Gateway.IP.String()
 			}
 		}
-		for i, c := range n.ipamV6Config {
-			if c.Gateway == "" && n.ipamV6Info[i].Gateway != nil {
-				c.Gateway = n.ipamV6Info[i].Gateway.IP.String()
+		if n.enableIPv6 {
+			for i, c := range n.ipamV6Config {
+				if c.Gateway == "" && n.ipamV6Info[i].Gateway != nil {
+					c.Gateway = n.ipamV6Info[i].Gateway.IP.String()
+				}
 			}
 		}
 		// Reserve pools


### PR DESCRIPTION
Related to https://github.com/docker/docker/issues/26075

Fix reservePool logic to be cover the case where a restored network was created with a IPv6 subnet specified but no `--ipv6`.

Signed-off-by: Alessandro Boch <aboch@docker.com>