### PR TITLE
remove unused mConfig

### DIFF
--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -139,7 +139,6 @@ func (nDB *NetworkDB) clusterInit() error {
 
 	nDB.stopCh = make(chan struct{})
 	nDB.memberlist = mlist
-	nDB.mConfig = config
 
 	for _, trigger := range []struct {
 		interval time.Duration

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -29,10 +29,6 @@ type NetworkDB struct {
 	// NetworkDB configuration.
 	config *Config
 
-	// local copy of memberlist config that we use to driver
-	// network scoped gossip and bulk sync.
-	mConfig *memberlist.Config
-
 	// All the tree index (byTable, byNetwork) that we maintain
 	// the db.
 	indexes map[int]*radix.Tree
@@ -57,7 +53,6 @@ type NetworkDB struct {
 
 	// A map of nodes which are participating in a given
 	// network. The key is a network ID.
-
 	networkNodes map[string][]string
 
 	// A table of ack channels for every node from which we are


### PR DESCRIPTION
remove unused mConfig in network. Here is my reason:
1. it is unused;
2. we can get this config from memberlist.Config

Just a kind of minor change, feel free to tell me if I miss something

Signed-off-by: allencloud <allen.sun@daocloud.io>