### PR TITLE
validate network and endpoint name more strictly

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -14,6 +16,12 @@ import (
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/osl"
 )
+
+// RestrictedNameChars collects the characters allowed to represent a network or endpoint name.
+const restrictedNameChars = `[a-zA-Z0-9][a-zA-Z0-9_.-]`
+
+// RestrictedNamePattern is a regular expression to validate names against the collection of restricted characters.
+var restrictedNamePattern = regexp.MustCompile(`^/?` + restrictedNameChars + `+$`)
 
 // Config encapsulates configurations of various Libnetwork components
 type Config struct {
@@ -223,12 +231,12 @@ func (c *Config) ProcessOptions(options ...Option) {
 	}
 }
 
-// IsValidName validates configuration objects supported by libnetwork
-func IsValidName(name string) bool {
-	if strings.TrimSpace(name) == "" {
-		return false
+// ValidateName validates configuration objects supported by libnetwork
+func ValidateName(name string) error {
+	if !restrictedNamePattern.MatchString(name) {
+		return fmt.Errorf("%s includes invalid characters, only %q are allowed", name, restrictedNameChars)
 	}
-	return true
+	return nil
 }
 
 // OptionLocalKVProvider function returns an option setter for kvstore provider

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,13 +46,16 @@ func TestOptionsLabels(t *testing.T) {
 }
 
 func TestValidName(t *testing.T) {
-	if !IsValidName("test") {
+	if err := ValidateName("test"); err != nil {
 		t.Fatal("Name validation fails for a name that must be accepted")
 	}
-	if IsValidName("") {
+	if err := ValidateName(""); err == nil {
 		t.Fatal("Name validation succeeds for a case when it is expected to fail")
 	}
-	if IsValidName("   ") {
+	if err := ValidateName("   "); err == nil {
+		t.Fatal("Name validation succeeds for a case when it is expected to fail")
+	}
+	if err := ValidateName("<>$$^"); err == nil {
 		t.Fatal("Name validation succeeds for a case when it is expected to fail")
 	}
 }

--- a/controller.go
+++ b/controller.go
@@ -626,8 +626,8 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 		}
 	}
 
-	if !config.IsValidName(name) {
-		return nil, ErrInvalidName(name)
+	if err := config.ValidateName(name); err != nil {
+		return nil, ErrInvalidName(err.Error())
 	}
 
 	if id == "" {

--- a/error.go
+++ b/error.go
@@ -69,7 +69,7 @@ func (ii ErrInvalidID) Error() string {
 func (ii ErrInvalidID) BadRequest() {}
 
 // ErrInvalidName is returned when a query-by-name or resource create method is
-// invoked with an empty name parameter
+// invoked with an invalid name parameter
 type ErrInvalidName string
 
 func (in ErrInvalidName) Error() string {

--- a/network.go
+++ b/network.go
@@ -848,8 +848,9 @@ func (n *network) addEndpoint(ep *endpoint) error {
 
 func (n *network) CreateEndpoint(name string, options ...EndpointOption) (Endpoint, error) {
 	var err error
-	if !config.IsValidName(name) {
-		return nil, ErrInvalidName(name)
+
+	if err = config.ValidateName(name); err != nil {
+		return nil, ErrInvalidName(err.Error())
 	}
 
 	if _, err = n.EndpointByName(name); err == nil {


### PR DESCRIPTION
fixes https://github.com/docker/docker/issues/27449

I think currently docker network name validation is not so strict.
This PR tries to make it more strictly like container or volume name validation.

Signed-off-by: allencloud allen.sun@daocloud.io
