### PR TITLE
when enabling ip forwarding set the default forward policy to drop

### DIFF
--- a/drivers/bridge/setup_ip_forwarding.go
+++ b/drivers/bridge/setup_ip_forwarding.go
@@ -2,6 +2,8 @@ package bridge
 
 import (
 	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/libnetwork/iptables"
 	"io/ioutil"
 )
 
@@ -10,7 +12,15 @@ const (
 	ipv4ForwardConfPerm = 0644
 )
 
-func setupIPForwarding() error {
+func configureIPForwarding(enable bool) error {
+	var val byte
+	if enable {
+		val = '1'
+	}
+	return ioutil.WriteFile(ipv4ForwardConf, []byte{val, '\n'}, ipv4ForwardConfPerm)
+}
+
+func setupIPForwarding(enableIPTables bool) error {
 	// Get current IPv4 forward setup
 	ipv4ForwardData, err := ioutil.ReadFile(ipv4ForwardConf)
 	if err != nil {
@@ -20,10 +30,26 @@ func setupIPForwarding() error {
 	// Enable IPv4 forwarding only if it is not already enabled
 	if ipv4ForwardData[0] != '1' {
 		// Enable IPv4 forwarding
-		if err := ioutil.WriteFile(ipv4ForwardConf, []byte{'1', '\n'}, ipv4ForwardConfPerm); err != nil {
-			return fmt.Errorf("Setup IP forwarding failed: %v", err)
+		if err := configureIPForwarding(true); err != nil {
+			return fmt.Errorf("Enabling IP forwarding failed: %v", err)
 		}
+		// When enabling ip_forward set the default policy on forward chain to
+		// drop only if the daemon option iptables is not set to false.
+		if !enableIPTables {
+			return nil
+		}
+		if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
+			if err := configureIPForwarding(false); err != nil {
+				log.Errorf("Disabling IP forwarding failed, %v", err)
+			}
+			return err
+		}
+		iptables.OnReloaded(func() {
+			log.Debugf("Setting the default DROP policy on firewall reload")
+			if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
+				log.Warnf("Settig the default DROP policy on firewall reload failed, %v", err)
+			}
+		})
 	}
-
 	return nil
 }

--- a/drivers/bridge/setup_ip_forwarding_test.go
+++ b/drivers/bridge/setup_ip_forwarding_test.go
@@ -17,7 +17,7 @@ func TestSetupIPForwarding(t *testing.T) {
 	}
 
 	// Set IP Forwarding
-	if err := setupIPForwarding(); err != nil {
+	if err := setupIPForwarding(true); err != nil {
 		t.Fatalf("Failed to setup IP forwarding: %v", err)
 	}
 

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -16,6 +16,9 @@ import (
 // Action signifies the iptable action.
 type Action string
 
+// Policy is the default iptable policies
+type Policy string
+
 // Table refers to Nat, Filter or Mangle.
 type Table string
 
@@ -32,6 +35,10 @@ const (
 	Filter Table = "filter"
 	// Mangle table is used for mangling the packet.
 	Mangle Table = "mangle"
+	// Drop is the default iptables DROP policy
+	Drop Policy = "DROP"
+	// Accept is the default iptables ACCEPT policy
+	Accept Policy = "ACCEPT"
 )
 
 var (
@@ -420,6 +427,14 @@ func GetVersion() (major, minor, micro int, err error) {
 		major, minor, micro = parseVersionNumbers(string(out))
 	}
 	return
+}
+
+// SetDefaultPolicy sets the passed default policy for the table/chain
+func SetDefaultPolicy(table Table, chain string, policy Policy) error {
+	if err := RawCombinedOutput("-t", string(table), "-P", chain, string(policy)); err != nil {
+		return fmt.Errorf("setting default policy to %v in %v chain failed: %v", policy, chain, err)
+	}
+	return nil
 }
 
 func parseVersionNumbers(input string) (major, minor, micro int) {


### PR DESCRIPTION
Related to [docker #14041](https://github.com/docker/docker/issues/14041)

If docker daemon enables ip_forwarding on a host set the policy in the FORWARD chain to DROP. This blocks the vulnerability explained in the above mentioned issue. Setting the policy is done from the bridge driver to keep it consistent with the current handling for `ip_forward` flag.

Signed-off-by: Santhosh Manohar santhosh@docker.com
