### PR TITLE
Respect auto allocation for --ipv6

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -225,9 +225,7 @@ func TestCreateDeleteNetwork(t *testing.T) {
 	}
 
 	dops := GetOpsMap("abc", "")
-	nops := map[string]string{
-		netlabel.EnableIPv6: "true",
-	}
+	nops := map[string]string{}
 	nc := networkCreate{Name: "network_1", NetworkType: bridgeNetType, DriverOpts: dops, NetworkOpts: nops}
 	goodBody, err := json.Marshal(nc)
 	if err != nil {
@@ -1807,9 +1805,7 @@ func TestEndToEnd(t *testing.T) {
 	handleRequest := NewHTTPHandler(c)
 
 	dops := GetOpsMap("cdef", "1460")
-	nops := map[string]string{
-		netlabel.EnableIPv6: "true",
-	}
+	nops := map[string]string{}
 
 	// Create network
 	nc := networkCreate{Name: "network-fiftyfive", NetworkType: bridgeNetType, DriverOpts: dops, NetworkOpts: nops}

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -413,7 +413,7 @@ func (a *Allocator) getPredefinedPool(as string, ipV6 bool) (*net.IPNet, error) 
 		}
 	}
 
-	return nil, types.NotFoundErrorf("could not find an available non-overlapping address pool among the defaults to auto assign to the network")
+	return nil, types.NotFoundErrorf("could not find an available, non-overlapping IPv%d address pool among the defaults to assign to the network", v)
 }
 
 // RequestAddress returns an address from the specified pool ID

--- a/network.go
+++ b/network.go
@@ -1289,9 +1289,6 @@ func (n *network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {
 	}
 
 	if len(*cfgList) == 0 {
-		if ipVer == 6 {
-			return nil
-		}
 		*cfgList = []*IpamConf{{}}
 	}
 


### PR DESCRIPTION
Related to https://github.com/docker/docker/issues/28055

```
$ docker network create --ipv6 nw6
Error response from daemon: could not find an available, non-overlapping IPv6 address pool among the defaults to auto assign to the network
```

Signed-off-by: Alessandro Boch <aboch@docker.com>