### PR TITLE
Avoid controller/service lock AB/BA situation

### DIFF
--- a/service_linux.go
+++ b/service_linux.go
@@ -41,8 +41,15 @@ func newService(name string, id string, ingressPorts []*PortConfig, aliases []st
 
 func (c *controller) cleanupServiceBindings(cleanupNID string) {
 	var cleanupFuncs []func()
+
 	c.Lock()
+	services := make([]*service, 0, len(c.serviceBindings))
 	for _, s := range c.serviceBindings {
+		services = append(services, s)
+	}
+	c.Unlock()
+
+	for _, s := range services {
 		s.Lock()
 		for nid, lb := range s.loadBalancers {
 			if cleanupNID != "" && nid != cleanupNID {
@@ -67,7 +74,6 @@ func (c *controller) cleanupServiceBindings(cleanupNID string) {
 		}
 		s.Unlock()
 	}
-	c.Unlock()
 
 	for _, f := range cleanupFuncs {
 		f()


### PR DESCRIPTION
Currently there is an instance of controller and service lock being
obtained in different order which causes the AB/BA deadlock. Do not ever
wrap controller lock around service lock.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>