### PR TITLE
Respect icc option for internal networks

### DIFF
--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -79,11 +79,11 @@ func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInt
 		Mask: i.bridgeIPv4.Mask,
 	}
 	if config.Internal {
-		if err = setupInternalNetworkRules(config.BridgeName, maskedAddrv4, true); err != nil {
+		if err = setupInternalNetworkRules(config.BridgeName, maskedAddrv4, config.EnableICC, true); err != nil {
 			return fmt.Errorf("Failed to Setup IP tables: %s", err.Error())
 		}
 		n.registerIptCleanFunc(func() error {
-			return setupInternalNetworkRules(config.BridgeName, maskedAddrv4, false)
+			return setupInternalNetworkRules(config.BridgeName, maskedAddrv4, config.EnableICC, false)
 		})
 	} else {
 		if err = setupIPTablesInternal(config.BridgeName, maskedAddrv4, config.EnableICC, config.EnableIPMasquerade, hairpinMode, true); err != nil {
@@ -333,7 +333,7 @@ func removeIPChains() {
 	}
 }
 
-func setupInternalNetworkRules(bridgeIface string, addr net.Addr, insert bool) error {
+func setupInternalNetworkRules(bridgeIface string, addr net.Addr, icc, insert bool) error {
 	var (
 		inDropRule  = iptRule{table: iptables.Filter, chain: IsolationChain, args: []string{"-i", bridgeIface, "!", "-d", addr.String(), "-j", "DROP"}}
 		outDropRule = iptRule{table: iptables.Filter, chain: IsolationChain, args: []string{"-o", bridgeIface, "!", "-s", addr.String(), "-j", "DROP"}}
@@ -342,6 +342,10 @@ func setupInternalNetworkRules(bridgeIface string, addr net.Addr, insert bool) e
 		return err
 	}
 	if err := programChainRule(outDropRule, "DROP OUTGOING", insert); err != nil {
+		return err
+	}
+	// Set Inter Container Communication.
+	if err := setIcc(bridgeIface, icc, insert); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Related to https://github.com/docker/docker/issues/26724

```
$ docker network create --opt com.docker.network.bridge.enable_icc=false --internal nicc
a13d820de6c06810fa2797853faba7793bdf135f097c137fddd9c188b67ba1b3
$ 
$ docker run -d --name c1 --network nicc busybox top
fcbb2b8db5a54f64f99c68856a18a626e9fa00af4f3ce63aa1ff8cb875520d3b
$ docker run -d --name c2 --network nicc busybox top
89307983319a362170fb0922ad92444f7f3572b343699151e805d81beabccc7c
$ docker exec c1 ping -c 2 c2
^C
$ sudo iptables -nvL FORWARD
Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination         
    2   168 DOCKER-ISOLATION  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
    0     0 DOCKER     all  --  *      docker0  0.0.0.0/0            0.0.0.0/0           
    0     0 ACCEPT     all  --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
    0     0 ACCEPT     all  --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
    0     0 ACCEPT     all  --  docker0 docker0  0.0.0.0/0            0.0.0.0/0           
    2   168 DROP       all  --  br-a13d820de6c0 br-a13d820de6c0  0.0.0.0/0            0.0.0.0/0           <-- <--
$
```

Signed-off-by: Alessandro Boch aboch@docker.com
