### PR TITLE
Fixing incorrect resovler error message shown on daemon startup

### DIFF
--- a/network_windows.go
+++ b/network_windows.go
@@ -30,6 +30,10 @@ func (n *network) startResolver() {
 		options := n.Info().DriverOptions()
 		hnsid := options[windows.HNSID]
 
+		if hnsid == "" {
+			return
+		}
+
 		hnsresponse, err := hcsshim.HNSNetworkRequest("GET", hnsid, "")
 		if err != nil {
 			log.Errorf("Resolver Setup/Start failed for container %s, %q", n.Name(), err)


### PR DESCRIPTION
This fixes docker daemon showing incorrect message on startup:

time="2016-11-01T14:46:22.385577300-07:00" level=error msg="Resolver Setup/Start failed for container none, \"json: cannot unmarshal array into Go value of type hcsshim.HNSNetwork\""

Signed-off-by: msabansal <sabansal@microsoft.com>