### PR TITLE
Use monotonic clock source to reap networkDB entries

### DIFF
--- a/networkdb/delegate.go
+++ b/networkdb/delegate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/gogo/protobuf/proto"
@@ -121,7 +120,7 @@ func (nDB *NetworkDB) handleNetworkEvent(nEvent *NetworkEvent) bool {
 		n.ltime = nEvent.LTime
 		n.leaving = nEvent.Type == NetworkEventTypeLeave
 		if n.leaving {
-			n.leaveTime = time.Now()
+			n.reapTime = reapInterval
 		}
 
 		nDB.addNetworkNode(nEvent.NetworkID, nEvent.NodeName)
@@ -178,7 +177,7 @@ func (nDB *NetworkDB) handleTableEvent(tEvent *TableEvent) bool {
 	}
 
 	if e.deleting {
-		e.deleteTime = time.Now()
+		e.reapTime = reapInterval
 	}
 
 	nDB.Lock()


### PR DESCRIPTION
Go's time.Now() uses `CLOCK_REALTIME` source. In the networkDB we use `time.Now() and Sub()` to determine the elapsed time to delete the entries. `CLOCK_REALTIME` source can be modified by the user (it can jump forward or backward) or by NTP (though NTP never moves the time back, the time can jump forward at different speed at different intervals till it catches up).

This is problematic because if the time changes significantly it can lead to premature removal of state from networkDB. For delete events this can lead to stale state in the cluster.

We should use a monotonic clock source. Surprisingly Golang doesn't expose the monotonic source in the standard library; https://github.com/golang/go/issues/12914. Hence using a work around which is still platform agnostic.