### PR TITLE
Honor user provided listen address for gossip

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -172,10 +172,12 @@ func (c *controller) agentSetup() error {
 	advAddr := clusterProvider.GetAdvertiseAddress()
 	remote := clusterProvider.GetRemoteAddress()
 	remoteAddr, _, _ := net.SplitHostPort(remote)
+	listen := clusterProvider.GetListenAddress()
+	listenAddr, _, _ := net.SplitHostPort(listen)
 
-	logrus.Infof("Initializing Libnetwork Agent Local-addr=%s Adv-addr=%s Remote-addr =%s", bindAddr, advAddr, remoteAddr)
+	logrus.Infof("Initializing Libnetwork Agent Listen-Addr=%s Local-addr=%s Adv-addr=%s Remote-addr =%s", listenAddr, bindAddr, advAddr, remoteAddr)
 	if advAddr != "" && c.agent == nil {
-		if err := c.agentInit(bindAddr, advAddr); err != nil {
+		if err := c.agentInit(listenAddr, bindAddr, advAddr); err != nil {
 			logrus.Errorf("Error in agentInit : %v", err)
 		} else {
 			c.drvRegistry.WalkDrivers(func(name string, driver driverapi.Driver, capability driverapi.Capability) bool {
@@ -236,7 +238,7 @@ func (c *controller) getPrimaryKeyTag(subsys string) ([]byte, uint64, error) {
 	return keys[1].Key, keys[1].LamportTime, nil
 }
 
-func (c *controller) agentInit(bindAddrOrInterface, advertiseAddr string) error {
+func (c *controller) agentInit(listenAddr, bindAddrOrInterface, advertiseAddr string) error {
 	if !c.isAgent() {
 		return nil
 	}
@@ -252,6 +254,7 @@ func (c *controller) agentInit(bindAddrOrInterface, advertiseAddr string) error 
 	logrus.Info("Gossip cluster hostname ", nodeName)
 
 	nDB, err := networkdb.New(&networkdb.Config{
+		BindAddr:      listenAddr,
 		AdvertiseAddr: advertiseAddr,
 		NodeName:      nodeName,
 		Keys:          keys,

--- a/cluster/provider.go
+++ b/cluster/provider.go
@@ -10,6 +10,7 @@ type Provider interface {
 	IsManager() bool
 	IsAgent() bool
 	GetLocalAddress() string
+	GetListenAddress() string
 	GetAdvertiseAddress() string
 	GetRemoteAddress() string
 	ListenClusterEvents() <-chan struct{}

--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -316,6 +316,10 @@ func (d *dnetConnection) GetLocalAddress() string {
 	return d.Orchestration.Bind
 }
 
+func (d *dnetConnection) GetListenAddress() string {
+	return d.Orchestration.Bind
+}
+
 func (d *dnetConnection) GetRemoteAddress() string {
 	return d.Orchestration.Peer
 }

--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -86,6 +86,7 @@ func (nDB *NetworkDB) RemoveKey(key []byte) {
 func (nDB *NetworkDB) clusterInit() error {
 	config := memberlist.DefaultLANConfig()
 	config.Name = nDB.config.NodeName
+	config.BindAddr = nDB.config.BindAddr
 	config.AdvertiseAddr = nDB.config.AdvertiseAddr
 
 	if nDB.config.BindPort != 0 {

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -121,6 +121,10 @@ type Config struct {
 	// NodeName is the cluster wide unique name for this node.
 	NodeName string
 
+	// BindAddr is the IP on which networkdb listens. It can be
+	// 0.0.0.0 to listen on all addresses on the host.
+	BindAddr string
+
 	// AdvertiseAddr is the node's IP address that we advertise for
 	// cluster communication.
 	AdvertiseAddr string


### PR DESCRIPTION
If user provided a non-zero listen address, honor that and bind only to
that address. Right now it is not honored and we always bind to all ip
addresses in the host.

This requires an equivalent change in docker.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>