### PR TITLE
Add support for NetworkAllocate and NetworkFree in remote driver

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -75,6 +75,9 @@ type NetworkController interface {
 	// ID provides a unique identity for the controller
 	ID() string
 
+	// BuiltinDrivers returns list of builtin drivers
+	BuiltinDrivers() []string
+
 	// Config method returns the bootup configuration for the controller
 	Config() config.Config
 
@@ -461,6 +464,17 @@ func (c *controller) ReloadConfiguration(cfgOptions ...config.Option) error {
 
 func (c *controller) ID() string {
 	return c.id
+}
+
+func (c *controller) BuiltinDrivers() []string {
+	drivers := []string{}
+	for _, i := range getInitializers() {
+		if i.ntype == "remote" {
+			continue
+		}
+		drivers = append(drivers, i.ntype)
+	}
+	return drivers
 }
 
 func (c *controller) validateHostDiscoveryConfig() bool {

--- a/drivers/remote/api/api.go
+++ b/drivers/remote/api/api.go
@@ -27,6 +27,38 @@ type GetCapabilityResponse struct {
 	Scope string
 }
 
+// AllocateNetworkRequest requests allocation of new network by manager
+type AllocateNetworkRequest struct {
+	// A network ID that remote plugins are expected to store for future
+	// reference.
+	NetworkID string
+
+	// A free form map->object interface for communication of options.
+	Options map[string]string
+
+	// IPAMData contains the address pool information for this network
+	IPv4Data, IPv6Data []driverapi.IPAMData
+}
+
+// AllocateNetworkResponse is the response to the AllocateNetworkRequest.
+type AllocateNetworkResponse struct {
+	Response
+	// A free form plugin specific string->string object to be sent in
+	// CreateNetworkRequest call in the libnetwork agents
+	Options map[string]string
+}
+
+// FreeNetworkRequest is the request to free allocated network in the manager
+type FreeNetworkRequest struct {
+	// The ID of the network to be freed.
+	NetworkID string
+}
+
+// FreeNetworkResponse is the response to a request for freeing a network.
+type FreeNetworkResponse struct {
+	Response
+}
+
 // CreateNetworkRequest requests a new network.
 type CreateNetworkRequest struct {
 	// A network ID that remote plugins are expected to store for future

--- a/drivers/remote/driver.go
+++ b/drivers/remote/driver.go
@@ -88,12 +88,21 @@ func (d *driver) call(methodName string, arg interface{}, retVal maybeError) err
 	return nil
 }
 
-func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {
-	return nil, types.NotImplementedErrorf("not implemented")
+func (d *driver) NetworkAllocate(id string, options map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {
+	create := &api.AllocateNetworkRequest{
+		NetworkID: id,
+		Options:   options,
+		IPv4Data:  ipV4Data,
+		IPv6Data:  ipV6Data,
+	}
+	retVal := api.AllocateNetworkResponse{}
+	err := d.call("AllocateNetwork", create, &retVal)
+	return retVal.Options, err
 }
 
 func (d *driver) NetworkFree(id string) error {
-	return types.NotImplementedErrorf("not implemented")
+	fr := &api.FreeNetworkRequest{NetworkID: id}
+	return d.call("FreeNetwork", fr, &api.FreeNetworkResponse{})
 }
 
 func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key string, value []byte) {


### PR DESCRIPTION
Also added an API to return list of builtin network drivers

Signed-off-by: Madhu Venugopal <madhu@docker.com>