### PR TITLE
Add sandbox API for task insertion to service LB and service discovery

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -74,6 +74,7 @@ type endpoint struct {
 	ingressPorts      []*PortConfig
 	dbIndex           uint64
 	dbExists          bool
+	serviceEnabled    bool
 	sync.Mutex
 }
 
@@ -303,6 +304,18 @@ func (ep *endpoint) isAnonymous() bool {
 	return ep.anonymous
 }
 
+// enableService sets ep's serviceEnabled to the passed value if it's not in the
+// current state and returns true; false otherwise.
+func (ep *endpoint) enableService(state bool) bool {
+	ep.Lock()
+	defer ep.Unlock()
+	if ep.serviceEnabled != state {
+		ep.serviceEnabled = state
+		return true
+	}
+	return false
+}
+
 func (ep *endpoint) needResolver() bool {
 	ep.Lock()
 	defer ep.Unlock()
@@ -498,10 +511,6 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 
 	if err = sb.populateNetworkResources(ep); err != nil {
 		return err
-	}
-
-	if e := ep.addToCluster(); e != nil {
-		log.Errorf("Could not update state for endpoint %s into cluster: %v", ep.Name(), e)
 	}
 
 	if sb.needDefaultGW() && sb.getEndpointInGWNetwork() == nil {

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -855,6 +855,14 @@ func (f *fakeSandbox) Endpoints() []libnetwork.Endpoint {
 	return nil
 }
 
+func (f *fakeSandbox) EnableService() error {
+	return nil
+}
+
+func (f *fakeSandbox) DisableService() error {
+	return nil
+}
+
 func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 	if !testutils.IsRunningInContainer() {
 		defer testutils.SetupTestOSContext(t)()


### PR DESCRIPTION
This change [was added earlier](https://github.com/docker/libnetwork/pull/1416) but reverted since the docker changes weren't ready.

In this version there are some minor changes to address the comments raised in the docker/docker review, https://github.com/docker/docker/pull/27279

Signed-off-by: Santhosh Manohar santhosh@docker.com
