### PR TITLE
Wait for the kernel to notify the veth interfaces are running

### DIFF
--- a/ns/init_linux.go
+++ b/ns/init_linux.go
@@ -47,11 +47,11 @@ func SetNamespace() error {
 
 // ParseHandlerInt transforms the namespace handler into an integer
 func ParseHandlerInt() int {
-	return int(getHandler())
+	return int(GetHandler())
 }
 
 // GetHandler returns the namespace handler
-func getHandler() netns.NsHandle {
+func GetHandler() netns.NsHandle {
 	initOnce.Do(Init)
 	return initNs
 }


### PR DESCRIPTION
This is a revised patch from docker/docker#26492, adding a timeout and moving the synchronizing code into a separate function.

It addresses race conditions that apparently caused a few different problems.  According to my own testing, this seems to fix at least docker/docker#26492, coreos/bugs#1554, and coreos/bugs#254.