### PR TITLE
WIP: per-network control plane encryption in libnetwork

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -3,6 +3,7 @@ package libnetwork
 //go:generate protoc -I.:Godeps/_workspace/src/github.com/gogo/protobuf  --gogo_out=import_path=github.com/docker/libnetwork,Mgogoproto/gogo.proto=github.com/gogo/protobuf/gogoproto:. agent.proto
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/go-events"
+	"github.com/docker/libnetwork/crypto"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
@@ -412,7 +414,14 @@ func (ep *endpoint) addToCluster() error {
 			return err
 		}
 
-		if err := c.agent.networkDB.CreateEntry("endpoint_table", n.ID(), ep.ID(), buf); err != nil {
+		// Encrypt the networkDB data with per-network encryption key. globalKay to be replaced
+		// with per network Keyring from swarm manager.
+		var msg bytes.Buffer
+		if err := crypto.EncryptPayload(crypto.Aes128Gcm, c.globalKey, buf, nil, &msg); err != nil {
+			return err
+		}
+
+		if err := c.agent.networkDB.CreateEntry("endpoint_table", n.ID(), ep.ID(), msg.Bytes()); err != nil {
 			return err
 		}
 	}
@@ -590,7 +599,12 @@ func (c *controller) handleEpTableEvent(ev events.Event) {
 	}
 	n := nw.(*network)
 
-	err = proto.Unmarshal(value, &epRec)
+	var buff []byte
+	if buff, err = crypto.DecryptPayload(crypto.Aes128Gcm, [][]byte{c.globalKey}, value, nil); err != nil {
+		return
+	}
+
+	err = proto.Unmarshal(buff, &epRec)
 	if err != nil {
 		logrus.Errorf("Failed to unmarshal service table value: %v", err)
 		return

--- a/controller.go
+++ b/controller.go
@@ -45,6 +45,7 @@ package libnetwork
 
 import (
 	"container/heap"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"strings"
@@ -153,6 +154,7 @@ type controller struct {
 	networkLocker          *locker.Locker
 	agentInitDone          chan struct{}
 	keys                   []*types.EncryptionKey
+	globalKey              []byte
 	clusterConfigAvailable bool
 	sync.Mutex
 }
@@ -226,6 +228,9 @@ func New(cfgOptions ...config.Option) (NetworkController, error) {
 	if err := c.startExternalKeyListener(); err != nil {
 		return nil, err
 	}
+
+	// PoC code to verify per network encryption in libnetwork
+	c.globalKey, _ = base64.StdEncoding.DecodeString("Uv38ByGCZU8WP18PmmIdcg==")
 
 	return c, nil
 }

--- a/crypto/encrypt.go
+++ b/crypto/encrypt.go
@@ -1,0 +1,132 @@
+// Adopted from github.com/hashicorp/memberlist with minor changes
+// Only AES 128 bit encryption in GCM mode is supported now.
+
+package crypto
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+const (
+	cipherSize     = 1
+	nonceSize      = 12
+	tagSize        = 16
+	maxPadOverhead = 16
+	blockSize      = aes.BlockSize
+)
+
+//Cipher represents the encryption algorithm
+type Cipher uint8
+
+const (
+	// Aes128Gcm AES 128 bit in GCM mode
+	Aes128Gcm Cipher = 1
+)
+
+// encryptedLength is used to compute the buffer size needed
+// for a message of given length
+func encryptedLength(msgSize int) int {
+	return cipherSize + nonceSize + msgSize + tagSize
+}
+
+// EncryptPayload is used to encrypt a message with a given key.
+// We make use of AES-128 in GCM mode. dst buffer will have cipher,
+// nonce, ciphertext and tag
+func EncryptPayload(c Cipher, key []byte, msg []byte, data []byte, dst *bytes.Buffer) error {
+	// Only AES 128 bits in GCM mode is supported now.
+	if c != Aes128Gcm {
+		return fmt.Errorf("invalid cipher for encryption")
+	}
+
+	// Get the AES block cipher
+	aesBlock, err := aes.NewCipher(key)
+	if err != nil {
+		return err
+	}
+	// Get the GCM cipher mode
+	gcm, err := cipher.NewGCM(aesBlock)
+	if err != nil {
+		return err
+	}
+
+	// Grow the buffer to make room for everything
+	offset := dst.Len()
+	dst.Grow(encryptedLength(len(msg)))
+
+	// Write the cipher value
+	dst.WriteByte(byte(c))
+
+	// Add a random nonce
+	io.CopyN(dst, rand.Reader, nonceSize)
+	afterNonce := dst.Len()
+
+	// Encrypt message using GCM
+	slice := dst.Bytes()[offset:]
+	nonce := slice[cipherSize : cipherSize+nonceSize]
+
+	out := gcm.Seal(nil, nonce, msg, data)
+	// Truncate the plaintext, and write the cipher text
+	dst.Truncate(afterNonce)
+	dst.Write(out)
+	return nil
+}
+
+// decryptMessage performs the actual decryption of ciphertext. This is in its
+// own function to allow it to be called on all keys easily.
+func decryptMessage(key, msg, data []byte) ([]byte, error) {
+	// Get the AES block cipher
+	aesBlock, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the GCM cipher mode
+	gcm, err := cipher.NewGCM(aesBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decrypt the message
+	nonce := msg[cipherSize : cipherSize+nonceSize]
+	ciphertext := msg[cipherSize+nonceSize:]
+	plain, err := gcm.Open(nil, nonce, ciphertext, data)
+	if err != nil {
+		return nil, err
+	}
+
+	// Success!
+	return plain, nil
+}
+
+// DecryptPayload is used to decrypt a message with a given key,
+// and verify it's contents. returned slice has the plaintext data
+func DecryptPayload(c Cipher, keys [][]byte, msg, data []byte) ([]byte, error) {
+	// Ensure we have at least one byte
+	if len(msg) == 0 {
+		return nil, fmt.Errorf("cannot decrypt empty payload")
+	}
+	// Check if the cipher is supported
+	msgCipher := Cipher(msg[0])
+	if msgCipher != c {
+		return nil, fmt.Errorf("unsupported encryption cipher %d", msg[0])
+	}
+
+	// Ensure the length is sane
+	if len(msg) < encryptedLength(0) {
+		return nil, fmt.Errorf("payload is too small to decrypt: %d", len(msg))
+	}
+
+	for _, key := range keys {
+		plain, err := decryptMessage(key, msg, data)
+		if err == nil {
+			return plain, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no installed keys could decrypt the message")
+}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -3,6 +3,7 @@ package overlay
 //go:generate protoc -I.:../../Godeps/_workspace/src/github.com/gogo/protobuf  --gogo_out=import_path=github.com/docker/libnetwork/drivers/overlay,Mgogoproto/gogo.proto=github.com/gogo/protobuf/gogoproto:. overlay.proto
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net"
 	"sync"
@@ -49,6 +50,7 @@ type driver struct {
 	once             sync.Once
 	joinOnce         sync.Once
 	keys             []*key
+	globalKey        []byte
 	sync.Mutex
 }
 
@@ -104,6 +106,8 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 			n.once = &sync.Once{}
 		}
 	}
+	// PoC code to verify per network encryption in libnetwork
+	d.globalKey, _ = base64.StdEncoding.DecodeString("Uv38ByGCZU8WP18PmmIdcg==")
 
 	return dc.RegisterDriver(networkType, d, c)
 }


### PR DESCRIPTION
Supporting gossip encryption using per-network shared secret needs changes in swarmkit, docker engine, and in libnetwork. This PR is for the libnetwork changes so that it can be verified independently by using hard coded keys.

Signed-off-by: Santhosh Manohar santhosh@docker.com
