### PR TITLE
Register remote network driver on Windows.

### DIFF
--- a/drivers_windows.go
+++ b/drivers_windows.go
@@ -2,6 +2,7 @@ package libnetwork
 
 import (
 	"github.com/docker/libnetwork/drivers/null"
+	"github.com/docker/libnetwork/drivers/remote"
 	"github.com/docker/libnetwork/drivers/windows"
 	"github.com/docker/libnetwork/drivers/windows/overlay"
 )
@@ -10,6 +11,7 @@ func getInitializers() []initializer {
 	return []initializer{
 		{null.Init, "null"},
 		{overlay.Init, "overlay"},
+		{remote.Init, "remote"},
 		{windows.GetInit("transparent"), "transparent"},
 		{windows.GetInit("l2bridge"), "l2bridge"},
 		{windows.GetInit("l2tunnel"), "l2tunnel"},


### PR DESCRIPTION
Without this change, specifying a remote network driver on Windows results in "could not resolve driver X in registry" error. Fixes #1539 

Signed-off-by: Michal Kostrzewa <kostrzewa.michal@o2.pl>