### PR TITLE
Serialize overlay filter plumbing

### DIFF
--- a/drivers/overlay/filter.go
+++ b/drivers/overlay/filter.go
@@ -12,6 +12,13 @@ const globalChain = "DOCKER-OVERLAY"
 
 var filterOnce sync.Once
 
+var filterChan = make(chan struct{}, 1)
+
+func filterWait() func() {
+	filterChan <- struct{}{}
+	return func() { <-filterChan }
+}
+
 func chainExists(cname string) bool {
 	if _, err := iptables.Raw("-L", cname); err != nil {
 		return false
@@ -69,10 +76,14 @@ func setNetworkChain(cname string, remove bool) error {
 }
 
 func addNetworkChain(cname string) error {
+	defer filterWait()()
+
 	return setNetworkChain(cname, false)
 }
 
 func removeNetworkChain(cname string) error {
+	defer filterWait()()
+
 	return setNetworkChain(cname, true)
 }
 
@@ -119,9 +130,13 @@ func setFilters(cname, brName string, remove bool) error {
 }
 
 func addFilters(cname, brName string) error {
+	defer filterWait()()
+
 	return setFilters(cname, brName, false)
 }
 
 func removeFilters(cname, brName string) error {
+	defer filterWait()()
+
 	return setFilters(cname, brName, true)
 }


### PR DESCRIPTION
When plumbing overlay filter rules serialize this to make sure that
multiple sandbox join or leave is not causing erroneous behavior while
moving the RETURN rule in the predefined chains.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>