### PR TITLE
Fix logrus formatting

### DIFF
--- a/bitseq/sequence.go
+++ b/bitseq/sequence.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/types"
 )
@@ -286,7 +286,7 @@ func (h *Handle) CheckConsistency() error {
 			continue
 		}
 
-		log.Infof("Fixed inconsistent bit sequence in datastore:\n%s\n%s", h, nh)
+		logrus.Infof("Fixed inconsistent bit sequence in datastore:\n%s\n%s", h, nh)
 
 		h.Lock()
 		h.head = nh.head

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/discovery"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/go-connections/tlsconfig"
@@ -100,7 +100,7 @@ type Option func(c *Config)
 // OptionDefaultNetwork function returns an option setter for a default network
 func OptionDefaultNetwork(dn string) Option {
 	return func(c *Config) {
-		log.Debugf("Option DefaultNetwork: %s", dn)
+		logrus.Debugf("Option DefaultNetwork: %s", dn)
 		c.Daemon.DefaultNetwork = strings.TrimSpace(dn)
 	}
 }
@@ -108,7 +108,7 @@ func OptionDefaultNetwork(dn string) Option {
 // OptionDefaultDriver function returns an option setter for default driver
 func OptionDefaultDriver(dd string) Option {
 	return func(c *Config) {
-		log.Debugf("Option DefaultDriver: %s", dd)
+		logrus.Debugf("Option DefaultDriver: %s", dd)
 		c.Daemon.DefaultDriver = strings.TrimSpace(dd)
 	}
 }
@@ -134,7 +134,7 @@ func OptionLabels(labels []string) Option {
 // OptionKVProvider function returns an option setter for kvstore provider
 func OptionKVProvider(provider string) Option {
 	return func(c *Config) {
-		log.Debugf("Option OptionKVProvider: %s", provider)
+		logrus.Debugf("Option OptionKVProvider: %s", provider)
 		if _, ok := c.Scopes[datastore.GlobalScope]; !ok {
 			c.Scopes[datastore.GlobalScope] = &datastore.ScopeCfg{}
 		}
@@ -145,7 +145,7 @@ func OptionKVProvider(provider string) Option {
 // OptionKVProviderURL function returns an option setter for kvstore url
 func OptionKVProviderURL(url string) Option {
 	return func(c *Config) {
-		log.Debugf("Option OptionKVProviderURL: %s", url)
+		logrus.Debugf("Option OptionKVProviderURL: %s", url)
 		if _, ok := c.Scopes[datastore.GlobalScope]; !ok {
 			c.Scopes[datastore.GlobalScope] = &datastore.ScopeCfg{}
 		}
@@ -157,14 +157,14 @@ func OptionKVProviderURL(url string) Option {
 func OptionKVOpts(opts map[string]string) Option {
 	return func(c *Config) {
 		if opts["kv.cacertfile"] != "" && opts["kv.certfile"] != "" && opts["kv.keyfile"] != "" {
-			log.Info("Option Initializing KV with TLS")
+			logrus.Info("Option Initializing KV with TLS")
 			tlsConfig, err := tlsconfig.Client(tlsconfig.Options{
 				CAFile:   opts["kv.cacertfile"],
 				CertFile: opts["kv.certfile"],
 				KeyFile:  opts["kv.keyfile"],
 			})
 			if err != nil {
-				log.Errorf("Unable to set up TLS: %s", err)
+				logrus.Errorf("Unable to set up TLS: %s", err)
 				return
 			}
 			if _, ok := c.Scopes[datastore.GlobalScope]; !ok {
@@ -182,7 +182,7 @@ func OptionKVOpts(opts map[string]string) Option {
 				KeyFile:    opts["kv.keyfile"],
 			}
 		} else {
-			log.Info("Option Initializing KV without TLS")
+			logrus.Info("Option Initializing KV without TLS")
 		}
 	}
 }
@@ -242,7 +242,7 @@ func ValidateName(name string) error {
 // OptionLocalKVProvider function returns an option setter for kvstore provider
 func OptionLocalKVProvider(provider string) Option {
 	return func(c *Config) {
-		log.Debugf("Option OptionLocalKVProvider: %s", provider)
+		logrus.Debugf("Option OptionLocalKVProvider: %s", provider)
 		if _, ok := c.Scopes[datastore.LocalScope]; !ok {
 			c.Scopes[datastore.LocalScope] = &datastore.ScopeCfg{}
 		}
@@ -253,7 +253,7 @@ func OptionLocalKVProvider(provider string) Option {
 // OptionLocalKVProviderURL function returns an option setter for kvstore url
 func OptionLocalKVProviderURL(url string) Option {
 	return func(c *Config) {
-		log.Debugf("Option OptionLocalKVProviderURL: %s", url)
+		logrus.Debugf("Option OptionLocalKVProviderURL: %s", url)
 		if _, ok := c.Scopes[datastore.LocalScope]; !ok {
 			c.Scopes[datastore.LocalScope] = &datastore.ScopeCfg{}
 		}
@@ -264,7 +264,7 @@ func OptionLocalKVProviderURL(url string) Option {
 // OptionLocalKVProviderConfig function returns an option setter for kvstore config
 func OptionLocalKVProviderConfig(config *store.Config) Option {
 	return func(c *Config) {
-		log.Debugf("Option OptionLocalKVProviderConfig: %v", config)
+		logrus.Debugf("Option OptionLocalKVProviderConfig: %v", config)
 		if _, ok := c.Scopes[datastore.LocalScope]; !ok {
 			c.Scopes[datastore.LocalScope] = &datastore.ScopeCfg{}
 		}

--- a/drivers/bridge/link.go
+++ b/drivers/bridge/link.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/types"
 )
@@ -44,7 +44,7 @@ func (l *link) Disable() {
 	// -D == iptables delete flag
 	err := linkContainers("-D", l.parentIP, l.childIP, l.ports, l.bridge, true)
 	if err != nil {
-		log.Errorf("Error removing IPTables rules for a link %s due to %s", l.String(), err.Error())
+		logrus.Errorf("Error removing IPTables rules for a link %s due to %s", l.String(), err.Error())
 	}
 	// Return proper error once we move to use a proper iptables package
 	// that returns typed errors

--- a/drivers/bridge/setup_ipv4.go
+++ b/drivers/bridge/setup_ipv4.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"path/filepath"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 )
@@ -39,7 +39,7 @@ func setupBridgeIPv4(config *networkConfiguration, i *bridgeInterface) error {
 				return fmt.Errorf("failed to remove current ip address from bridge: %v", err)
 			}
 		}
-		log.Debugf("Assigning address to bridge interface %s: %s", config.BridgeName, config.AddressIPv4)
+		logrus.Debugf("Assigning address to bridge interface %s: %s", config.BridgeName, config.AddressIPv4)
 		if err := i.nlh.AddrAdd(i.Link, &netlink.Addr{IPNet: config.AddressIPv4}); err != nil {
 			return &IPv4AddrAddError{IP: config.AddressIPv4, Err: err}
 		}

--- a/drivers/bridge/setup_verify.go
+++ b/drivers/bridge/setup_verify.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/ns"
 	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
@@ -39,7 +39,7 @@ func setupVerifyAndReconcile(config *networkConfiguration, i *bridgeInterface) e
 	for _, addrv6 := range addrsv6 {
 		if addrv6.IP.IsGlobalUnicast() && !types.CompareIPNet(addrv6.IPNet, i.bridgeIPv6) {
 			if err := i.nlh.AddrDel(i.Link, &addrv6); err != nil {
-				log.Warnf("Failed to remove residual IPv6 address %s from bridge: %v", addrv6.IPNet, err)
+				logrus.Warnf("Failed to remove residual IPv6 address %s from bridge: %v", addrv6.IPNet, err)
 			}
 		}
 	}

--- a/drivers/overlay/encryption.go
+++ b/drivers/overlay/encryption.go
@@ -12,7 +12,7 @@ import (
 
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/ns"
 	"github.com/docker/libnetwork/types"
@@ -77,7 +77,7 @@ func (e *encrMap) String() string {
 }
 
 func (d *driver) checkEncryption(nid string, rIP net.IP, vxlanID uint32, isLocal, add bool) error {
-	log.Debugf("checkEncryption(%s, %v, %d, %t)", nid[0:7], rIP, vxlanID, isLocal)
+	logrus.Debugf("checkEncryption(%s, %v, %d, %t)", nid[0:7], rIP, vxlanID, isLocal)
 
 	n := d.network(nid)
 	if n == nil || !n.secure {
@@ -100,7 +100,7 @@ func (d *driver) checkEncryption(nid string, rIP net.IP, vxlanID uint32, isLocal
 			}
 			return false
 		}); err != nil {
-			log.Warnf("Failed to retrieve list of participating nodes in overlay network %s: %v", nid[0:5], err)
+			logrus.Warnf("Failed to retrieve list of participating nodes in overlay network %s: %v", nid[0:5], err)
 		}
 	default:
 		if len(d.network(nid).endpoints) > 0 {
@@ -108,18 +108,18 @@ func (d *driver) checkEncryption(nid string, rIP net.IP, vxlanID uint32, isLocal
 		}
 	}
 
-	log.Debugf("List of nodes: %s", nodes)
+	logrus.Debugf("List of nodes: %s", nodes)
 
 	if add {
 		for _, rIP := range nodes {
 			if err := setupEncryption(lIP, aIP, rIP, vxlanID, d.secMap, d.keys); err != nil {
-				log.Warnf("Failed to program network encryption between %s and %s: %v", lIP, rIP, err)
+				logrus.Warnf("Failed to program network encryption between %s and %s: %v", lIP, rIP, err)
 			}
 		}
 	} else {
 		if len(nodes) == 0 {
 			if err := removeEncryption(lIP, rIP, d.secMap); err != nil {
-				log.Warnf("Failed to remove network encryption between %s and %s: %v", lIP, rIP, err)
+				logrus.Warnf("Failed to remove network encryption between %s and %s: %v", lIP, rIP, err)
 			}
 		}
 	}
@@ -128,14 +128,14 @@ func (d *driver) checkEncryption(nid string, rIP net.IP, vxlanID uint32, isLocal
 }
 
 func setupEncryption(localIP, advIP, remoteIP net.IP, vni uint32, em *encrMap, keys []*key) error {
-	log.Debugf("Programming encryption for vxlan %d between %s and %s", vni, localIP, remoteIP)
+	logrus.Debugf("Programming encryption for vxlan %d between %s and %s", vni, localIP, remoteIP)
 	rIPs := remoteIP.String()
 
 	indices := make([]*spi, 0, len(keys))
 
 	err := programMangle(vni, true)
 	if err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 
 	for i, k := range keys {
@@ -146,7 +146,7 @@ func setupEncryption(localIP, advIP, remoteIP net.IP, vni uint32, em *encrMap, k
 		}
 		fSA, rSA, err := programSA(localIP, remoteIP, spis, k, dir, true)
 		if err != nil {
-			log.Warn(err)
+			logrus.Warn(err)
 		}
 		indices = append(indices, spis)
 		if i != 0 {
@@ -154,7 +154,7 @@ func setupEncryption(localIP, advIP, remoteIP net.IP, vni uint32, em *encrMap, k
 		}
 		err = programSP(fSA, rSA, true)
 		if err != nil {
-			log.Warn(err)
+			logrus.Warn(err)
 		}
 	}
 
@@ -179,14 +179,14 @@ func removeEncryption(localIP, remoteIP net.IP, em *encrMap) error {
 		}
 		fSA, rSA, err := programSA(localIP, remoteIP, idxs, nil, dir, false)
 		if err != nil {
-			log.Warn(err)
+			logrus.Warn(err)
 		}
 		if i != 0 {
 			continue
 		}
 		err = programSP(fSA, rSA, false)
 		if err != nil {
-			log.Warn(err)
+			logrus.Warn(err)
 		}
 	}
 	return nil
@@ -213,7 +213,7 @@ func programMangle(vni uint32, add bool) (err error) {
 	}
 
 	if err = iptables.RawCombinedOutput(append([]string{"-t", string(iptables.Mangle), a, chain}, rule...)...); err != nil {
-		log.Warnf("could not %s mangle rule: %v", action, err)
+		logrus.Warnf("could not %s mangle rule: %v", action, err)
 	}
 
 	return
@@ -248,9 +248,9 @@ func programSA(localIP, remoteIP net.IP, spi *spi, k *key, dir int, add bool) (f
 		}
 
 		if add != exists {
-			log.Debugf("%s: rSA{%s}", action, rSA)
+			logrus.Debugf("%s: rSA{%s}", action, rSA)
 			if err := xfrmProgram(rSA); err != nil {
-				log.Warnf("Failed %s rSA{%s}: %v", action, rSA, err)
+				logrus.Warnf("Failed %s rSA{%s}: %v", action, rSA, err)
 			}
 		}
 	}
@@ -273,9 +273,9 @@ func programSA(localIP, remoteIP net.IP, spi *spi, k *key, dir int, add bool) (f
 		}
 
 		if add != exists {
-			log.Debugf("%s fSA{%s}", action, fSA)
+			logrus.Debugf("%s fSA{%s}", action, fSA)
 			if err := xfrmProgram(fSA); err != nil {
-				log.Warnf("Failed %s fSA{%s}: %v.", action, fSA, err)
+				logrus.Warnf("Failed %s fSA{%s}: %v.", action, fSA, err)
 			}
 		}
 	}
@@ -319,9 +319,9 @@ func programSP(fSA *netlink.XfrmState, rSA *netlink.XfrmState, add bool) error {
 	}
 
 	if add != exists {
-		log.Debugf("%s fSP{%s}", action, fPol)
+		logrus.Debugf("%s fSP{%s}", action, fPol)
 		if err := xfrmProgram(fPol); err != nil {
-			log.Warnf("%s fSP{%s}: %v", action, fPol, err)
+			logrus.Warnf("%s fSP{%s}: %v", action, fPol, err)
 		}
 	}
 
@@ -337,7 +337,7 @@ func saExists(sa *netlink.XfrmState) (bool, error) {
 		return false, nil
 	default:
 		err = fmt.Errorf("Error while checking for SA existence: %v", err)
-		log.Warn(err)
+		logrus.Warn(err)
 		return false, err
 	}
 }
@@ -351,7 +351,7 @@ func spExists(sp *netlink.XfrmPolicy) (bool, error) {
 		return false, nil
 	default:
 		err = fmt.Errorf("Error while checking for SP existence: %v", err)
-		log.Warn(err)
+		logrus.Warn(err)
 		return false, err
 	}
 }
@@ -397,16 +397,16 @@ func (d *driver) setKeys(keys []*key) error {
 	d.keys = keys
 	d.secMap = &encrMap{nodes: map[string][]*spi{}}
 	d.Unlock()
-	log.Debugf("Initial encryption keys: %v", d.keys)
+	logrus.Debugf("Initial encryption keys: %v", d.keys)
 	return nil
 }
 
 // updateKeys allows to add a new key and/or change the primary key and/or prune an existing key
 // The primary key is the key used in transmission and will go in first position in the list.
 func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
-	log.Debugf("Updating Keys. New: %v, Primary: %v, Pruned: %v", newKey, primary, pruneKey)
+	logrus.Debugf("Updating Keys. New: %v, Primary: %v, Pruned: %v", newKey, primary, pruneKey)
 
-	log.Debugf("Current: %v", d.keys)
+	logrus.Debugf("Current: %v", d.keys)
 
 	var (
 		newIdx = -1
@@ -459,7 +459,7 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 	}
 	d.Unlock()
 
-	log.Debugf("Updated: %v", d.keys)
+	logrus.Debugf("Updated: %v", d.keys)
 
 	return nil
 }
@@ -472,10 +472,10 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 
 // Spis and keys are sorted in such away the one in position 0 is the primary
 func updateNodeKey(lIP, rIP net.IP, idxs []*spi, curKeys []*key, newIdx, priIdx, delIdx int) []*spi {
-	log.Debugf("Updating keys for node: %s (%d,%d,%d)", rIP, newIdx, priIdx, delIdx)
+	logrus.Debugf("Updating keys for node: %s (%d,%d,%d)", rIP, newIdx, priIdx, delIdx)
 
 	spis := idxs
-	log.Debugf("Current: %v", spis)
+	logrus.Debugf("Current: %v", spis)
 
 	// add new
 	if newIdx != -1 {
@@ -520,9 +520,9 @@ func updateNodeKey(lIP, rIP net.IP, idxs []*spi, curKeys []*key, newIdx, priIdx,
 				},
 			},
 		}
-		log.Debugf("Updating fSP{%s}", fSP1)
+		logrus.Debugf("Updating fSP{%s}", fSP1)
 		if err := ns.NlHandle().XfrmPolicyUpdate(fSP1); err != nil {
-			log.Warnf("Failed to update fSP{%s}: %v", fSP1, err)
+			logrus.Warnf("Failed to update fSP{%s}: %v", fSP1, err)
 		}
 
 		// -fSA1
@@ -543,7 +543,7 @@ func updateNodeKey(lIP, rIP net.IP, idxs []*spi, curKeys []*key, newIdx, priIdx,
 		spis = append(spis[:delIdx], spis[delIdx+1:]...)
 	}
 
-	log.Debugf("Updated: %v", spis)
+	logrus.Debugf("Updated: %v", spis)
 
 	return spis
 }

--- a/drivers/overlay/joinleave.go
+++ b/drivers/overlay/joinleave.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/ns"
 	"github.com/docker/libnetwork/types"
@@ -109,7 +109,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 			continue
 		}
 		if err := jinfo.AddStaticRoute(sub.subnetIP, types.NEXTHOP, s.gwIP.IP); err != nil {
-			log.Errorf("Adding subnet %s static route in network %q failed\n", s.subnetIP, n.id)
+			logrus.Errorf("Adding subnet %s static route in network %q failed\n", s.subnetIP, n.id)
 		}
 	}
 
@@ -124,7 +124,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		net.ParseIP(d.advertiseAddress), true)
 
 	if err := d.checkEncryption(nid, nil, n.vxlanID(s), true, true); err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 
 	buf, err := proto.Marshal(&PeerRecord{
@@ -137,7 +137,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 	}
 
 	if err := jinfo.AddTableEntry(ovPeerTable, eid, buf); err != nil {
-		log.Errorf("overlay: Failed adding table entry to joininfo: %v", err)
+		logrus.Errorf("overlay: Failed adding table entry to joininfo: %v", err)
 	}
 
 	d.pushLocalEndpointEvent("join", nid, eid)
@@ -147,7 +147,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 
 func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key string, value []byte) {
 	if tableName != ovPeerTable {
-		log.Errorf("Unexpected table notification for table %s received", tableName)
+		logrus.Errorf("Unexpected table notification for table %s received", tableName)
 		return
 	}
 
@@ -155,7 +155,7 @@ func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key stri
 
 	var peer PeerRecord
 	if err := proto.Unmarshal(value, &peer); err != nil {
-		log.Errorf("Failed to unmarshal peer record: %v", err)
+		logrus.Errorf("Failed to unmarshal peer record: %v", err)
 		return
 	}
 
@@ -167,19 +167,19 @@ func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key stri
 
 	addr, err := types.ParseCIDR(peer.EndpointIP)
 	if err != nil {
-		log.Errorf("Invalid peer IP %s received in event notify", peer.EndpointIP)
+		logrus.Errorf("Invalid peer IP %s received in event notify", peer.EndpointIP)
 		return
 	}
 
 	mac, err := net.ParseMAC(peer.EndpointMAC)
 	if err != nil {
-		log.Errorf("Invalid mac %s received in event notify", peer.EndpointMAC)
+		logrus.Errorf("Invalid mac %s received in event notify", peer.EndpointMAC)
 		return
 	}
 
 	vtep := net.ParseIP(peer.TunnelEndpointIP)
 	if vtep == nil {
-		log.Errorf("Invalid VTEP %s received in event notify", peer.TunnelEndpointIP)
+		logrus.Errorf("Invalid VTEP %s received in event notify", peer.TunnelEndpointIP)
 		return
 	}
 
@@ -219,7 +219,7 @@ func (d *driver) Leave(nid, eid string) error {
 	n.leaveSandbox()
 
 	if err := d.checkEncryption(nid, nil, 0, true, false); err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 
 	return nil

--- a/drivers/overlay/ov_endpoint.go
+++ b/drivers/overlay/ov_endpoint.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netutils"
@@ -116,7 +116,7 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 	n.deleteEndpoint(eid)
 
 	if err := d.deleteEndpointFromStore(ep); err != nil {
-		log.Warnf("Failed to delete overlay endpoint %s from local store: %v", ep.id[0:7], err)
+		logrus.Warnf("Failed to delete overlay endpoint %s from local store: %v", ep.id[0:7], err)
 	}
 
 	if ep.ifName == "" {
@@ -125,11 +125,11 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 
 	link, err := nlh.LinkByName(ep.ifName)
 	if err != nil {
-		log.Debugf("Failed to retrieve interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
+		logrus.Debugf("Failed to retrieve interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
 		return nil
 	}
 	if err := nlh.LinkDel(link); err != nil {
-		log.Debugf("Failed to delete interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
+		logrus.Debugf("Failed to delete interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
 	}
 
 	return nil

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -111,7 +111,7 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 // Endpoints are stored in the local store. Restore them and reconstruct the overlay sandbox
 func (d *driver) restoreEndpoints() error {
 	if d.localStore == nil {
-		logrus.Warnf("Cannot restore overlay endpoints because local datastore is missing")
+		logrus.Warn("Cannot restore overlay endpoints because local datastore is missing")
 		return nil
 	}
 	kvol, err := d.localStore.List(datastore.Key(overlayEndpointPrefix), &endpoint{})

--- a/drivers/overlay/peerdb.go
+++ b/drivers/overlay/peerdb.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 const ovPeerTable = "overlay_peer_table"
@@ -90,7 +90,7 @@ func (d *driver) peerDbNetworkWalk(nid string, f func(*peerKey, *peerEntry) bool
 	for pKeyStr, pEntry := range pMap.mp {
 		var pKey peerKey
 		if _, err := fmt.Sscan(pKeyStr, &pKey); err != nil {
-			log.Warnf("Peer key scan on network %s failed: %v", nid, err)
+			logrus.Warnf("Peer key scan on network %s failed: %v", nid, err)
 		}
 
 		if f(&pKey, &pEntry) {
@@ -289,7 +289,7 @@ func (d *driver) peerAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask,
 	}
 
 	if err := d.checkEncryption(nid, vtep, n.vxlanID(s), false, true); err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 
 	// Add neighbor entry for the peer IP
@@ -349,7 +349,7 @@ func (d *driver) peerDelete(nid, eid string, peerIP net.IP, peerIPMask net.IPMas
 	}
 
 	if err := d.checkEncryption(nid, vtep, 0, false, false); err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 
 	return nil

--- a/drivers/remote/driver.go
+++ b/drivers/remote/driver.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
@@ -39,11 +39,11 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 		d := newDriver(name, client)
 		c, err := d.(*driver).getCapabilities()
 		if err != nil {
-			log.Errorf("error getting capability for %s due to %v", name, err)
+			logrus.Errorf("error getting capability for %s due to %v", name, err)
 			return
 		}
 		if err = dc.RegisterDriver(name, d, *c); err != nil {
-			log.Errorf("error registering driver for %s due to %v", name, err)
+			logrus.Errorf("error registering driver for %s due to %v", name, err)
 		}
 	})
 	return nil

--- a/drivers/solaris/bridge/bridge.go
+++ b/drivers/solaris/bridge/bridge.go
@@ -390,7 +390,7 @@ func bridgeSetup(config *networkConfiguration) error {
 			"/usr/bin/grep " + config.DefaultBindingIP.String()
 		out, err := exec.Command("/usr/bin/bash", "-c", ipadmCmd).Output()
 		if err != nil {
-			logrus.Warnf("cannot find binding interface")
+			logrus.Warn("cannot find binding interface")
 			return err
 		}
 		bindingIntf = strings.SplitN(string(out), "/", 2)[0]
@@ -456,21 +456,21 @@ func bridgeCleanup(config *networkConfiguration, logErr bool) {
 
 	err = exec.Command("/usr/sbin/pfctl", "-a", pfAnchor, "-F", "all").Run()
 	if err != nil && logErr {
-		logrus.Warnf("cannot flush firewall rules")
+		logrus.Warn("cannot flush firewall rules")
 	}
 	err = exec.Command("/usr/sbin/ifconfig", gwName, "unplumb").Run()
 	if err != nil && logErr {
-		logrus.Warnf("cannot remove gateway interface")
+		logrus.Warn("cannot remove gateway interface")
 	}
 	err = exec.Command("/usr/sbin/dladm", "delete-vnic",
 		"-t", gwName).Run()
 	if err != nil && logErr {
-		logrus.Warnf("cannot delete vnic")
+		logrus.Warn("cannot delete vnic")
 	}
 	err = exec.Command("/usr/sbin/dladm", "delete-etherstub",
 		"-t", config.BridgeNameInternal).Run()
 	if err != nil && logErr {
-		logrus.Warnf("cannot delete etherstub")
+		logrus.Warn("cannot delete etherstub")
 	}
 	err = exec.Command("/usr/sbin/pfctl", "-a", tableAnchor, "-t", tableName, "-T", "delete", gwIP).Run()
 	if err != nil && logErr {

--- a/drivers/solaris/bridge/port_mapping.go
+++ b/drivers/solaris/bridge/port_mapping.go
@@ -36,7 +36,7 @@ func addPFRules(epid, bindIntf string, bs []types.PortBinding) {
 	f, err := os.OpenFile(fname,
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
-		logrus.Warnf("cannot open temp pf file")
+		logrus.Warn("cannot open temp pf file")
 		return
 	}
 	for _, b := range bs {

--- a/drivers/solaris/overlay/encryption.go
+++ b/drivers/solaris/overlay/encryption.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/types"
 )
 
@@ -71,7 +71,7 @@ func (e *encrMap) String() string {
 }
 
 func (d *driver) checkEncryption(nid string, rIP net.IP, vxlanID uint32, isLocal, add bool) error {
-	log.Debugf("checkEncryption(%s, %v, %d, %t)", nid[0:7], rIP, vxlanID, isLocal)
+	logrus.Debugf("checkEncryption(%s, %v, %d, %t)", nid[0:7], rIP, vxlanID, isLocal)
 
 	n := d.network(nid)
 	if n == nil || !n.secure {
@@ -94,7 +94,7 @@ func (d *driver) checkEncryption(nid string, rIP net.IP, vxlanID uint32, isLocal
 			}
 			return false
 		}); err != nil {
-			log.Warnf("Failed to retrieve list of participating nodes in overlay network %s: %v", nid[0:5], err)
+			logrus.Warnf("Failed to retrieve list of participating nodes in overlay network %s: %v", nid[0:5], err)
 		}
 	default:
 		if len(d.network(nid).endpoints) > 0 {
@@ -102,18 +102,18 @@ func (d *driver) checkEncryption(nid string, rIP net.IP, vxlanID uint32, isLocal
 		}
 	}
 
-	log.Debugf("List of nodes: %s", nodes)
+	logrus.Debugf("List of nodes: %s", nodes)
 
 	if add {
 		for _, rIP := range nodes {
 			if err := setupEncryption(lIP, aIP, rIP, vxlanID, d.secMap, d.keys); err != nil {
-				log.Warnf("Failed to program network encryption between %s and %s: %v", lIP, rIP, err)
+				logrus.Warnf("Failed to program network encryption between %s and %s: %v", lIP, rIP, err)
 			}
 		}
 	} else {
 		if len(nodes) == 0 {
 			if err := removeEncryption(lIP, rIP, d.secMap); err != nil {
-				log.Warnf("Failed to remove network encryption between %s and %s: %v", lIP, rIP, err)
+				logrus.Warnf("Failed to remove network encryption between %s and %s: %v", lIP, rIP, err)
 			}
 		}
 	}
@@ -122,14 +122,14 @@ func (d *driver) checkEncryption(nid string, rIP net.IP, vxlanID uint32, isLocal
 }
 
 func setupEncryption(localIP, advIP, remoteIP net.IP, vni uint32, em *encrMap, keys []*key) error {
-	log.Debugf("Programming encryption for vxlan %d between %s and %s", vni, localIP, remoteIP)
+	logrus.Debugf("Programming encryption for vxlan %d between %s and %s", vni, localIP, remoteIP)
 	rIPs := remoteIP.String()
 
 	indices := make([]*spi, 0, len(keys))
 
 	err := programMangle(vni, true)
 	if err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 
 	em.Lock()
@@ -177,16 +177,16 @@ func (d *driver) setKeys(keys []*key) error {
 		return types.ForbiddenErrorf("initial keys are already present")
 	}
 	d.keys = keys
-	log.Debugf("Initial encryption keys: %v", d.keys)
+	logrus.Debugf("Initial encryption keys: %v", d.keys)
 	return nil
 }
 
 // updateKeys allows to add a new key and/or change the primary key and/or prune an existing key
 // The primary key is the key used in transmission and will go in first position in the list.
 func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
-	log.Debugf("Updating Keys. New: %v, Primary: %v, Pruned: %v", newKey, primary, pruneKey)
+	logrus.Debugf("Updating Keys. New: %v, Primary: %v, Pruned: %v", newKey, primary, pruneKey)
 
-	log.Debugf("Current: %v", d.keys)
+	logrus.Debugf("Current: %v", d.keys)
 
 	var (
 		newIdx = -1
@@ -216,7 +216,7 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 		(pruneKey != nil && delIdx == -1) {
 		err := types.BadRequestErrorf("cannot find proper key indices while processing key update:"+
 			"(newIdx,priIdx,delIdx):(%d, %d, %d)", newIdx, priIdx, delIdx)
-		log.Warn(err)
+		logrus.Warn(err)
 		return err
 	}
 
@@ -241,7 +241,7 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 	}
 	d.Unlock()
 
-	log.Debugf("Updated: %v", d.keys)
+	logrus.Debugf("Updated: %v", d.keys)
 
 	return nil
 }
@@ -254,7 +254,7 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 
 // Spis and keys are sorted in such away the one in position 0 is the primary
 func updateNodeKey(lIP, rIP net.IP, idxs []*spi, curKeys []*key, newIdx, priIdx, delIdx int) []*spi {
-	log.Debugf("Updating keys for node: %s (%d,%d,%d)", rIP, newIdx, priIdx, delIdx)
+	logrus.Debugf("Updating keys for node: %s (%d,%d,%d)", rIP, newIdx, priIdx, delIdx)
 	return nil
 }
 

--- a/drivers/solaris/overlay/joinleave.go
+++ b/drivers/solaris/overlay/joinleave.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/types"
 	"github.com/gogo/protobuf/proto"
@@ -67,7 +67,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 			continue
 		}
 		if err := jinfo.AddStaticRoute(sub.subnetIP, types.NEXTHOP, s.gwIP.IP); err != nil {
-			log.Errorf("Adding subnet %s static route in network %q failed\n", s.subnetIP, n.id)
+			logrus.Errorf("Adding subnet %s static route in network %q failed\n", s.subnetIP, n.id)
 		}
 	}
 
@@ -82,7 +82,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		net.ParseIP(d.advertiseAddress), true)
 
 	if err := d.checkEncryption(nid, nil, n.vxlanID(s), true, true); err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 
 	buf, err := proto.Marshal(&PeerRecord{
@@ -95,7 +95,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 	}
 
 	if err := jinfo.AddTableEntry(ovPeerTable, eid, buf); err != nil {
-		log.Errorf("overlay: Failed adding table entry to joininfo: %v", err)
+		logrus.Errorf("overlay: Failed adding table entry to joininfo: %v", err)
 	}
 
 	d.pushLocalEndpointEvent("join", nid, eid)
@@ -105,7 +105,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 
 func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key string, value []byte) {
 	if tableName != ovPeerTable {
-		log.Errorf("Unexpected table notification for table %s received", tableName)
+		logrus.Errorf("Unexpected table notification for table %s received", tableName)
 		return
 	}
 
@@ -113,7 +113,7 @@ func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key stri
 
 	var peer PeerRecord
 	if err := proto.Unmarshal(value, &peer); err != nil {
-		log.Errorf("Failed to unmarshal peer record: %v", err)
+		logrus.Errorf("Failed to unmarshal peer record: %v", err)
 		return
 	}
 
@@ -125,19 +125,19 @@ func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key stri
 
 	addr, err := types.ParseCIDR(peer.EndpointIP)
 	if err != nil {
-		log.Errorf("Invalid peer IP %s received in event notify", peer.EndpointIP)
+		logrus.Errorf("Invalid peer IP %s received in event notify", peer.EndpointIP)
 		return
 	}
 
 	mac, err := net.ParseMAC(peer.EndpointMAC)
 	if err != nil {
-		log.Errorf("Invalid mac %s received in event notify", peer.EndpointMAC)
+		logrus.Errorf("Invalid mac %s received in event notify", peer.EndpointMAC)
 		return
 	}
 
 	vtep := net.ParseIP(peer.TunnelEndpointIP)
 	if vtep == nil {
-		log.Errorf("Invalid VTEP %s received in event notify", peer.TunnelEndpointIP)
+		logrus.Errorf("Invalid VTEP %s received in event notify", peer.TunnelEndpointIP)
 		return
 	}
 
@@ -177,7 +177,7 @@ func (d *driver) Leave(nid, eid string) error {
 	n.leaveSandbox()
 
 	if err := d.checkEncryption(nid, nil, 0, true, false); err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 
 	return nil

--- a/drivers/solaris/overlay/ov_endpoint.go
+++ b/drivers/solaris/overlay/ov_endpoint.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netutils"
@@ -113,7 +113,7 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 	n.deleteEndpoint(eid)
 
 	if err := d.deleteEndpointFromStore(ep); err != nil {
-		log.Warnf("Failed to delete overlay endpoint %s from local store: %v", ep.id[0:7], err)
+		logrus.Warnf("Failed to delete overlay endpoint %s from local store: %v", ep.id[0:7], err)
 	}
 
 	if ep.ifName == "" {

--- a/drivers/solaris/overlay/peerdb.go
+++ b/drivers/solaris/overlay/peerdb.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 const ovPeerTable = "overlay_peer_table"
@@ -89,7 +89,7 @@ func (d *driver) peerDbNetworkWalk(nid string, f func(*peerKey, *peerEntry) bool
 	for pKeyStr, pEntry := range pMap.mp {
 		var pKey peerKey
 		if _, err := fmt.Sscan(pKeyStr, &pKey); err != nil {
-			log.Warnf("Peer key scan on network %s failed: %v", nid, err)
+			logrus.Warnf("Peer key scan on network %s failed: %v", nid, err)
 		}
 
 		if f(&pKey, &pEntry) {
@@ -275,7 +275,7 @@ func (d *driver) peerAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask,
 	}
 
 	if err := d.checkEncryption(nid, vtep, n.vxlanID(s), false, true); err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 
 	// Add neighbor entry for the peer IP
@@ -320,7 +320,7 @@ func (d *driver) peerDelete(nid, eid string, peerIP net.IP, peerIPMask net.IPMas
 	}
 
 	if err := d.checkEncryption(nid, vtep, 0, false, false); err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 
 	return nil

--- a/drivers/windows/overlay/peerdb_windows.go
+++ b/drivers/windows/overlay/peerdb_windows.go
@@ -6,7 +6,7 @@ import (
 
 	"encoding/json"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/docker/libnetwork/types"
@@ -44,7 +44,7 @@ func (d *driver) pushLocalDb() {
 func (d *driver) peerAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask,
 	peerMac net.HardwareAddr, vtep net.IP, updateDb bool) error {
 
-	log.Debugf("WINOVERLAY: Enter peerAdd for ca ip %s with ca mac %s", peerIP.String(), peerMac.String())
+	logrus.Debugf("WINOVERLAY: Enter peerAdd for ca ip %s with ca mac %s", peerIP.String(), peerMac.String())
 
 	if err := validateID(nid, eid); err != nil {
 		return err
@@ -56,7 +56,7 @@ func (d *driver) peerAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask,
 	}
 
 	if updateDb {
-		log.Info("WINOVERLAY: peerAdd: notifying HNS of the REMOTE endpoint")
+		logrus.Info("WINOVERLAY: peerAdd: notifying HNS of the REMOTE endpoint")
 
 		hnsEndpoint := &hcsshim.HNSEndpoint{
 			VirtualNetwork:   n.hnsId,
@@ -121,7 +121,7 @@ func (d *driver) peerAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask,
 func (d *driver) peerDelete(nid, eid string, peerIP net.IP, peerIPMask net.IPMask,
 	peerMac net.HardwareAddr, vtep net.IP, updateDb bool) error {
 
-	log.Infof("WINOVERLAY: Enter peerDelete for endpoint %s and peer ip %s", eid, peerIP.String())
+	logrus.Infof("WINOVERLAY: Enter peerDelete for endpoint %s and peer ip %s", eid, peerIP.String())
 
 	if err := validateID(nid, eid); err != nil {
 		return err
@@ -146,7 +146,7 @@ func (d *driver) peerDelete(nid, eid string, peerIP net.IP, peerIPMask net.IPMas
 		n.deleteEndpoint(eid)
 
 		if err := d.deleteEndpointFromStore(ep); err != nil {
-			log.Debugf("Failed to delete stale overlay endpoint (%s) from store", ep.id[0:7])
+			logrus.Debugf("Failed to delete stale overlay endpoint (%s) from store", ep.id[0:7])
 		}
 	}
 

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 
 	"github.com/Microsoft/hcsshim"
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
@@ -271,7 +271,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		}
 
 		configuration := string(configurationb)
-		log.Debugf("HNSNetwork Request =%v Address Space=%v", configuration, subnets)
+		logrus.Debugf("HNSNetwork Request =%v Address Space=%v", configuration, subnets)
 
 		hnsresponse, err := hcsshim.HNSNetworkRequest("POST", "", configuration)
 		if err != nil {

--- a/endpoint.go
+++ b/endpoint.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/libnetwork/netlabel"
@@ -142,12 +142,12 @@ func (ep *endpoint) UnmarshalJSON(b []byte) (err error) {
 
 				bytes, err := json.Marshal(tmp)
 				if err != nil {
-					log.Error(err)
+					logrus.Error(err)
 					break
 				}
 				err = json.Unmarshal(bytes, &pb)
 				if err != nil {
-					log.Error(err)
+					logrus.Error(err)
 					break
 				}
 				pblist = append(pblist, pb)
@@ -164,12 +164,12 @@ func (ep *endpoint) UnmarshalJSON(b []byte) (err error) {
 
 				bytes, err := json.Marshal(tmp)
 				if err != nil {
-					log.Error(err)
+					logrus.Error(err)
 					break
 				}
 				err = json.Unmarshal(bytes, &tp)
 				if err != nil {
-					log.Error(err)
+					logrus.Error(err)
 					break
 				}
 				tplist = append(tplist, tp)
@@ -472,7 +472,7 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 	defer func() {
 		if err != nil {
 			if err := d.Leave(nid, epid); err != nil {
-				log.Warnf("driver leave failed while rolling back join: %v", err)
+				logrus.Warnf("driver leave failed while rolling back join: %v", err)
 			}
 		}
 	}()
@@ -523,7 +523,7 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 
 	if moveExtConn {
 		if extEp != nil {
-			log.Debugf("Revoking external connectivity on endpoint %s (%s)", extEp.Name(), extEp.ID())
+			logrus.Debugf("Revoking external connectivity on endpoint %s (%s)", extEp.Name(), extEp.ID())
 			extN, err := extEp.getNetworkFromStore()
 			if err != nil {
 				return fmt.Errorf("failed to get network from store during join: %v", err)
@@ -540,14 +540,14 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 			defer func() {
 				if err != nil {
 					if e := extD.ProgramExternalConnectivity(extEp.network.ID(), extEp.ID(), sb.Labels()); e != nil {
-						log.Warnf("Failed to roll-back external connectivity on endpoint %s (%s): %v",
+						logrus.Warnf("Failed to roll-back external connectivity on endpoint %s (%s): %v",
 							extEp.Name(), extEp.ID(), e)
 					}
 				}
 			}()
 		}
 		if !n.internal {
-			log.Debugf("Programming external connectivity on endpoint %s (%s)", ep.Name(), ep.ID())
+			logrus.Debugf("Programming external connectivity on endpoint %s (%s)", ep.Name(), ep.ID())
 			if err = d.ProgramExternalConnectivity(n.ID(), ep.ID(), sb.Labels()); err != nil {
 				return types.InternalErrorf(
 					"driver failed programming external connectivity on endpoint %s (%s): %v",
@@ -559,7 +559,7 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 
 	if !sb.needDefaultGW() {
 		if err := sb.clearDefaultGW(); err != nil {
-			log.Warnf("Failure while disconnecting sandbox %s (%s) from gateway network: %v",
+			logrus.Warnf("Failure while disconnecting sandbox %s (%s) from gateway network: %v",
 				sb.ID(), sb.ContainerID(), err)
 		}
 	}
@@ -682,22 +682,22 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 
 	if d != nil {
 		if moveExtConn {
-			log.Debugf("Revoking external connectivity on endpoint %s (%s)", ep.Name(), ep.ID())
+			logrus.Debugf("Revoking external connectivity on endpoint %s (%s)", ep.Name(), ep.ID())
 			if err := d.RevokeExternalConnectivity(n.id, ep.id); err != nil {
-				log.Warnf("driver failed revoking external connectivity on endpoint %s (%s): %v",
+				logrus.Warnf("driver failed revoking external connectivity on endpoint %s (%s): %v",
 					ep.Name(), ep.ID(), err)
 			}
 		}
 
 		if err := d.Leave(n.id, ep.id); err != nil {
 			if _, ok := err.(types.MaskableError); !ok {
-				log.Warnf("driver error disconnecting container %s : %v", ep.name, err)
+				logrus.Warnf("driver error disconnecting container %s : %v", ep.name, err)
 			}
 		}
 	}
 
 	if err := sb.clearNetworkResources(ep); err != nil {
-		log.Warnf("Could not cleanup network resources on container %s disconnect: %v", ep.name, err)
+		logrus.Warnf("Could not cleanup network resources on container %s disconnect: %v", ep.name, err)
 	}
 
 	// Update the store about the sandbox detach only after we
@@ -710,7 +710,7 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 	}
 
 	if e := ep.deleteFromCluster(); e != nil {
-		log.Errorf("Could not delete state for endpoint %s from cluster: %v", ep.Name(), e)
+		logrus.Errorf("Could not delete state for endpoint %s from cluster: %v", ep.Name(), e)
 	}
 
 	sb.deleteHostsEntries(n.getSvcRecords(ep))
@@ -721,7 +721,7 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 	// New endpoint providing external connectivity for the sandbox
 	extEp = sb.getGatewayEndpoint()
 	if moveExtConn && extEp != nil {
-		log.Debugf("Programming external connectivity on endpoint %s (%s)", extEp.Name(), extEp.ID())
+		logrus.Debugf("Programming external connectivity on endpoint %s (%s)", extEp.Name(), extEp.ID())
 		extN, err := extEp.getNetworkFromStore()
 		if err != nil {
 			return fmt.Errorf("failed to get network from store during leave: %v", err)
@@ -731,14 +731,14 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 			return fmt.Errorf("failed to leave endpoint: %v", err)
 		}
 		if err := extD.ProgramExternalConnectivity(extEp.network.ID(), extEp.ID(), sb.Labels()); err != nil {
-			log.Warnf("driver failed programming external connectivity on endpoint %s: (%s) %v",
+			logrus.Warnf("driver failed programming external connectivity on endpoint %s: (%s) %v",
 				extEp.Name(), extEp.ID(), err)
 		}
 	}
 
 	if !sb.needDefaultGW() {
 		if err := sb.clearDefaultGW(); err != nil {
-			log.Warnf("Failure while disconnecting sandbox %s (%s) from gateway network: %v",
+			logrus.Warnf("Failure while disconnecting sandbox %s (%s) from gateway network: %v",
 				sb.ID(), sb.ContainerID(), err)
 		}
 	}
@@ -771,7 +771,7 @@ func (ep *endpoint) Delete(force bool) error {
 
 	if sb != nil {
 		if e := ep.sbLeave(sb.(*sandbox), force); e != nil {
-			log.Warnf("failed to leave sandbox for endpoint %s : %v", name, e)
+			logrus.Warnf("failed to leave sandbox for endpoint %s : %v", name, e)
 		}
 	}
 
@@ -783,7 +783,7 @@ func (ep *endpoint) Delete(force bool) error {
 		if err != nil && !force {
 			ep.dbExists = false
 			if e := n.getController().updateToStore(ep); e != nil {
-				log.Warnf("failed to recreate endpoint in store %s : %v", name, e)
+				logrus.Warnf("failed to recreate endpoint in store %s : %v", name, e)
 			}
 		}
 	}()
@@ -798,7 +798,7 @@ func (ep *endpoint) Delete(force bool) error {
 	ep.releaseAddress()
 
 	if err := n.getEpCnt().DecEndpointCnt(); err != nil {
-		log.Warnf("failed to decrement endpoint count for ep %s: %v", ep.ID(), err)
+		logrus.Warnf("failed to decrement endpoint count for ep %s: %v", ep.ID(), err)
 	}
 
 	return nil
@@ -826,7 +826,7 @@ func (ep *endpoint) deleteEndpoint(force bool) error {
 		}
 
 		if _, ok := err.(types.MaskableError); !ok {
-			log.Warnf("driver error deleting endpoint %s : %v", name, err)
+			logrus.Warnf("driver error deleting endpoint %s : %v", name, err)
 		}
 	}
 
@@ -976,7 +976,7 @@ func JoinOptionPriority(ep Endpoint, prio int) EndpointOption {
 		sb, ok := c.sandboxes[ep.sandboxID]
 		c.Unlock()
 		if !ok {
-			log.Errorf("Could not set endpoint priority value during Join to endpoint %s: No sandbox id present in endpoint", ep.id)
+			logrus.Errorf("Could not set endpoint priority value during Join to endpoint %s: No sandbox id present in endpoint", ep.id)
 			return
 		}
 		sb.epPriority[ep.id] = prio
@@ -995,7 +995,7 @@ func (ep *endpoint) assignAddress(ipam ipamapi.Ipam, assignIPv4, assignIPv6 bool
 		return nil
 	}
 
-	log.Debugf("Assigning addresses for endpoint %s's interface on network %s", ep.Name(), n.Name())
+	logrus.Debugf("Assigning addresses for endpoint %s's interface on network %s", ep.Name(), n.Name())
 
 	if assignIPv4 {
 		if err = ep.assignAddressVersion(4, ipam); err != nil {
@@ -1075,23 +1075,23 @@ func (ep *endpoint) releaseAddress() {
 		return
 	}
 
-	log.Debugf("Releasing addresses for endpoint %s's interface on network %s", ep.Name(), n.Name())
+	logrus.Debugf("Releasing addresses for endpoint %s's interface on network %s", ep.Name(), n.Name())
 
 	ipam, _, err := n.getController().getIPAMDriver(n.ipamType)
 	if err != nil {
-		log.Warnf("Failed to retrieve ipam driver to release interface address on delete of endpoint %s (%s): %v", ep.Name(), ep.ID(), err)
+		logrus.Warnf("Failed to retrieve ipam driver to release interface address on delete of endpoint %s (%s): %v", ep.Name(), ep.ID(), err)
 		return
 	}
 
 	if ep.iface.addr != nil {
 		if err := ipam.ReleaseAddress(ep.iface.v4PoolID, ep.iface.addr.IP); err != nil {
-			log.Warnf("Failed to release ip address %s on delete of endpoint %s (%s): %v", ep.iface.addr.IP, ep.Name(), ep.ID(), err)
+			logrus.Warnf("Failed to release ip address %s on delete of endpoint %s (%s): %v", ep.iface.addr.IP, ep.Name(), ep.ID(), err)
 		}
 	}
 
 	if ep.iface.addrv6 != nil && ep.iface.addrv6.IP.IsGlobalUnicast() {
 		if err := ipam.ReleaseAddress(ep.iface.v6PoolID, ep.iface.addrv6.IP); err != nil {
-			log.Warnf("Failed to release ip address %s on delete of endpoint %s (%s): %v", ep.iface.addrv6.IP, ep.Name(), ep.ID(), err)
+			logrus.Warnf("Failed to release ip address %s on delete of endpoint %s (%s): %v", ep.iface.addrv6.IP, ep.Name(), ep.ID(), err)
 		}
 	}
 }
@@ -1106,14 +1106,14 @@ func (c *controller) cleanupLocalEndpoints() {
 	}
 	nl, err := c.getNetworksForScope(datastore.LocalScope)
 	if err != nil {
-		log.Warnf("Could not get list of networks during endpoint cleanup: %v", err)
+		logrus.Warnf("Could not get list of networks during endpoint cleanup: %v", err)
 		return
 	}
 
 	for _, n := range nl {
 		epl, err := n.getEndpointsFromStore()
 		if err != nil {
-			log.Warnf("Could not get list of endpoints in network %s during endpoint cleanup: %v", n.name, err)
+			logrus.Warnf("Could not get list of endpoints in network %s during endpoint cleanup: %v", n.name, err)
 			continue
 		}
 
@@ -1121,21 +1121,21 @@ func (c *controller) cleanupLocalEndpoints() {
 			if _, ok := eps[ep.id]; ok {
 				continue
 			}
-			log.Infof("Removing stale endpoint %s (%s)", ep.name, ep.id)
+			logrus.Infof("Removing stale endpoint %s (%s)", ep.name, ep.id)
 			if err := ep.Delete(true); err != nil {
-				log.Warnf("Could not delete local endpoint %s during endpoint cleanup: %v", ep.name, err)
+				logrus.Warnf("Could not delete local endpoint %s during endpoint cleanup: %v", ep.name, err)
 			}
 		}
 
 		epl, err = n.getEndpointsFromStore()
 		if err != nil {
-			log.Warnf("Could not get list of endpoints in network %s for count update: %v", n.name, err)
+			logrus.Warnf("Could not get list of endpoints in network %s for count update: %v", n.name, err)
 			continue
 		}
 
 		epCnt := n.getEpCnt().EndpointCnt()
 		if epCnt != uint64(len(epl)) {
-			log.Infof("Fixing inconsistent endpoint_cnt for network %s. Expected=%d, Actual=%d", n.name, len(epl), epCnt)
+			logrus.Infof("Fixing inconsistent endpoint_cnt for network %s. Expected=%d, Actual=%d", n.name, len(epl), epCnt)
 			n.getEpCnt().setCnt(uint64(len(epl)))
 		}
 	}

--- a/hostdiscovery/hostdiscovery.go
+++ b/hostdiscovery/hostdiscovery.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/docker/docker/pkg/discovery"
@@ -54,7 +54,7 @@ func (h *hostDiscovery) monitorDiscovery(ch <-chan discovery.Entries, errCh <-ch
 			h.processCallback(entries, activeCallback, joinCallback, leaveCallback)
 		case err := <-errCh:
 			if err != nil {
-				log.Errorf("discovery error: %v", err)
+				logrus.Errorf("discovery error: %v", err)
 			}
 		case <-h.stopChan:
 			return

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/bitseq"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
@@ -135,7 +135,7 @@ func (a *Allocator) checkConsistency(as string) {
 		bm := a.addresses[sk]
 		a.Unlock()
 		if err := bm.CheckConsistency(); err != nil {
-			log.Warnf("Error while running consistency check for %s: %v", sk, err)
+			logrus.Warnf("Error while running consistency check for %s: %v", sk, err)
 		}
 	}
 }
@@ -198,7 +198,7 @@ func (a *Allocator) GetDefaultAddressSpaces() (string, string, error) {
 
 // RequestPool returns an address pool along with its unique id.
 func (a *Allocator) RequestPool(addressSpace, pool, subPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
-	log.Debugf("RequestPool(%s, %s, %s, %v, %t)", addressSpace, pool, subPool, options, v6)
+	logrus.Debugf("RequestPool(%s, %s, %s, %v, %t)", addressSpace, pool, subPool, options, v6)
 
 	k, nw, ipr, err := a.parsePoolRequest(addressSpace, pool, subPool, v6)
 	if err != nil {
@@ -227,7 +227,7 @@ retry:
 	insert, err := aSpace.updatePoolDBOnAdd(*k, nw, ipr, pdf)
 	if err != nil {
 		if _, ok := err.(types.MaskableError); ok {
-			log.Debugf("Retrying predefined pool search: %v", err)
+			logrus.Debugf("Retrying predefined pool search: %v", err)
 			goto retry
 		}
 		return "", nil, nil, err
@@ -246,7 +246,7 @@ retry:
 
 // ReleasePool releases the address pool identified by the passed id
 func (a *Allocator) ReleasePool(poolID string) error {
-	log.Debugf("ReleasePool(%s)", poolID)
+	logrus.Debugf("ReleasePool(%s)", poolID)
 	k := SubnetKey{}
 	if err := k.FromString(poolID); err != nil {
 		return types.BadRequestErrorf("invalid pool id: %s", poolID)
@@ -322,7 +322,7 @@ func (a *Allocator) parsePoolRequest(addressSpace, pool, subPool string, v6 bool
 }
 
 func (a *Allocator) insertBitMask(key SubnetKey, pool *net.IPNet) error {
-	//log.Debugf("Inserting bitmask (%s, %s)", key.String(), pool.String())
+	//logrus.Debugf("Inserting bitmask (%s, %s)", key.String(), pool.String())
 
 	store := a.getStore(key.AddressSpace)
 	ipVer := getAddressVersion(pool.IP)
@@ -360,7 +360,7 @@ func (a *Allocator) retrieveBitmask(k SubnetKey, n *net.IPNet) (*bitseq.Handle, 
 	bm, ok := a.addresses[k]
 	a.Unlock()
 	if !ok {
-		log.Debugf("Retrieving bitmask (%s, %s)", k.String(), n.String())
+		logrus.Debugf("Retrieving bitmask (%s, %s)", k.String(), n.String())
 		if err := a.insertBitMask(k, n); err != nil {
 			return nil, types.InternalErrorf("could not find bitmask in datastore for %s", k.String())
 		}
@@ -418,7 +418,7 @@ func (a *Allocator) getPredefinedPool(as string, ipV6 bool) (*net.IPNet, error) 
 
 // RequestAddress returns an address from the specified pool ID
 func (a *Allocator) RequestAddress(poolID string, prefAddress net.IP, opts map[string]string) (*net.IPNet, map[string]string, error) {
-	log.Debugf("RequestAddress(%s, %v, %v)", poolID, prefAddress, opts)
+	logrus.Debugf("RequestAddress(%s, %v, %v)", poolID, prefAddress, opts)
 	k := SubnetKey{}
 	if err := k.FromString(poolID); err != nil {
 		return nil, nil, types.BadRequestErrorf("invalid pool id: %s", poolID)
@@ -467,7 +467,7 @@ func (a *Allocator) RequestAddress(poolID string, prefAddress net.IP, opts map[s
 
 // ReleaseAddress releases the address from the specified pool ID
 func (a *Allocator) ReleaseAddress(poolID string, address net.IP) error {
-	log.Debugf("ReleaseAddress(%s, %v)", poolID, address)
+	logrus.Debugf("ReleaseAddress(%s, %v)", poolID, address)
 	k := SubnetKey{}
 	if err := k.FromString(poolID); err != nil {
 		return types.BadRequestErrorf("invalid pool id: %s", poolID)

--- a/ipam/store.go
+++ b/ipam/store.go
@@ -3,7 +3,7 @@ package ipam
 import (
 	"encoding/json"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/types"
 )
@@ -26,7 +26,7 @@ func (aSpace *addrSpace) KeyPrefix() []string {
 func (aSpace *addrSpace) Value() []byte {
 	b, err := json.Marshal(aSpace)
 	if err != nil {
-		log.Warnf("Failed to marshal ipam configured pools: %v", err)
+		logrus.Warnf("Failed to marshal ipam configured pools: %v", err)
 		return nil
 	}
 	return b

--- a/ipams/remote/remote.go
+++ b/ipams/remote/remote.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/ipamapi"
@@ -40,13 +40,13 @@ func Init(cb ipamapi.Callback, l, g interface{}) error {
 		a := newAllocator(name, client)
 		if cps, err := a.(*allocator).getCapabilities(); err == nil {
 			if err := cb.RegisterIpamDriverWithCapabilities(name, a, cps); err != nil {
-				log.Errorf("error registering remote ipam driver %s due to %v", name, err)
+				logrus.Errorf("error registering remote ipam driver %s due to %v", name, err)
 			}
 		} else {
-			log.Infof("remote ipam driver %s does not support capabilities", name)
-			log.Debug(err)
+			logrus.Infof("remote ipam driver %s does not support capabilities", name)
+			logrus.Debug(err)
 			if err := cb.RegisterIpamDriver(name, a); err != nil {
-				log.Errorf("error registering remote ipam driver %s due to %v", name, err)
+				logrus.Errorf("error registering remote ipam driver %s due to %v", name, err)
 			}
 		}
 	})

--- a/ipams/windowsipam/windowsipam.go
+++ b/ipams/windowsipam/windowsipam.go
@@ -3,7 +3,7 @@ package windowsipam
 import (
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/libnetwork/netlabel"
@@ -39,7 +39,7 @@ func (a *allocator) GetDefaultAddressSpaces() (string, string, error) {
 // RequestPool returns an address pool along with its unique id. This is a null ipam driver. It allocates the
 // subnet user asked and does not validate anything. Doesn't support subpool allocation
 func (a *allocator) RequestPool(addressSpace, pool, subPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
-	log.Debugf("RequestPool(%s, %s, %s, %v, %t)", addressSpace, pool, subPool, options, v6)
+	logrus.Debugf("RequestPool(%s, %s, %s, %v, %t)", addressSpace, pool, subPool, options, v6)
 	if subPool != "" || v6 {
 		return "", nil, nil, types.InternalErrorf("This request is not supported by null ipam driver")
 	}
@@ -61,14 +61,14 @@ func (a *allocator) RequestPool(addressSpace, pool, subPool string, options map[
 
 // ReleasePool releases the address pool - always succeeds
 func (a *allocator) ReleasePool(poolID string) error {
-	log.Debugf("ReleasePool(%s)", poolID)
+	logrus.Debugf("ReleasePool(%s)", poolID)
 	return nil
 }
 
 // RequestAddress returns an address from the specified pool ID.
 // Always allocate the 0.0.0.0/32 ip if no preferred address was specified
 func (a *allocator) RequestAddress(poolID string, prefAddress net.IP, opts map[string]string) (*net.IPNet, map[string]string, error) {
-	log.Debugf("RequestAddress(%s, %v, %v)", poolID, prefAddress, opts)
+	logrus.Debugf("RequestAddress(%s, %v, %v)", poolID, prefAddress, opts)
 	_, ipNet, err := net.ParseCIDR(poolID)
 
 	if err != nil {
@@ -88,7 +88,7 @@ func (a *allocator) RequestAddress(poolID string, prefAddress net.IP, opts map[s
 
 // ReleaseAddress releases the address - always succeeds
 func (a *allocator) ReleaseAddress(poolID string, address net.IP) error {
-	log.Debugf("ReleaseAddress(%s, %v)", poolID, address)
+	logrus.Debugf("ReleaseAddress(%s, %v)", poolID, address)
 	return nil
 }
 

--- a/ipvs/netlink.go
+++ b/ipvs/netlink.go
@@ -64,7 +64,7 @@ func setup() {
 
 		ipvsFamily, err = getIPVSFamily()
 		if err != nil {
-			logrus.Errorf("Could not get ipvs family information from the kernel. It is possible that ipvs is not enabled in your kernel. Native loadbalancing will not work until this is fixed.")
+			logrus.Error("Could not get ipvs family information from the kernel. It is possible that ipvs is not enabled in your kernel. Native loadbalancing will not work until this is fixed.")
 		}
 	})
 }

--- a/libnetwork_linux_test.go
+++ b/libnetwork_linux_test.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/libnetwork"
 	"github.com/docker/libnetwork/ipamapi"
@@ -471,7 +471,7 @@ func externalKeyTest(t *testing.T, reexec bool) {
 	} else {
 		defer func() {
 			if err := extOsBox.Destroy(); err != nil {
-				log.Warnf("Failed to remove os sandbox: %v", err)
+				logrus.Warnf("Failed to remove os sandbox: %v", err)
 			}
 		}()
 	}

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/libnetwork"
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := createController(); err != nil {
-		log.Errorf("Error creating controller: %v", err)
+		logrus.Errorf("Error creating controller: %v", err)
 		os.Exit(1)
 	}
 

--- a/network.go
+++ b/network.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/datastore"
@@ -473,7 +473,7 @@ func (n *network) UnmarshalJSON(b []byte) (err error) {
 	if v, ok := netMap["created"]; ok {
 		// n.created is time.Time but marshalled as string
 		if err = n.created.UnmarshalText([]byte(v.(string))); err != nil {
-			log.Warnf("failed to unmarshal creation time %v: %v", v, err)
+			logrus.Warnf("failed to unmarshal creation time %v: %v", v, err)
 			n.created = time.Time{}
 		}
 	}
@@ -779,12 +779,12 @@ func (n *network) delete(force bool) error {
 		if !force {
 			return err
 		}
-		log.Debugf("driver failed to delete stale network %s (%s): %v", n.Name(), n.ID(), err)
+		logrus.Debugf("driver failed to delete stale network %s (%s): %v", n.Name(), n.ID(), err)
 	}
 
 	n.ipamRelease()
 	if err = c.updateToStore(n); err != nil {
-		log.Warnf("Failed to update store after ipam release for network %s (%s): %v", n.Name(), n.ID(), err)
+		logrus.Warnf("Failed to update store after ipam release for network %s (%s): %v", n.Name(), n.ID(), err)
 	}
 
 	// We are about to delete the network. Leave the gossip
@@ -795,7 +795,7 @@ func (n *network) delete(force bool) error {
 	// bindings cleanup requires the network in the store.
 	n.cancelDriverWatches()
 	if err = n.leaveCluster(); err != nil {
-		log.Errorf("Failed leaving network %s from the agent cluster: %v", n.Name(), err)
+		logrus.Errorf("Failed leaving network %s from the agent cluster: %v", n.Name(), err)
 	}
 
 	c.cleanupServiceBindings(n.ID())
@@ -807,7 +807,7 @@ func (n *network) delete(force bool) error {
 		if !force {
 			return fmt.Errorf("error deleting network endpoint count from store: %v", err)
 		}
-		log.Debugf("Error deleting endpoint count from store for stale network %s (%s) for deletion: %v", n.Name(), n.ID(), err)
+		logrus.Debugf("Error deleting endpoint count from store for stale network %s (%s) for deletion: %v", n.Name(), n.ID(), err)
 	}
 
 	if err = c.deleteFromStore(n); err != nil {
@@ -830,7 +830,7 @@ func (n *network) deleteNetwork() error {
 		}
 
 		if _, ok := err.(types.MaskableError); !ok {
-			log.Warnf("driver error deleting network %s : %v", n.name, err)
+			logrus.Warnf("driver error deleting network %s : %v", n.name, err)
 		}
 	}
 
@@ -923,7 +923,7 @@ func (n *network) CreateEndpoint(name string, options ...EndpointOption) (Endpoi
 	defer func() {
 		if err != nil {
 			if e := ep.deleteEndpoint(false); e != nil {
-				log.Warnf("cleaning up endpoint failed %s : %v", name, e)
+				logrus.Warnf("cleaning up endpoint failed %s : %v", name, e)
 			}
 		}
 	}()
@@ -938,7 +938,7 @@ func (n *network) CreateEndpoint(name string, options ...EndpointOption) (Endpoi
 	defer func() {
 		if err != nil {
 			if e := n.getController().deleteFromStore(ep); e != nil {
-				log.Warnf("error rolling back endpoint %s from store: %v", name, e)
+				logrus.Warnf("error rolling back endpoint %s from store: %v", name, e)
 			}
 		}
 	}()
@@ -964,7 +964,7 @@ func (n *network) Endpoints() []Endpoint {
 
 	endpoints, err := n.getEndpointsFromStore()
 	if err != nil {
-		log.Error(err)
+		logrus.Error(err)
 	}
 
 	for _, ep := range endpoints {
@@ -1172,7 +1172,7 @@ func (n *network) getSvcRecords(ep *endpoint) []etchosts.Record {
 			continue
 		}
 		if len(ip) == 0 {
-			log.Warnf("Found empty list of IP addresses for service %s on network %s (%s)", h, n.name, n.id)
+			logrus.Warnf("Found empty list of IP addresses for service %s on network %s (%s)", h, n.name, n.id)
 			continue
 		}
 		recs = append(recs, etchosts.Record{
@@ -1256,7 +1256,7 @@ func (n *network) requestPoolHelper(ipam ipamapi.Ipam, addressSpace, preferredPo
 		// pools.
 		defer func() {
 			if err := ipam.ReleasePool(poolID); err != nil {
-				log.Warnf("Failed to release overlapping pool %s while returning from pool request helper for network %s", pool, n.Name())
+				logrus.Warnf("Failed to release overlapping pool %s while returning from pool request helper for network %s", pool, n.Name())
 			}
 		}()
 
@@ -1297,7 +1297,7 @@ func (n *network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {
 
 	*infoList = make([]*IpamInfo, len(*cfgList))
 
-	log.Debugf("Allocating IPv%d pools for network %s (%s)", ipVer, n.Name(), n.ID())
+	logrus.Debugf("Allocating IPv%d pools for network %s (%s)", ipVer, n.Name(), n.ID())
 
 	for i, cfg := range *cfgList {
 		if err = cfg.Validate(); err != nil {
@@ -1315,7 +1315,7 @@ func (n *network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {
 		defer func() {
 			if err != nil {
 				if err := ipam.ReleasePool(d.PoolID); err != nil {
-					log.Warnf("Failed to release address pool %s after failure to create network %s (%s)", d.PoolID, n.Name(), n.ID())
+					logrus.Warnf("Failed to release address pool %s after failure to create network %s (%s)", d.PoolID, n.Name(), n.ID())
 				}
 			}
 		}()
@@ -1367,7 +1367,7 @@ func (n *network) ipamRelease() {
 	}
 	ipam, _, err := n.getController().getIPAMDriver(n.ipamType)
 	if err != nil {
-		log.Warnf("Failed to retrieve ipam driver to release address pool(s) on delete of network %s (%s): %v", n.Name(), n.ID(), err)
+		logrus.Warnf("Failed to retrieve ipam driver to release address pool(s) on delete of network %s (%s): %v", n.Name(), n.ID(), err)
 		return
 	}
 	n.ipamReleaseVersion(4, ipam)
@@ -1383,7 +1383,7 @@ func (n *network) ipamReleaseVersion(ipVer int, ipam ipamapi.Ipam) {
 	case 6:
 		infoList = &n.ipamV6Info
 	default:
-		log.Warnf("incorrect ip version passed to ipam release: %d", ipVer)
+		logrus.Warnf("incorrect ip version passed to ipam release: %d", ipVer)
 		return
 	}
 
@@ -1391,25 +1391,25 @@ func (n *network) ipamReleaseVersion(ipVer int, ipam ipamapi.Ipam) {
 		return
 	}
 
-	log.Debugf("releasing IPv%d pools from network %s (%s)", ipVer, n.Name(), n.ID())
+	logrus.Debugf("releasing IPv%d pools from network %s (%s)", ipVer, n.Name(), n.ID())
 
 	for _, d := range *infoList {
 		if d.Gateway != nil {
 			if err := ipam.ReleaseAddress(d.PoolID, d.Gateway.IP); err != nil {
-				log.Warnf("Failed to release gateway ip address %s on delete of network %s (%s): %v", d.Gateway.IP, n.Name(), n.ID(), err)
+				logrus.Warnf("Failed to release gateway ip address %s on delete of network %s (%s): %v", d.Gateway.IP, n.Name(), n.ID(), err)
 			}
 		}
 		if d.IPAMData.AuxAddresses != nil {
 			for k, nw := range d.IPAMData.AuxAddresses {
 				if d.Pool.Contains(nw.IP) {
 					if err := ipam.ReleaseAddress(d.PoolID, nw.IP); err != nil && err != ipamapi.ErrIPOutOfRange {
-						log.Warnf("Failed to release secondary ip address %s (%v) on delete of network %s (%s): %v", k, nw.IP, n.Name(), n.ID(), err)
+						logrus.Warnf("Failed to release secondary ip address %s (%v) on delete of network %s (%s): %v", k, nw.IP, n.Name(), n.ID(), err)
 					}
 				}
 			}
 		}
 		if err := ipam.ReleasePool(d.PoolID); err != nil {
-			log.Warnf("Failed to release address pool %s on delete of network %s (%s): %v", d.PoolID, n.Name(), n.ID(), err)
+			logrus.Warnf("Failed to release address pool %s on delete of network %s (%s): %v", d.PoolID, n.Name(), n.ID(), err)
 		}
 	}
 
@@ -1661,7 +1661,7 @@ func (n *network) ResolveService(name string) ([]*net.SRV, []net.IP) {
 	srv := []*net.SRV{}
 	ip := []net.IP{}
 
-	log.Debugf("Service name To resolve: %v", name)
+	logrus.Debugf("Service name To resolve: %v", name)
 
 	// There are DNS implementaions that allow SRV queries for names not in
 	// the format defined by RFC 2782. Hence specific validations checks are

--- a/network_windows.go
+++ b/network_windows.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim"
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/drivers/windows"
 	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/libnetwork/ipams/windowsipam"
@@ -17,7 +17,7 @@ func executeInCompartment(compartmentID uint32, x func()) {
 	runtime.LockOSThread()
 
 	if err := hcsshim.SetCurrentThreadCompartmentId(compartmentID); err != nil {
-		log.Error(err)
+		logrus.Error(err)
 	}
 	defer func() {
 		hcsshim.SetCurrentThreadCompartmentId(0)
@@ -29,7 +29,7 @@ func executeInCompartment(compartmentID uint32, x func()) {
 
 func (n *network) startResolver() {
 	n.resolverOnce.Do(func() {
-		log.Debugf("Launching DNS server for network", n.Name())
+		logrus.Debugf("Launching DNS server for network", n.Name())
 		options := n.Info().DriverOptions()
 		hnsid := options[windows.HNSID]
 
@@ -39,7 +39,7 @@ func (n *network) startResolver() {
 
 		hnsresponse, err := hcsshim.HNSNetworkRequest("GET", hnsid, "")
 		if err != nil {
-			log.Errorf("Resolver Setup/Start failed for container %s, %q", n.Name(), err)
+			logrus.Errorf("Resolver Setup/Start failed for container %s, %q", n.Name(), err)
 			return
 		}
 
@@ -47,14 +47,14 @@ func (n *network) startResolver() {
 			if subnet.GatewayAddress != "" {
 				for i := 0; i < 3; i++ {
 					resolver := NewResolver(subnet.GatewayAddress, false, "", n)
-					log.Debugf("Binding a resolver on network %s gateway %s", n.Name(), subnet.GatewayAddress)
+					logrus.Debugf("Binding a resolver on network %s gateway %s", n.Name(), subnet.GatewayAddress)
 					executeInCompartment(hnsresponse.DNSServerCompartment, resolver.SetupFunc(53))
 
 					if err = resolver.Start(); err != nil {
-						log.Errorf("Resolver Setup/Start failed for container %s, %q", n.Name(), err)
+						logrus.Errorf("Resolver Setup/Start failed for container %s, %q", n.Name(), err)
 						time.Sleep(1 * time.Second)
 					} else {
-						log.Debugf("Resolver bound successfuly for network %s", n.Name())
+						logrus.Debugf("Resolver bound successfuly for network %s", n.Name())
 						n.resolver = append(n.resolver, resolver)
 						break
 					}

--- a/ns/init_linux.go
+++ b/ns/init_linux.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 )
@@ -24,11 +24,11 @@ func Init() {
 	var err error
 	initNs, err = netns.Get()
 	if err != nil {
-		log.Errorf("could not get initial namespace: %v", err)
+		logrus.Errorf("could not get initial namespace: %v", err)
 	}
 	initNl, err = netlink.NewHandle(getSupportedNlFamilies()...)
 	if err != nil {
-		log.Errorf("could not create netlink handle on initial namespace: %v", err)
+		logrus.Errorf("could not create netlink handle on initial namespace: %v", err)
 	}
 }
 
@@ -70,7 +70,7 @@ func getSupportedNlFamilies() []int {
 	fams := []int{syscall.NETLINK_ROUTE}
 	if err := loadXfrmModules(); err != nil {
 		if checkXfrmSocket() != nil {
-			log.Warnf("Could not load necessary modules for IPSEC rules: %v", err)
+			logrus.Warnf("Could not load necessary modules for IPSEC rules: %v", err)
 			return fams
 		}
 	}

--- a/osl/interface_linux.go
+++ b/osl/interface_linux.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/ns"
 	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
@@ -167,7 +167,7 @@ func (i *nwIface) Remove() error {
 
 	err = nlh.LinkSetName(iface, i.SrcName())
 	if err != nil {
-		log.Debugf("LinkSetName failed for interface %s: %v", i.SrcName(), err)
+		logrus.Debugf("LinkSetName failed for interface %s: %v", i.SrcName(), err)
 		return err
 	}
 
@@ -179,7 +179,7 @@ func (i *nwIface) Remove() error {
 	} else if !isDefault {
 		// Move the network interface to caller namespace.
 		if err := nlh.LinkSetNsFd(iface, ns.ParseHandlerInt()); err != nil {
-			log.Debugf("LinkSetNsPid failed for interface %s: %v", i.SrcName(), err)
+			logrus.Debugf("LinkSetNsPid failed for interface %s: %v", i.SrcName(), err)
 			return err
 		}
 	}
@@ -315,7 +315,7 @@ func (n *networkNamespace) AddInterface(srcName, dstPrefix string, options ...If
 	// Up the interface.
 	cnt := 0
 	for err = nlh.LinkSetUp(iface); err != nil && cnt < 3; cnt++ {
-		log.Debugf("retrying link setup because of: %v", err)
+		logrus.Debugf("retrying link setup because of: %v", err)
 		time.Sleep(10 * time.Millisecond)
 		err = nlh.LinkSetUp(iface)
 	}

--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/libnetwork/ns"
 	"github.com/docker/libnetwork/types"
@@ -263,10 +263,10 @@ func GetSandboxForExternalKey(basePath string, key string) (Sandbox, error) {
 
 func reexecCreateNamespace() {
 	if len(os.Args) < 2 {
-		log.Fatal("no namespace path provided")
+		logrus.Fatal("no namespace path provided")
 	}
 	if err := mountNetworkNamespace("/proc/self/ns/net", os.Args[1]); err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 }
 
@@ -338,7 +338,7 @@ func (n *networkNamespace) InvokeFunc(f func()) error {
 func InitOSContext() func() {
 	runtime.LockOSThread()
 	if err := ns.SetNamespace(); err != nil {
-		log.Error(err)
+		logrus.Error(err)
 	}
 	return runtime.UnlockOSThread
 }

--- a/resolver.go
+++ b/resolver.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/types"
 	"github.com/miekg/dns"
 )
@@ -219,7 +219,7 @@ func (r *resolver) handleIPQuery(name string, query *dns.Msg, ipType int) (*dns.
 
 	if addr == nil && ipv6Miss {
 		// Send a reply without any Answer sections
-		log.Debugf("Lookup name %s present without IPv6 address", name)
+		logrus.Debugf("Lookup name %s present without IPv6 address", name)
 		resp := createRespMsg(query)
 		return resp, nil
 	}
@@ -227,7 +227,7 @@ func (r *resolver) handleIPQuery(name string, query *dns.Msg, ipType int) (*dns.
 		return nil, nil
 	}
 
-	log.Debugf("Lookup for %s: IP %v", name, addr)
+	logrus.Debugf("Lookup for %s: IP %v", name, addr)
 
 	resp := createRespMsg(query)
 	if len(addr) > 1 {
@@ -268,7 +268,7 @@ func (r *resolver) handlePTRQuery(ptr string, query *dns.Msg) (*dns.Msg, error) 
 		return nil, nil
 	}
 
-	log.Debugf("Lookup for IP %s: name %s", parts[0], host)
+	logrus.Debugf("Lookup for IP %s: name %s", parts[0], host)
 	fqdn := dns.Fqdn(host)
 
 	resp := new(dns.Msg)
@@ -352,7 +352,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 	}
 
 	if err != nil {
-		log.Error(err)
+		logrus.Error(err)
 		return
 	}
 
@@ -411,10 +411,10 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 
 			execErr := r.backend.ExecFunc(extConnect)
 			if execErr != nil || err != nil {
-				log.Debugf("Connect failed, %s", err)
+				logrus.Debugf("Connect failed, %s", err)
 				continue
 			}
-			log.Debugf("Query %s[%d] from %s, forwarding to %s:%s", name, query.Question[0].Qtype,
+			logrus.Debugf("Query %s[%d] from %s, forwarding to %s:%s", name, query.Question[0].Qtype,
 				extConn.LocalAddr().String(), proto, extDNS.ipStr)
 
 			// Timeout has to be set for every IO operation.
@@ -430,7 +430,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 				old := r.tStamp
 				r.tStamp = time.Now()
 				if r.tStamp.Sub(old) > logInterval {
-					log.Errorf("More than %v concurrent queries from %s", maxConcurrent, extConn.LocalAddr().String())
+					logrus.Errorf("More than %v concurrent queries from %s", maxConcurrent, extConn.LocalAddr().String())
 				}
 				continue
 			}
@@ -438,7 +438,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			err = co.WriteMsg(query)
 			if err != nil {
 				r.forwardQueryEnd()
-				log.Debugf("Send to DNS server failed, %s", err)
+				logrus.Debugf("Send to DNS server failed, %s", err)
 				continue
 			}
 
@@ -447,7 +447,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			// client can retry over TCP
 			if err != nil && err != dns.ErrTruncated {
 				r.forwardQueryEnd()
-				log.Debugf("Read from DNS server failed, %s", err)
+				logrus.Debugf("Read from DNS server failed, %s", err)
 				continue
 			}
 
@@ -462,7 +462,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 	}
 
 	if err = w.WriteMsg(resp); err != nil {
-		log.Errorf("error writing resolver resp, %s", err)
+		logrus.Errorf("error writing resolver resp, %s", err)
 	}
 }
 
@@ -483,7 +483,7 @@ func (r *resolver) forwardQueryEnd() {
 	defer r.queryLock.Unlock()
 
 	if r.count == 0 {
-		log.Errorf("Invalid concurrent query count")
+		logrus.Error("Invalid concurrent query count")
 	} else {
 		r.count--
 	}

--- a/resolver_unix.go
+++ b/resolver_unix.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"runtime"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/vishvananda/netns"
@@ -31,7 +31,7 @@ func reexecSetupResolver() {
 	defer runtime.UnlockOSThread()
 
 	if len(os.Args) < 4 {
-		log.Error("invalid number of arguments..")
+		logrus.Error("invalid number of arguments..")
 		os.Exit(1)
 	}
 
@@ -46,14 +46,14 @@ func reexecSetupResolver() {
 
 	f, err := os.OpenFile(os.Args[1], os.O_RDONLY, 0)
 	if err != nil {
-		log.Errorf("failed get network namespace %q: %v", os.Args[1], err)
+		logrus.Errorf("failed get network namespace %q: %v", os.Args[1], err)
 		os.Exit(2)
 	}
 	defer f.Close()
 
 	nsFD := f.Fd()
 	if err = netns.Set(netns.NsHandle(nsFD)); err != nil {
-		log.Errorf("setting into container net ns %v failed, %v", os.Args[1], err)
+		logrus.Errorf("setting into container net ns %v failed, %v", os.Args[1], err)
 		os.Exit(3)
 	}
 
@@ -76,7 +76,7 @@ func reexecSetupResolver() {
 
 	for _, rule := range rules {
 		if iptables.RawCombinedOutputNative(rule...) != nil {
-			log.Errorf("setting up rule failed, %v", rule)
+			logrus.Errorf("setting up rule failed, %v", rule)
 		}
 	}
 }

--- a/sandbox.go
+++ b/sandbox.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/etchosts"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/osl"
@@ -213,18 +213,18 @@ func (sb *sandbox) delete(force bool) error {
 			if c.isDistributedControl() {
 				retain = true
 			}
-			log.Warnf("Failed getting network for ep %s during sandbox %s delete: %v", ep.ID(), sb.ID(), err)
+			logrus.Warnf("Failed getting network for ep %s during sandbox %s delete: %v", ep.ID(), sb.ID(), err)
 			continue
 		}
 
 		if !force {
 			if err := ep.Leave(sb); err != nil {
-				log.Warnf("Failed detaching sandbox %s from endpoint %s: %v\n", sb.ID(), ep.ID(), err)
+				logrus.Warnf("Failed detaching sandbox %s from endpoint %s: %v\n", sb.ID(), ep.ID(), err)
 			}
 		}
 
 		if err := ep.Delete(force); err != nil {
-			log.Warnf("Failed deleting endpoint %s: %v\n", ep.ID(), err)
+			logrus.Warnf("Failed deleting endpoint %s: %v\n", ep.ID(), err)
 		}
 	}
 
@@ -247,7 +247,7 @@ func (sb *sandbox) delete(force bool) error {
 	}
 
 	if err := sb.storeDelete(); err != nil {
-		log.Warnf("Failed to delete sandbox %s from store: %v", sb.ID(), err)
+		logrus.Warnf("Failed to delete sandbox %s from store: %v", sb.ID(), err)
 	}
 
 	c.Lock()
@@ -291,7 +291,7 @@ func (sb *sandbox) Refresh(options ...SandboxOption) error {
 	// Detach from all endpoints
 	for _, ep := range epList {
 		if err := ep.Leave(sb); err != nil {
-			log.Warnf("Failed detaching sandbox %s from endpoint %s: %v\n", sb.ID(), ep.ID(), err)
+			logrus.Warnf("Failed detaching sandbox %s from endpoint %s: %v\n", sb.ID(), ep.ID(), err)
 		}
 	}
 
@@ -307,7 +307,7 @@ func (sb *sandbox) Refresh(options ...SandboxOption) error {
 	// Re-connect to all endpoints
 	for _, ep := range epList {
 		if err := ep.Join(sb); err != nil {
-			log.Warnf("Failed attach sandbox %s to endpoint %s: %v\n", sb.ID(), ep.ID(), err)
+			logrus.Warnf("Failed attach sandbox %s to endpoint %s: %v\n", sb.ID(), ep.ID(), err)
 		}
 	}
 
@@ -413,7 +413,7 @@ func (sb *sandbox) updateGateway(ep *endpoint) error {
 
 func (sb *sandbox) ResolveIP(ip string) string {
 	var svc string
-	log.Debugf("IP To resolve %v", ip)
+	logrus.Debugf("IP To resolve %v", ip)
 
 	for _, ep := range sb.getConnectedEndpoints() {
 		n := ep.getNetwork()
@@ -434,7 +434,7 @@ func (sb *sandbox) ResolveService(name string) ([]*net.SRV, []net.IP) {
 	srv := []*net.SRV{}
 	ip := []net.IP{}
 
-	log.Debugf("Service name To resolve: %v", name)
+	logrus.Debugf("Service name To resolve: %v", name)
 
 	// There are DNS implementaions that allow SRV queries for names not in
 	// the format defined by RFC 2782. Hence specific validations checks are
@@ -497,7 +497,7 @@ func (sb *sandbox) ResolveName(name string, ipType int) ([]net.IP, bool) {
 	// {a.b in network c.d},
 	// {a in network b.c.d},
 
-	log.Debugf("Name To resolve: %v", name)
+	logrus.Debugf("Name To resolve: %v", name)
 	name = strings.TrimSuffix(name, ".")
 	reqName := []string{name}
 	networkName := []string{""}
@@ -605,7 +605,7 @@ func (sb *sandbox) resolveName(req string, networkName string, epList []*endpoin
 func (sb *sandbox) SetKey(basePath string) error {
 	start := time.Now()
 	defer func() {
-		log.Debugf("sandbox set key processing took %s for container %s", time.Now().Sub(start), sb.ContainerID())
+		logrus.Debugf("sandbox set key processing took %s for container %s", time.Now().Sub(start), sb.ContainerID())
 	}()
 
 	if basePath == "" {
@@ -646,10 +646,10 @@ func (sb *sandbox) SetKey(basePath string) error {
 
 		if err := sb.osSbox.InvokeFunc(sb.resolver.SetupFunc(0)); err == nil {
 			if err := sb.resolver.Start(); err != nil {
-				log.Errorf("Resolver Start failed for container %s, %q", sb.ContainerID(), err)
+				logrus.Errorf("Resolver Start failed for container %s, %q", sb.ContainerID(), err)
 			}
 		} else {
-			log.Errorf("Resolver Setup Function failed for container %s, %q", sb.ContainerID(), err)
+			logrus.Errorf("Resolver Setup Function failed for container %s, %q", sb.ContainerID(), err)
 		}
 	}
 
@@ -690,7 +690,7 @@ func releaseOSSboxResources(osSbox osl.Sandbox, ep *endpoint) {
 		// Only remove the interfaces owned by this endpoint from the sandbox.
 		if ep.hasInterface(i.SrcName()) {
 			if err := i.Remove(); err != nil {
-				log.Debugf("Remove interface %s failed: %v", i.SrcName(), err)
+				logrus.Debugf("Remove interface %s failed: %v", i.SrcName(), err)
 			}
 		}
 	}
@@ -706,7 +706,7 @@ func releaseOSSboxResources(osSbox osl.Sandbox, ep *endpoint) {
 	// Remove non-interface routes.
 	for _, r := range joinInfo.StaticRoutes {
 		if err := osSbox.RemoveStaticRoute(r); err != nil {
-			log.Debugf("Remove route failed: %v", err)
+			logrus.Debugf("Remove route failed: %v", err)
 		}
 	}
 }
@@ -741,7 +741,7 @@ func (sb *sandbox) restoreOslSandbox() error {
 		ep.Unlock()
 
 		if i == nil {
-			log.Errorf("error restoring endpoint %s for container %s", ep.Name(), sb.ContainerID())
+			logrus.Errorf("error restoring endpoint %s for container %s", ep.Name(), sb.ContainerID())
 			continue
 		}
 
@@ -876,7 +876,7 @@ func (sb *sandbox) clearNetworkResources(origEp *endpoint) error {
 	if len(sb.endpoints) == 0 {
 		// sb.endpoints should never be empty and this is unexpected error condition
 		// We log an error message to note this down for debugging purposes.
-		log.Errorf("No endpoints in sandbox while trying to remove endpoint %s", ep.Name())
+		logrus.Errorf("No endpoints in sandbox while trying to remove endpoint %s", ep.Name())
 		sb.Unlock()
 		return nil
 	}

--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/etchosts"
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/docker/libnetwork/types"
@@ -40,19 +40,19 @@ func (sb *sandbox) startResolver(restore bool) {
 		if !restore {
 			err = sb.rebuildDNS()
 			if err != nil {
-				log.Errorf("Updating resolv.conf failed for container %s, %q", sb.ContainerID(), err)
+				logrus.Errorf("Updating resolv.conf failed for container %s, %q", sb.ContainerID(), err)
 				return
 			}
 		}
 		sb.resolver.SetExtServers(sb.extDNS)
 
 		if err = sb.osSbox.InvokeFunc(sb.resolver.SetupFunc(0)); err != nil {
-			log.Errorf("Resolver Setup function failed for container %s, %q", sb.ContainerID(), err)
+			logrus.Errorf("Resolver Setup function failed for container %s, %q", sb.ContainerID(), err)
 			return
 		}
 
 		if err = sb.resolver.Start(); err != nil {
-			log.Errorf("Resolver Start failed for container %s, %q", sb.ContainerID(), err)
+			logrus.Errorf("Resolver Start failed for container %s, %q", sb.ContainerID(), err)
 		}
 	})
 }
@@ -125,13 +125,13 @@ func (sb *sandbox) updateHostsFile(ifaceIP string) error {
 
 func (sb *sandbox) addHostsEntries(recs []etchosts.Record) {
 	if err := etchosts.Add(sb.config.hostsPath, recs); err != nil {
-		log.Warnf("Failed adding service host entries to the running container: %v", err)
+		logrus.Warnf("Failed adding service host entries to the running container: %v", err)
 	}
 }
 
 func (sb *sandbox) deleteHostsEntries(recs []etchosts.Record) {
 	if err := etchosts.Delete(sb.config.hostsPath, recs); err != nil {
-		log.Warnf("Failed deleting service host entries to the running container: %v", err)
+		logrus.Warnf("Failed deleting service host entries to the running container: %v", err)
 	}
 }
 
@@ -261,7 +261,7 @@ func (sb *sandbox) updateDNS(ipv6Enabled bool) error {
 	if currHash != "" && currHash != currRC.Hash {
 		// Seems the user has changed the container resolv.conf since the last time
 		// we checked so return without doing anything.
-		//log.Infof("Skipping update of resolv.conf file with ipv6Enabled: %t because file was touched by user", ipv6Enabled)
+		//logrus.Infof("Skipping update of resolv.conf file with ipv6Enabled: %t because file was touched by user", ipv6Enabled)
 		return nil
 	}
 

--- a/sandbox_store.go
+++ b/sandbox_store.go
@@ -178,7 +178,7 @@ func (sb *sandbox) storeDelete() error {
 func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 	store := c.getStore(datastore.LocalScope)
 	if store == nil {
-		logrus.Errorf("Could not find local scope store while trying to cleanup sandboxes")
+		logrus.Error("Could not find local scope store while trying to cleanup sandboxes")
 		return
 	}
 

--- a/store.go
+++ b/store.go
@@ -3,7 +3,7 @@ package libnetwork
 import (
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store/boltdb"
 	"github.com/docker/libkv/store/consul"
 	"github.com/docker/libkv/store/etcd"
@@ -85,7 +85,7 @@ func (c *controller) getNetworkFromStore(nid string) (*network, error) {
 		// Continue searching in the next store if the key is not found in this store
 		if err != nil {
 			if err != datastore.ErrKeyNotFound {
-				log.Debugf("could not find network %s: %v", nid, err)
+				logrus.Debugf("could not find network %s: %v", nid, err)
 			}
 			continue
 		}
@@ -126,7 +126,7 @@ func (c *controller) getNetworksForScope(scope string) ([]*network, error) {
 		ec := &endpointCnt{n: n}
 		err = store.GetObject(datastore.Key(ec.Key()...), ec)
 		if err != nil && !n.inDelete {
-			log.Warnf("Could not find endpoint count key %s for network %s while listing: %v", datastore.Key(ec.Key()...), n.Name(), err)
+			logrus.Warnf("Could not find endpoint count key %s for network %s while listing: %v", datastore.Key(ec.Key()...), n.Name(), err)
 			continue
 		}
 
@@ -147,7 +147,7 @@ func (c *controller) getNetworksFromStore() ([]*network, error) {
 		// Continue searching in the next store if no keys found in this store
 		if err != nil {
 			if err != datastore.ErrKeyNotFound {
-				log.Debugf("failed to get networks for scope %s: %v", store.Scope(), err)
+				logrus.Debugf("failed to get networks for scope %s: %v", store.Scope(), err)
 			}
 			continue
 		}
@@ -161,7 +161,7 @@ func (c *controller) getNetworksFromStore() ([]*network, error) {
 			ec := &endpointCnt{n: n}
 			err = store.GetObject(datastore.Key(ec.Key()...), ec)
 			if err != nil && !n.inDelete {
-				log.Warnf("could not find endpoint count key %s for network %s while listing: %v", datastore.Key(ec.Key()...), n.Name(), err)
+				logrus.Warnf("could not find endpoint count key %s for network %s while listing: %v", datastore.Key(ec.Key()...), n.Name(), err)
 				continue
 			}
 
@@ -185,7 +185,7 @@ func (n *network) getEndpointFromStore(eid string) (*endpoint, error) {
 		if err != nil {
 			if err != datastore.ErrKeyNotFound {
 				errors = append(errors, fmt.Sprintf("{%s:%v}, ", store.Scope(), err))
-				log.Debugf("could not find endpoint %s in %s: %v", eid, store.Scope(), err)
+				logrus.Debugf("could not find endpoint %s in %s: %v", eid, store.Scope(), err)
 			}
 			continue
 		}
@@ -203,7 +203,7 @@ func (n *network) getEndpointsFromStore() ([]*endpoint, error) {
 		// Continue searching in the next store if no keys found in this store
 		if err != nil {
 			if err != datastore.ErrKeyNotFound {
-				log.Debugf("failed to get endpoints for network %s scope %s: %v",
+				logrus.Debugf("failed to get endpoints for network %s scope %s: %v",
 					n.Name(), store.Scope(), err)
 			}
 			continue
@@ -396,7 +396,7 @@ func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoi
 
 	ch, err := store.Watch(ep.getNetwork().getEpCnt(), nw.stopCh)
 	if err != nil {
-		log.Warnf("Error creating watch for network: %v", err)
+		logrus.Warnf("Error creating watch for network: %v", err)
 		return
 	}
 
@@ -459,15 +459,15 @@ func (c *controller) startWatch() {
 func (c *controller) networkCleanup() {
 	networks, err := c.getNetworksFromStore()
 	if err != nil {
-		log.Warnf("Could not retrieve networks from store(s) during network cleanup: %v", err)
+		logrus.Warnf("Could not retrieve networks from store(s) during network cleanup: %v", err)
 		return
 	}
 
 	for _, n := range networks {
 		if n.inDelete {
-			log.Infof("Removing stale network %s (%s)", n.Name(), n.ID())
+			logrus.Infof("Removing stale network %s (%s)", n.Name(), n.ID())
 			if err := n.delete(true); err != nil {
-				log.Debugf("Error while removing stale network: %v", err)
+				logrus.Debugf("Error while removing stale network: %v", err)
 			}
 		}
 	}
@@ -476,7 +476,7 @@ func (c *controller) networkCleanup() {
 var populateSpecial NetworkWalker = func(nw Network) bool {
 	if n := nw.(*network); n.hasSpecialDriver() {
 		if err := n.getController().addNetwork(n); err != nil {
-			log.Warnf("Failed to populate network %q with driver %q", nw.Name(), nw.Type())
+			logrus.Warnf("Failed to populate network %q with driver %q", nw.Name(), nw.Type())
 		}
 	}
 	return false


### PR DESCRIPTION
Refactoring logrus import and formatting

Following docker's issue https://github.com/docker/docker/issues/23459

This fix tries to fix logrus formatting by removing `f` from
`logrus.[Error|Warn|Debug|Fatal|Panic|Info]f` when formatting string
is not present.
Also fix import name to use original project name 'logrus' instead of
'log'
