### PR TITLE
In overlay driver reset any state on setkey()

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -336,7 +336,9 @@ func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) 
 			}
 			keys = append(keys, k)
 		}
-		d.setKeys(keys)
+		if err := d.setKeys(keys); err != nil {
+			logrus.Warn(err)
+		}
 	case discoverapi.EncryptionKeysUpdate:
 		var newKey, delKey, priKey *key
 		encrData, ok := data.(discoverapi.DriverEncryptionUpdate)
@@ -361,7 +363,9 @@ func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) 
 				tag:   uint32(encrData.PruneTag),
 			}
 		}
-		d.updateKeys(newKey, priKey, delKey)
+		if err := d.updateKeys(newKey, priKey, delKey); err != nil {
+			logrus.Warn(err)
+		}
 	default:
 	}
 	return nil


### PR DESCRIPTION
Overlay driver needs to reset the encrypion keys and any neigh map when libnetwork core sets the key.
Current logic would cause issues in case a node leaves a cluster and joins the cluster back after the key rotation has happened, for example.

Related to https://github.com/docker/docker/issues/25608

Signed-off-by: Alessandro Boch <aboch@docker.com>