### PR TITLE
Fix some typos about error

### DIFF
--- a/error.go
+++ b/error.go
@@ -107,7 +107,7 @@ func (nnr NetworkNameError) Error() string {
 // Forbidden denotes the type of this error
 func (nnr NetworkNameError) Forbidden() {}
 
-// UnknownNetworkError is returned when libnetwork could not find in it's database
+// UnknownNetworkError is returned when libnetwork could not find in its database
 // a network with the same name and id.
 type UnknownNetworkError struct {
 	name string
@@ -135,7 +135,7 @@ func (aee *ActiveEndpointsError) Error() string {
 // Forbidden denotes the type of this error
 func (aee *ActiveEndpointsError) Forbidden() {}
 
-// UnknownEndpointError is returned when libnetwork could not find in it's database
+// UnknownEndpointError is returned when libnetwork could not find in its database
 // an endpoint with the same name and id.
 type UnknownEndpointError struct {
 	name string


### PR DESCRIPTION
1. Modify it's to its.
2. The information of error should be begin with low-case letter and keep the same style in this file.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
