### PR TITLE
Name the ingress sandbox explicitly

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -920,6 +920,7 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (s
 
 	if sb.ingress {
 		c.ingressSandbox = sb
+		sb.id = "ingress_sbox"
 	}
 	c.Unlock()
 	defer func() {


### PR DESCRIPTION
For ease of debugging the ingress sandbox should have a fixed name that doesn't change.

This PR sets it explicitly in libnetwork. An alternative would be to use the container id `ingress-sandbox` which is passed to the sandbox creation. But the presence of `-` is currently interpreted as overlay network sandbox.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>