### PR TITLE
Check for ExecFunc failure

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -421,8 +421,7 @@ func (sb *sandbox) ResolveIP(ip string) string {
 }
 
 func (sb *sandbox) ExecFunc(f func()) error {
-	sb.osSbox.InvokeFunc(f)
-	return nil
+	return sb.osSbox.InvokeFunc(f)
 }
 
 func (sb *sandbox) ResolveService(name string) ([]*net.SRV, []net.IP) {
@@ -639,9 +638,12 @@ func (sb *sandbox) SetKey(basePath string) error {
 	if oldosSbox != nil && sb.resolver != nil {
 		sb.resolver.Stop()
 
-		sb.osSbox.InvokeFunc(sb.resolver.SetupFunc(0))
-		if err := sb.resolver.Start(); err != nil {
-			log.Errorf("Resolver Setup/Start failed for container %s, %q", sb.ContainerID(), err)
+		if err := sb.osSbox.InvokeFunc(sb.resolver.SetupFunc(0)); err == nil {
+			if err := sb.resolver.Start(); err != nil {
+				log.Errorf("Resolver Start failed for container %s, %q", sb.ContainerID(), err)
+			}
+		} else {
+			log.Errorf("Resolver Setup Function failed for container %s, %q", sb.ContainerID(), err)
 		}
 	}
 

--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -46,9 +46,13 @@ func (sb *sandbox) startResolver(restore bool) {
 		}
 		sb.resolver.SetExtServers(sb.extDNS)
 
-		sb.osSbox.InvokeFunc(sb.resolver.SetupFunc(0))
+		if err = sb.osSbox.InvokeFunc(sb.resolver.SetupFunc(0)); err != nil {
+			log.Errorf("Resolver Setup function failed for container %s, %q", sb.ContainerID(), err)
+			return
+		}
+
 		if err = sb.resolver.Start(); err != nil {
-			log.Errorf("Resolver Setup/Start failed for container %s, %q", sb.ContainerID(), err)
+			log.Errorf("Resolver Start failed for container %s, %q", sb.ContainerID(), err)
 		}
 	})
 }


### PR DESCRIPTION
Related to [docker #26356] (https://github.com/docker/docker/issues/26356)

Panic was in ServeDNS(), in this dereference extConn.LocalAddr().String()
```
                        log.Debugf("Query %s[%d] from %s, forwarding to %s:%s", name, query.Question[0].Qtype,
                                extConn.LocalAddr().String(), proto, extDNS.ipStr)
```

It can happen only if the `execFunc` failed for some reason. #1412 already added a check for the execFunc failure. But the error from InvokeFunc was being ignored. Fixed that and also added error checks for other calls to InvokeFunc()

There is a 2nd panic mentioned in the same issue. Its a different decode. We can ask the submitter to open a different issue after collecting the required info to root cause it.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>