### PR TITLE
IDM need not be bound by default vxlan-id start index

### DIFF
--- a/drivers/overlay/ovmanager/ovmanager.go
+++ b/drivers/overlay/ovmanager/ovmanager.go
@@ -57,7 +57,7 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 		config:   config,
 	}
 
-	d.vxlanIdm, err = idm.New(nil, "vxlan-id", vxlanIDStart, vxlanIDEnd)
+	d.vxlanIdm, err = idm.New(nil, "vxlan-id", 1, vxlanIDEnd)
 	if err != nil {
 		return fmt.Errorf("failed to initialize vxlan id manager: %v", err)
 	}
@@ -164,7 +164,7 @@ func (n *network) obtainVxlanID(s *subnet) error {
 	n.Unlock()
 
 	if vni == 0 {
-		vni, err = n.driver.vxlanIdm.GetID()
+		vni, err = n.driver.vxlanIdm.GetIDInRange(vxlanIDStart, vxlanIDEnd)
 		if err != nil {
 			return err
 		}

--- a/idm/idm.go
+++ b/idm/idm.go
@@ -54,6 +54,19 @@ func (i *Idm) GetSpecificID(id uint64) error {
 	return i.handle.Set(id - i.start)
 }
 
+// GetIDInRange returns the first available id in the set within a range
+func (i *Idm) GetIDInRange(start, end uint64) (uint64, error) {
+	if i.handle == nil {
+		return 0, fmt.Errorf("ID set is not initialized")
+	}
+
+	if start < i.start || end > i.end {
+		return 0, fmt.Errorf("Requested range does not belong to the set")
+	}
+
+	return i.handle.SetAnyInRange(start, end-start)
+}
+
 // Release releases the specified id
 func (i *Idm) Release(id uint64) {
 	i.handle.Unset(id - i.start)


### PR DESCRIPTION
This will allow users to use the full spectrum of vxlan-ids

Signed-off-by: Madhu Venugopal <madhu@docker.com>