### PR TITLE
Reap failed nodes after 24 hours

### DIFF
--- a/networkdb/event_delegate.go
+++ b/networkdb/event_delegate.go
@@ -29,6 +29,8 @@ func (e *eventDelegate) NotifyLeave(mn *memberlist.Node) {
 	e.nDB.Lock()
 	if n, ok := e.nDB.nodes[mn.Name]; ok {
 		delete(e.nDB.nodes, mn.Name)
+
+		n.reapTime = reapInterval
 		e.nDB.failedNodes[mn.Name] = n
 	}
 	e.nDB.Unlock()

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -94,6 +94,8 @@ type NetworkDB struct {
 type node struct {
 	memberlist.Node
 	ltime serf.LamportTime
+	// Number of hours left before the reaper removes the node
+	reapTime time.Duration
 }
 
 // network describes the node/network attachment.


### PR DESCRIPTION
Remove the failed nodes after a 24 hour interval to avoid unnecessary reconnect attempts.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>