### PR TITLE
update reapNode interval

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -702,7 +702,7 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 	defer func() {
 		if err != nil {
 			if e := c.deleteFromStore(epCnt); e != nil {
-				log.Warnf("couldnt rollback from store, epCnt %v on failure (%v): %v", epCnt, err, e)
+				log.Warnf("could not rollback from store, epCnt %v on failure (%v): %v", epCnt, err, e)
 			}
 		}
 	}()

--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -242,7 +242,7 @@ func (nDB *NetworkDB) reapDeadNode() {
 	defer nDB.Unlock()
 	for id, n := range nDB.failedNodes {
 		if n.reapTime > 0 {
-			n.reapTime -= reapPeriod
+			n.reapTime -= nodeReapPeriod
 			continue
 		}
 		logrus.Debugf("Removing failed node %v from gossip cluster", n.Name)


### PR DESCRIPTION
When I was learning networkdb in libnetwork, I found some nits in code.

When init networkdb, reapDeadNode should be executed periodically every `nodeReapPeriod`, when one loop finishes, reapTime of node should minus `nodeReapPeriod` instead of `reapPeriod`.

What I did:
1. update the reapNode interval;
2. fix a typo

Signed-off-by: allencloud <allen.sun@daocloud.io>