### PR TITLE
Separate service LB & SD from network plumbing

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -515,6 +515,10 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 		return err
 	}
 
+	if err = ep.addDriverInfoToCluster(); err != nil {
+		return err
+	}
+
 	if sb.needDefaultGW() && sb.getEndpointInGWNetwork() == nil {
 		return sb.setupDefaultGW()
 	}
@@ -709,8 +713,12 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 		return err
 	}
 
-	if e := ep.deleteFromCluster(); e != nil {
-		logrus.Errorf("Could not delete state for endpoint %s from cluster: %v", ep.Name(), e)
+	if e := ep.deleteServiceInfoFromCluster(); e != nil {
+		logrus.Errorf("Could not delete service state for endpoint %s from cluster: %v", ep.Name(), e)
+	}
+
+	if e := ep.deleteDriverInfoFromCluster(); e != nil {
+		logrus.Errorf("Could not delete endpoint state for endpoint %s from cluster: %v", ep.Name(), e)
 	}
 
 	sb.deleteHostsEntries(n.getSvcRecords(ep))

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -265,7 +265,7 @@ func (nDB *NetworkDB) CreateEntry(tname, nid, key string, value []byte) error {
 	}
 
 	if err := nDB.sendTableEvent(TableEventTypeCreate, nid, tname, key, entry); err != nil {
-		return fmt.Errorf("cannot send table create event: %v", err)
+		return fmt.Errorf("cannot send create event for table %s, %v", tname, err)
 	}
 
 	nDB.Lock()

--- a/sandbox.go
+++ b/sandbox.go
@@ -670,7 +670,7 @@ func (sb *sandbox) SetKey(basePath string) error {
 func (sb *sandbox) EnableService() error {
 	for _, ep := range sb.getConnectedEndpoints() {
 		if ep.enableService(true) {
-			if err := ep.addToCluster(); err != nil {
+			if err := ep.addServiceInfoToCluster(); err != nil {
 				ep.enableService(false)
 				return fmt.Errorf("could not update state for endpoint %s into cluster: %v", ep.Name(), err)
 			}
@@ -682,7 +682,7 @@ func (sb *sandbox) EnableService() error {
 func (sb *sandbox) DisableService() error {
 	for _, ep := range sb.getConnectedEndpoints() {
 		if ep.enableService(false) {
-			if err := ep.deleteFromCluster(); err != nil {
+			if err := ep.deleteServiceInfoFromCluster(); err != nil {
 				ep.enableService(true)
 				return fmt.Errorf("could not delete state for endpoint %s from cluster: %v", ep.Name(), err)
 			}


### PR DESCRIPTION
`EnableService` and `DisableService` APIs allow a service to be accessible through Service Discovery and Load Balancer only if the image's healthcheck passes. Currently these APIs control the network plumbing as well. So if the healthcheck of an image tries to connect to other services on the same network it will not work. This PR separates the networking plumbing from the `<Enable|Disable>Service` APIs.

This will also help in the upgrade case where we want to take the service out of availability (ie: no new client connections to the service), but the existing connections should work till a grace period.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>