### PR TITLE
Reset endpoint port info on connectivity revoke in bridge driver

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  environment:
+    GODIST: "go1.7.1.linux-amd64.tar.gz"
   services:
     - docker
 

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -1318,6 +1318,12 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 		logrus.Warn(err)
 	}
 
+	endpoint.portMapping = nil
+
+	if err = d.storeUpdate(endpoint); err != nil {
+		return fmt.Errorf("failed to update bridge endpoint %s to store: %v", endpoint.id[0:7], err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
- and update it to store. Otherwise after an ungraceful shutdown,
  at next boot there will be in store two bridge endpoints with
  same port-mapping data. When bridge driver will try to restore
  the endpoints, there will be conflicts and a container with
  restart policy could fail to start.

- It can be related to some of the reports in https://github.com/docker/docker/issues/20486 and in https://github.com/docker/docker/issues/25981

- Steps to reproduce:
```
$ # create two networks and run a container on the second one in lexical order
$ docker network create nwa
11d1f4bc8e5e3c06d3025fb2509869fa8f31e0b428a2185e60a649ab5ede552f
$ docker network create nwb
d84ae082627e45ea3254a86b905a20869a9ca8d910be53c046a8f955991454bc
$
$ docker run -d --name w0 --restart always -d -p 8000:8000 -p 9000:9000 --network nwb busybox top
7b208647007d947855eecd8d43124d1c7f6bebfb2cc68c28db3438ec2602164f
$ 
$ sudo iptables -t nat -S POSTROUTING | grep dport
-A POSTROUTING -s 172.19.0.2/32 -d 172.19.0.2/32 -p tcp -m tcp --dport 9000 -j MASQUERADE
-A POSTROUTING -s 172.19.0.2/32 -d 172.19.0.2/32 -p tcp -m tcp --dport 8000 -j MASQUERADE
$ 
$ # connect the container to the first network to trigger the external connectivity change
$ docker network connect nwa w0
$ 
$ sudo iptables -t nat -S POSTROUTING | grep dport
-A POSTROUTING -s 172.18.0.2/32 -d 172.18.0.2/32 -p tcp -m tcp --dport 9000 -j MASQUERADE
-A POSTROUTING -s 172.18.0.2/32 -d 172.18.0.2/32 -p tcp -m tcp --dport 8000 -j MASQUERADE
$ 
$ docker ps 
CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS                                            NAMES
7b208647007d        busybox             "top"               About a minute ago   Up About a minute   0.0.0.0:8000->8000/tcp, 0.0.0.0:9000->9000/tcp   w0
$ 
$ # now kill docker daemon and restart
$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
$ 

Logs from daemon start:

ERRO[0002] Failed to start container 7b208647007d947855eecd8d43124d1c7f6bebfb2cc68c28db3438ec2602164f: driver failed programming external connectivity on endpoint w0 (e9deb1c283c0dade7d25e614d1d16d332ae3a1df153ef9942a142bb135017440): Bind for 0.0.0.0:9000 failed: port is already allocated 
```