### PR TITLE
Fix test failures

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1667,9 +1667,8 @@ func (f *localResponseWriter) WriteHeader(c int) {
 	f.statusCode = c
 }
 
-func TestwriteJSON(t *testing.T) {
-	testCode := 55
-	testData, err := json.Marshal("test data")
+func testWriteJSON(t *testing.T, testCode int, testData interface{}) {
+	testDataMarshalled, err := json.Marshal(testData)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1679,10 +1678,17 @@ func TestwriteJSON(t *testing.T) {
 	if rsp.statusCode != testCode {
 		t.Fatalf("writeJSON() failed to set the status code. Expected %d. Got %d", testCode, rsp.statusCode)
 	}
-	if !bytes.Equal(testData, rsp.body) {
-		t.Fatalf("writeJSON() failed to set the body. Expected %s. Got %s", testData, rsp.body)
+	// writeJSON calls json.Encode and it appends '\n' to the result,
+	// while json.Marshal not
+	expected := append(testDataMarshalled, byte('\n'))
+	if !bytes.Equal(expected, rsp.body) {
+		t.Fatalf("writeJSON() failed to set the body. Expected %q. Got %q", expected, rsp.body)
 	}
+}
 
+func TestWriteJSON(t *testing.T) {
+	testWriteJSON(t, 55, "test data as string")
+	testWriteJSON(t, 55, []byte("test data as bytes"))
 }
 
 func TestHttpHandlerUninit(t *testing.T) {

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -1545,7 +1545,7 @@ func TestLeaveAll(t *testing.T) {
 	}
 }
 
-func TestontainerInvalidLeave(t *testing.T) {
+func TestContainerInvalidLeave(t *testing.T) {
 	if !testutils.IsRunningInContainer() {
 		defer testutils.SetupTestOSContext(t)()
 	}
@@ -1595,11 +1595,11 @@ func TestontainerInvalidLeave(t *testing.T) {
 		t.Fatalf("Failed with unexpected error type: %T. Desc: %s", err, err.Error())
 	}
 
-	if err := ep.Leave(nil); err == nil {
+	if err = ep.Leave(nil); err == nil {
 		t.Fatalf("Expected to fail leave nil Sandbox")
 	}
 	if _, ok := err.(types.BadRequestError); !ok {
-		t.Fatalf("Unexpected error type returned: %T", err)
+		t.Fatalf("Unexpected error type returned: %T. Desc: %s", err, err.Error())
 	}
 
 	fsbx := &fakeSandbox{}
@@ -1607,7 +1607,7 @@ func TestontainerInvalidLeave(t *testing.T) {
 		t.Fatalf("Expected to fail leave with invalid Sandbox")
 	}
 	if _, ok := err.(types.BadRequestError); !ok {
-		t.Fatalf("Unexpected error type returned: %T", err)
+		t.Fatalf("Unexpected error type returned: %T. Desc: %s", err, err.Error())
 	}
 }
 


### PR DESCRIPTION
   * TestwriteJSON and TestontainerInvalidLeave were never executed due to the typos. Recent govet found them.
   * TestWriteJSON was failing due to the comparison between string and []byte. Also, it didn't considered that json.Encode a
ppends LF.
   * TestContainerInvalidLeave was faling due to a typo

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>