### PR TITLE
Enable ping for service vip address

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -1109,3 +1109,20 @@ func (c *controller) cleanupLocalEndpoints() {
 		}
 	}
 }
+
+func (ep *endpoint) setAliasIP(sb *sandbox, ip net.IP, add bool) error {
+	sb.Lock()
+	sbox := sb.osSbox
+	sb.Unlock()
+
+	for _, i := range sbox.Info().Interfaces() {
+		if ep.hasInterface(i.SrcName()) {
+			ipNet := &net.IPNet{IP: ip, Mask: []byte{255, 255, 255, 255}}
+			if err := i.SetAliasIP(ipNet, add); err != nil {
+				return err
+			}
+			break
+		}
+	}
+	return nil
+}

--- a/osl/interface_linux.go
+++ b/osl/interface_linux.go
@@ -26,7 +26,6 @@ type nwIface struct {
 	mac         net.HardwareAddr
 	address     *net.IPNet
 	addressIPv6 *net.IPNet
-	ipAliases   []*net.IPNet
 	llAddrs     []*net.IPNet
 	routes      []*net.IPNet
 	bridge      bool
@@ -97,13 +96,6 @@ func (i *nwIface) LinkLocalAddresses() []*net.IPNet {
 	return i.llAddrs
 }
 
-func (i *nwIface) IPAliases() []*net.IPNet {
-	i.Lock()
-	defer i.Unlock()
-
-	return i.ipAliases
-}
-
 func (i *nwIface) Routes() []*net.IPNet {
 	i.Lock()
 	defer i.Unlock()
@@ -128,6 +120,28 @@ func (n *networkNamespace) Interfaces() []Interface {
 	}
 
 	return ifaces
+}
+
+func (i *nwIface) SetAliasIP(ip *net.IPNet, add bool) error {
+	i.Lock()
+	n := i.ns
+	i.Unlock()
+
+	n.Lock()
+	nlh := n.nlHandle
+	n.Unlock()
+
+	// Find the network interface identified by the DstName attribute.
+	iface, err := nlh.LinkByName(i.DstName())
+	if err != nil {
+		return err
+	}
+
+	ipAddr := &netlink.Addr{IPNet: ip, Label: ""}
+	if add {
+		return nlh.AddrAdd(iface, ipAddr)
+	}
+	return nlh.AddrDel(iface, ipAddr)
 }
 
 func (i *nwIface) Remove() error {
@@ -333,7 +347,6 @@ func configureInterface(nlh *netlink.Handle, iface netlink.Link, i *nwIface) err
 		{setInterfaceIPv6, fmt.Sprintf("error setting interface %q IPv6 to %v", ifaceName, i.AddressIPv6())},
 		{setInterfaceMaster, fmt.Sprintf("error setting interface %q master to %q", ifaceName, i.DstMaster())},
 		{setInterfaceLinkLocalIPs, fmt.Sprintf("error setting interface %q link local IPs to %v", ifaceName, i.LinkLocalAddresses())},
-		{setInterfaceIPAliases, fmt.Sprintf("error setting interface %q IP Aliases to %v", ifaceName, i.IPAliases())},
 	}
 
 	for _, config := range ifaceConfigurators {
@@ -380,16 +393,6 @@ func setInterfaceIPv6(nlh *netlink.Handle, iface netlink.Link, i *nwIface) error
 func setInterfaceLinkLocalIPs(nlh *netlink.Handle, iface netlink.Link, i *nwIface) error {
 	for _, llIP := range i.LinkLocalAddresses() {
 		ipAddr := &netlink.Addr{IPNet: llIP}
-		if err := nlh.AddrAdd(iface, ipAddr); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func setInterfaceIPAliases(nlh *netlink.Handle, iface netlink.Link, i *nwIface) error {
-	for _, si := range i.IPAliases() {
-		ipAddr := &netlink.Addr{IPNet: si}
 		if err := nlh.AddrAdd(iface, ipAddr); err != nil {
 			return err
 		}

--- a/osl/options_linux.go
+++ b/osl/options_linux.go
@@ -66,12 +66,6 @@ func (n *networkNamespace) LinkLocalAddresses(list []*net.IPNet) IfaceOption {
 	}
 }
 
-func (n *networkNamespace) IPAliases(list []*net.IPNet) IfaceOption {
-	return func(i *nwIface) {
-		i.ipAliases = list
-	}
-}
-
 func (n *networkNamespace) Routes(routes []*net.IPNet) IfaceOption {
 	return func(i *nwIface) {
 		i.routes = routes

--- a/osl/sandbox.go
+++ b/osl/sandbox.go
@@ -91,9 +91,6 @@ type IfaceOptionSetter interface {
 	// LinkLocalAddresses returns an option setter to set the link-local IP addresses.
 	LinkLocalAddresses([]*net.IPNet) IfaceOption
 
-	// IPAliases returns an option setter to set IP address Aliases
-	IPAliases([]*net.IPNet) IfaceOption
-
 	// Master returns an option setter to set the master interface if any for this
 	// interface. The master interface name should refer to the srcname of a
 	// previously added interface of type bridge.
@@ -150,9 +147,6 @@ type Interface interface {
 	// LinkLocalAddresses returns the link-local IP addresses assigned to the interface.
 	LinkLocalAddresses() []*net.IPNet
 
-	// IPAliases returns the IP address aliases assigned to the interface.
-	IPAliases() []*net.IPNet
-
 	// IP routes for the interface.
 	Routes() []*net.IPNet
 
@@ -165,6 +159,10 @@ type Interface interface {
 	// Remove an interface from the sandbox by renaming to original name
 	// and moving it out of the sandbox.
 	Remove() error
+
+	// SetAliasIP adds or deletes the passed IP as an alias on the interface.
+	// ex: set the vip of services in the same network as secondary IP.
+	SetAliasIP(ip *net.IPNet, add bool) error
 
 	// Statistics returns the statistics for this interface
 	Statistics() (*types.InterfaceStatistics, error)

--- a/sandbox.go
+++ b/sandbox.go
@@ -725,10 +725,6 @@ func (sb *sandbox) restoreOslSandbox() error {
 		if len(i.llAddrs) != 0 {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().LinkLocalAddresses(i.llAddrs))
 		}
-		if len(ep.virtualIP) != 0 {
-			vipAlias := &net.IPNet{IP: ep.virtualIP, Mask: net.CIDRMask(32, 32)}
-			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().IPAliases([]*net.IPNet{vipAlias}))
-		}
 		Ifaces[fmt.Sprintf("%s+%s", i.srcName, i.dstPrefix)] = ifaceOptions
 		if joinInfo != nil {
 			for _, r := range joinInfo.StaticRoutes {
@@ -781,10 +777,6 @@ func (sb *sandbox) populateNetworkResources(ep *endpoint) error {
 		}
 		if len(i.llAddrs) != 0 {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().LinkLocalAddresses(i.llAddrs))
-		}
-		if len(ep.virtualIP) != 0 {
-			vipAlias := &net.IPNet{IP: ep.virtualIP, Mask: net.CIDRMask(32, 32)}
-			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().IPAliases([]*net.IPNet{vipAlias}))
 		}
 		if i.mac != nil {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().MacAddress(i.mac))


### PR DESCRIPTION
Related to [docker #25497](https://github.com/docker/docker/issues/25497)

Being able to ping the service vip is useful for quick debugging. Currently only the vip of the service the task belongs to is programmed as a secondary IP on the interface.

This PR enables ping to vip of all services that are attached to a given network by programming the service's vip as a secondary IP.

Signed-off-by: Santhosh Manohar santhosh@docker.com
