### PR TITLE
Cherry Pick: Do not hold ack channel in ack table after closing

### DIFF
--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -555,10 +555,6 @@ func (nDB *NetworkDB) bulkSyncNode(networks []string, node string, unsolicited b
 		case <-t.C:
 			logrus.Errorf("Bulk sync to node %s timed out", node)
 		case <-ch:
-			nDB.Lock()
-			delete(nDB.bulkSyncAckTbl, node)
-			nDB.Unlock()
-
 			logrus.Debugf("%s: Bulk sync to node %s took %s", nDB.config.NodeName, node, time.Now().Sub(startTime))
 		}
 		t.Stop()

--- a/networkdb/delegate.go
+++ b/networkdb/delegate.go
@@ -318,12 +318,13 @@ func (nDB *NetworkDB) handleBulkSync(buf []byte) {
 
 	// Don't respond to a bulk sync which was not unsolicited
 	if !bsm.Unsolicited {
-		nDB.RLock()
+		nDB.Lock()
 		ch, ok := nDB.bulkSyncAckTbl[bsm.NodeName]
-		nDB.RUnlock()
 		if ok {
 			close(ch)
+			delete(nDB.bulkSyncAckTbl, bsm.NodeName)
 		}
+		nDB.Unlock()
 
 		return
 	}


### PR DESCRIPTION
Once the bulksync ack channel is closed remove it from the ack table
right away. There is no reason to keep it in the ack table and later
delete it in the ack waiter. Ack waiter anyways has reference to the
channel on which it is waiting.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>