### PR TITLE
Do not add names to ingress network

### DIFF
--- a/network.go
+++ b/network.go
@@ -1059,6 +1059,12 @@ func delNameToIP(svcMap map[string][]net.IP, name string, epIP net.IP) {
 }
 
 func (n *network) addSvcRecords(name string, epIP net.IP, epIPv6 net.IP, ipMapUpdate bool) {
+	// Do not add service names for ingress network as this is a
+	// routing only network
+	if n.ingress {
+		return
+	}
+
 	c := n.getController()
 	c.Lock()
 	defer c.Unlock()
@@ -1086,6 +1092,12 @@ func (n *network) addSvcRecords(name string, epIP net.IP, epIPv6 net.IP, ipMapUp
 }
 
 func (n *network) deleteSvcRecords(name string, epIP net.IP, epIPv6 net.IP, ipMapUpdate bool) {
+	// Do not delete service names from ingress network as this is a
+	// routing only network
+	if n.ingress {
+		return
+	}
+
 	c := n.getController()
 	c.Lock()
 	defer c.Unlock()


### PR DESCRIPTION
Do not add service discovery names to ingress network as this is a
routing only network and no intra-cluster discovery should happen in
that network. This fixes the ambiguity and resolving names between
services which are both publishing ports and also attached to same
another network.

Related to https://github.com/docker/docker/issues/27147

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>