### PR TITLE
Refactoring for logrus import Instead of 'log' use original package name logrus

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -111,7 +111,7 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 // Endpoints are stored in the local store. Restore them and reconstruct the overlay sandbox
 func (d *driver) restoreEndpoints() error {
 	if d.localStore == nil {
-		logrus.Warnf("Cannot restore overlay endpoints because local datastore is missing")
+		logrus.Warn("Cannot restore overlay endpoints because local datastore is missing")
 		return nil
 	}
 	kvol, err := d.localStore.List(datastore.Key(overlayEndpointPrefix), &endpoint{})

--- a/drivers/solaris/bridge/bridge.go
+++ b/drivers/solaris/bridge/bridge.go
@@ -390,7 +390,7 @@ func bridgeSetup(config *networkConfiguration) error {
 			"/usr/bin/grep " + config.DefaultBindingIP.String()
 		out, err := exec.Command("/usr/bin/bash", "-c", ipadmCmd).Output()
 		if err != nil {
-			logrus.Warnf("cannot find binding interface")
+			logrus.Warn("cannot find binding interface")
 			return err
 		}
 		bindingIntf = strings.SplitN(string(out), "/", 2)[0]
@@ -456,21 +456,21 @@ func bridgeCleanup(config *networkConfiguration, logErr bool) {
 
 	err = exec.Command("/usr/sbin/pfctl", "-a", pfAnchor, "-F", "all").Run()
 	if err != nil && logErr {
-		logrus.Warnf("cannot flush firewall rules")
+		logrus.Warn("cannot flush firewall rules")
 	}
 	err = exec.Command("/usr/sbin/ifconfig", gwName, "unplumb").Run()
 	if err != nil && logErr {
-		logrus.Warnf("cannot remove gateway interface")
+		logrus.Warn("cannot remove gateway interface")
 	}
 	err = exec.Command("/usr/sbin/dladm", "delete-vnic",
 		"-t", gwName).Run()
 	if err != nil && logErr {
-		logrus.Warnf("cannot delete vnic")
+		logrus.Warn("cannot delete vnic")
 	}
 	err = exec.Command("/usr/sbin/dladm", "delete-etherstub",
 		"-t", config.BridgeNameInternal).Run()
 	if err != nil && logErr {
-		logrus.Warnf("cannot delete etherstub")
+		logrus.Warn("cannot delete etherstub")
 	}
 	err = exec.Command("/usr/sbin/pfctl", "-a", tableAnchor, "-t", tableName, "-T", "delete", gwIP).Run()
 	if err != nil && logErr {

--- a/drivers/solaris/bridge/port_mapping.go
+++ b/drivers/solaris/bridge/port_mapping.go
@@ -36,7 +36,7 @@ func addPFRules(epid, bindIntf string, bs []types.PortBinding) {
 	f, err := os.OpenFile(fname,
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
-		logrus.Warnf("cannot open temp pf file")
+		logrus.Warn("cannot open temp pf file")
 		return
 	}
 	for _, b := range bs {

--- a/ipvs/netlink.go
+++ b/ipvs/netlink.go
@@ -64,7 +64,7 @@ func setup() {
 
 		ipvsFamily, err = getIPVSFamily()
 		if err != nil {
-			logrus.Errorf("Could not get ipvs family information from the kernel. It is possible that ipvs is not enabled in your kernel. Native loadbalancing will not work until this is fixed.")
+			logrus.Error("Could not get ipvs family information from the kernel. It is possible that ipvs is not enabled in your kernel. Native loadbalancing will not work until this is fixed.")
 		}
 	})
 }

--- a/sandbox_store.go
+++ b/sandbox_store.go
@@ -178,7 +178,7 @@ func (sb *sandbox) storeDelete() error {
 func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 	store := c.getStore(datastore.LocalScope)
 	if store == nil {
-		logrus.Errorf("Could not find local scope store while trying to cleanup sandboxes")
+		logrus.Error("Could not find local scope store while trying to cleanup sandboxes")
 		return
 	}
 


### PR DESCRIPTION
Both of package name 'log' and 'logrus' used. Refactoirng to use only 'logrus'

Signed-off-by: Daehyeok Mun <daehyeok@gmail.com>