### PR TITLE
Updated vagrant box, ubuntu/vivid64 was remove from atlas.hashicorp.com

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   num_nodes.times do |n|
     config.vm.define "net-#{n+1}" do |net|
-      net.vm.box = "ubuntu/vivid64"
+      net.vm.box = "ubuntu/xenial64"
       net_ip = net_ips[n]
       net_index = n+1
       net.vm.hostname = "net-#{net_index}"


### PR DESCRIPTION
This PR updates the Vagrantfile to use a box available at atlas.hashicorp.com

```
$ vagrant up
Bringing machine 'consul-server' up with 'virtualbox' provider...
Bringing machine 'net-1' up with 'virtualbox' provider...
Bringing machine 'net-2' up with 'virtualbox' provider...
==> consul-server: Checking if box 'ubuntu/trusty64' is up to date...
==> consul-server: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> consul-server: flag to force provisioning. Provisioners marked to run always will still run.
==> net-1: Box 'ubuntu/vivid64' could not be found. Attempting to find and install...
    net-1: Box Provider: virtualbox
    net-1: Box Version: >= 0
The box 'ubuntu/vivid64' could not be found or
could not be accessed in the remote catalog. If this is a private
box on HashiCorp's Atlas, please verify you're logged in via
`vagrant login`. Also, please double-check the name. The expanded
URL and error message are shown below:

URL: ["https://atlas.hashicorp.com/ubuntu/vivid64"]
Error: The requested URL returned error: 404 Not Found
```

Signed-off-by: Ty Alexander <ty.alexander@sendgrid.com>