### PR TITLE
Split common interfaces into separate package

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
+	"github.com/docker/libnetwork/types/common"
 )
 
 const (
@@ -82,7 +83,7 @@ func i2sbL(i interface{}) []*sandboxResource {
 	return s
 }
 
-func createTestNetwork(t *testing.T, network string) (libnetwork.NetworkController, libnetwork.Network) {
+func createTestNetwork(t *testing.T, network string) (libnetwork.NetworkController, common.Network) {
 	// Cleanup local datastore file
 	os.Remove(datastore.DefaultScopes("")[datastore.LocalScope].Client.Address)
 

--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -34,6 +34,7 @@ import (
 	"github.com/docker/libnetwork/netutils"
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/types"
+	"github.com/docker/libnetwork/types/common"
 	"github.com/gorilla/mux"
 	"golang.org/x/net/context"
 )
@@ -508,12 +509,12 @@ func encodeData(data interface{}) (*bytes.Buffer, error) {
 
 func ipamOption(bridgeName string) libnetwork.NetworkOption {
 	if nws, _, err := netutils.ElectInterfaceAddresses(bridgeName); err == nil {
-		ipamV4Conf := &libnetwork.IpamConf{PreferredPool: nws[0].String()}
+		ipamV4Conf := &common.IpamConf{PreferredPool: nws[0].String()}
 		hip, _ := types.GetHostPartIP(nws[0].IP, nws[0].Mask)
 		if hip.IsGlobalUnicast() {
 			ipamV4Conf.Gateway = nws[0].IP.String()
 		}
-		return libnetwork.NetworkOptionIpam("default", "", []*libnetwork.IpamConf{ipamV4Conf}, nil, nil)
+		return libnetwork.NetworkOptionIpam("default", "", []*common.IpamConf{ipamV4Conf}, nil, nil)
 	}
 	return nil
 }

--- a/default_gateway.go
+++ b/default_gateway.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/types"
+	"github.com/docker/libnetwork/types/common"
 )
 
 const (
@@ -46,7 +47,7 @@ func (sb *sandbox) setupDefaultGW() error {
 		}
 	}
 
-	createOptions := []EndpointOption{CreateOptionAnonymous()}
+	createOptions := []common.EndpointOption{CreateOptionAnonymous()}
 
 	eplen := gwEPlen
 	if len(sb.containerID) < gwEPlen {
@@ -163,7 +164,7 @@ func (sb *sandbox) getEPwithoutGateway() *endpoint {
 
 // Looks for the default gw network and creates it if not there.
 // Parallel executions are serialized.
-func (c *controller) defaultGwNetwork() (Network, error) {
+func (c *controller) defaultGwNetwork() (common.Network, error) {
 	procGwNetwork <- true
 	defer func() { <-procGwNetwork }()
 

--- a/default_gateway_linux.go
+++ b/default_gateway_linux.go
@@ -5,15 +5,16 @@ import (
 	"strconv"
 
 	"github.com/docker/libnetwork/drivers/bridge"
+	"github.com/docker/libnetwork/types/common"
 )
 
 const libnGWNetwork = "docker_gwbridge"
 
-func getPlatformOption() EndpointOption {
+func getPlatformOption() common.EndpointOption {
 	return nil
 }
 
-func (c *controller) createGWNetwork() (Network, error) {
+func (c *controller) createGWNetwork() (common.Network, error) {
 	netOption := map[string]string{
 		bridge.BridgeName:         libnGWNetwork,
 		bridge.EnableICC:          strconv.FormatBool(false),

--- a/default_gateway_solaris.go
+++ b/default_gateway_solaris.go
@@ -5,15 +5,16 @@ import (
 	"strconv"
 
 	"github.com/docker/libnetwork/drivers/solaris/bridge"
+	"github.com/docker/libnetwork/types/common"
 )
 
 const libnGWNetwork = "docker_gwbridge"
 
-func getPlatformOption() EndpointOption {
+func getPlatformOption() common.EndpointOption {
 	return nil
 }
 
-func (c *controller) createGWNetwork() (Network, error) {
+func (c *controller) createGWNetwork() (common.Network, error) {
 	netOption := map[string]string{
 		bridge.BridgeName:         libnGWNetwork,
 		bridge.EnableICC:          strconv.FormatBool(false),

--- a/default_gateway_windows.go
+++ b/default_gateway_windows.go
@@ -4,11 +4,12 @@ import (
 	windriver "github.com/docker/libnetwork/drivers/windows"
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/types"
+	"github.com/docker/libnetwork/types/common"
 )
 
 const libnGWNetwork = "nat"
 
-func getPlatformOption() EndpointOption {
+func getPlatformOption() common.EndpointOption {
 
 	epOption := options.Generic{
 		windriver.DisableICC: true,
@@ -17,6 +18,6 @@ func getPlatformOption() EndpointOption {
 	return EndpointOptionGeneric(epOption)
 }
 
-func (c *controller) createGWNetwork() (Network, error) {
+func (c *controller) createGWNetwork() (common.Network, error) {
 	return nil, types.NotImplementedErrorf("default gateway functionality is not implemented in windows")
 }

--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -7,46 +7,8 @@ import (
 
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/types"
+	"github.com/docker/libnetwork/types/common"
 )
-
-// EndpointInfo provides an interface to retrieve network resources bound to the endpoint.
-type EndpointInfo interface {
-	// Iface returns InterfaceInfo, go interface that can be used
-	// to get more information on the interface which was assigned to
-	// the endpoint by the driver. This can be used after the
-	// endpoint has been created.
-	Iface() InterfaceInfo
-
-	// Gateway returns the IPv4 gateway assigned by the driver.
-	// This will only return a valid value if a container has joined the endpoint.
-	Gateway() net.IP
-
-	// GatewayIPv6 returns the IPv6 gateway assigned by the driver.
-	// This will only return a valid value if a container has joined the endpoint.
-	GatewayIPv6() net.IP
-
-	// StaticRoutes returns the list of static routes configured by the network
-	// driver when the container joins a network
-	StaticRoutes() []*types.StaticRoute
-
-	// Sandbox returns the attached sandbox if there, nil otherwise.
-	Sandbox() Sandbox
-}
-
-// InterfaceInfo provides an interface to retrieve interface addresses bound to the endpoint.
-type InterfaceInfo interface {
-	// MacAddress returns the MAC address assigned to the endpoint.
-	MacAddress() net.HardwareAddr
-
-	// Address returns the IPv4 address assigned to the endpoint.
-	Address() *net.IPNet
-
-	// AddressIPv6 returns the IPv6 address assigned to the endpoint.
-	AddressIPv6() *net.IPNet
-
-	// LinkLocalAddresses returns the list of link-local (IPv4/IPv6) addresses assigned to the endpoint.
-	LinkLocalAddresses() []*net.IPNet
-}
 
 type endpointInterface struct {
 	mac       net.HardwareAddr
@@ -180,7 +142,7 @@ type tableEntry struct {
 	value     []byte
 }
 
-func (ep *endpoint) Info() EndpointInfo {
+func (ep *endpoint) Info() common.EndpointInfo {
 	n, err := ep.getNetworkFromStore()
 	if err != nil {
 		return nil
@@ -205,7 +167,7 @@ func (ep *endpoint) Info() EndpointInfo {
 	return nil
 }
 
-func (ep *endpoint) Iface() InterfaceInfo {
+func (ep *endpoint) Iface() common.InterfaceInfo {
 	ep.Lock()
 	defer ep.Unlock()
 
@@ -318,7 +280,7 @@ func (ep *endpoint) AddTableEntry(tableName, key string, value []byte) error {
 	return nil
 }
 
-func (ep *endpoint) Sandbox() Sandbox {
+func (ep *endpoint) Sandbox() common.Sandbox {
 	cnt, ok := ep.getSandbox()
 	if !ok {
 		return nil

--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
+	"github.com/docker/libnetwork/types/common"
 )
 
 func TestNetworkMarshalling(t *testing.T) {
@@ -29,7 +30,7 @@ func TestNetworkMarshalling(t *testing.T) {
 			netlabel.MacAddress: "a:b:c:d:e:f",
 			"primary":           "",
 		},
-		ipamV4Config: []*IpamConf{
+		ipamV4Config: []*common.IpamConf{
 			{
 				PreferredPool: "10.2.0.0/16",
 				SubPool:       "10.2.0.0/24",
@@ -42,7 +43,7 @@ func TestNetworkMarshalling(t *testing.T) {
 				Gateway:       "10.2.1.254",
 			},
 		},
-		ipamV6Config: []*IpamConf{
+		ipamV6Config: []*common.IpamConf{
 			{
 				PreferredPool: "abcd::/64",
 				SubPool:       "abcd:abcd:abcd:abcd:abcd::/80",
@@ -50,7 +51,7 @@ func TestNetworkMarshalling(t *testing.T) {
 				AuxAddresses:  nil,
 			},
 		},
-		ipamV4Info: []*IpamInfo{
+		ipamV4Info: []*common.IpamInfo{
 			{
 				PoolID: "ipoolverde123",
 				Meta: map[string]string{
@@ -94,7 +95,7 @@ func TestNetworkMarshalling(t *testing.T) {
 				},
 			},
 		},
-		ipamV6Info: []*IpamInfo{
+		ipamV6Info: []*common.IpamInfo{
 			{
 				PoolID: "ipoolv6",
 				IPAMData: driverapi.IPAMData{
@@ -150,8 +151,8 @@ func TestNetworkMarshalling(t *testing.T) {
 	}
 }
 
-func printIpamConf(list []*IpamConf) string {
-	s := fmt.Sprintf("\n[]*IpamConfig{")
+func printIpamConf(list []*common.IpamConf) string {
+	s := fmt.Sprintf("\n[]*common.IpamConfig{")
 	for _, i := range list {
 		s = fmt.Sprintf("%s %v,", s, i)
 	}
@@ -159,8 +160,8 @@ func printIpamConf(list []*IpamConf) string {
 	return s
 }
 
-func printIpamInfo(list []*IpamInfo) string {
-	s := fmt.Sprintf("\n[]*IpamInfo{")
+func printIpamInfo(list []*common.IpamInfo) string {
+	s := fmt.Sprintf("\n[]*common.IpamInfo{")
 	for _, i := range list {
 		s = fmt.Sprintf("%s\n{\n%s\n}", s, i)
 	}
@@ -221,8 +222,8 @@ func compareEndpointInterface(a, b *endpointInterface) bool {
 		types.CompareIPNet(a.addr, b.addr) && types.CompareIPNet(a.addrv6, b.addrv6)
 }
 
-func compareIpamConfList(listA, listB []*IpamConf) bool {
-	var a, b *IpamConf
+func compareIpamConfList(listA, listB []*common.IpamConf) bool {
+	var a, b *common.IpamConf
 	if len(listA) != len(listB) {
 		return false
 	}
@@ -238,8 +239,8 @@ func compareIpamConfList(listA, listB []*IpamConf) bool {
 	return true
 }
 
-func compareIpamInfoList(listA, listB []*IpamInfo) bool {
-	var a, b *IpamInfo
+func compareIpamInfoList(listA, listB []*common.IpamInfo) bool {
+	var a, b *common.IpamInfo
 	if len(listA) != len(listB) {
 		return false
 	}
@@ -309,7 +310,7 @@ func TestAuxAddresses(t *testing.T) {
 
 	for _, i := range input {
 
-		n.ipamV4Config = []*IpamConf{{PreferredPool: i.masterPool, SubPool: i.subPool, AuxAddresses: i.auxAddresses}}
+		n.ipamV4Config = []*common.IpamConf{{PreferredPool: i.masterPool, SubPool: i.subPool, AuxAddresses: i.auxAddresses}}
 
 		err = n.ipamAllocate()
 
@@ -437,7 +438,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 
 	// Test whether ipam state release is invoked  on network create failure from net driver
 	// by checking whether subsequent network creation requesting same gateway IP succeeds
-	ipamOpt := NetworkOptionIpam(ipamapi.DefaultIPAM, "", []*IpamConf{{PreferredPool: "10.34.0.0/16", Gateway: "10.34.255.254"}}, nil, nil)
+	ipamOpt := NetworkOptionIpam(ipamapi.DefaultIPAM, "", []*common.IpamConf{{PreferredPool: "10.34.0.0/16", Gateway: "10.34.255.254"}}, nil, nil)
 	if _, err := c.NewNetwork(badDriverName, "badnet1", "", ipamOpt); err == nil {
 		t.Fatalf("bad network driver should have failed network creation")
 	}
@@ -461,7 +462,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 	}
 
 	// Now create good bridge network with different gateway
-	ipamOpt2 := NetworkOptionIpam(ipamapi.DefaultIPAM, "", []*IpamConf{{PreferredPool: "10.34.0.0/16", Gateway: "10.34.255.253"}}, nil, nil)
+	ipamOpt2 := NetworkOptionIpam(ipamapi.DefaultIPAM, "", []*common.IpamConf{{PreferredPool: "10.34.0.0/16", Gateway: "10.34.255.253"}}, nil, nil)
 	gnw, err = c.NewNetwork("bridge", "goodnet2", "", ipamOpt2)
 	if err != nil {
 		t.Fatal(err)

--- a/libnetwork_linux_test.go
+++ b/libnetwork_linux_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/libnetwork/osl"
 	"github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
+	"github.com/docker/libnetwork/types/common"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/vishvananda/netlink"
@@ -143,8 +144,8 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 			"EnableIPMasquerade": true,
 		},
 	}
-	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24", Gateway: "192.168.100.1"}}
-	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
+	ipamV4ConfList := []*common.IpamConf{{PreferredPool: "192.168.100.0/24", Gateway: "192.168.100.1"}}
+	ipamV6ConfList := []*common.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
 
 	network, err := controller.NewNetwork(bridgeNetType, "testipv6mac", "",
 		libnetwork.NetworkOptionGeneric(netOption),
@@ -183,7 +184,7 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 	}
 }
 
-func checkSandbox(t *testing.T, info libnetwork.EndpointInfo) {
+func checkSandbox(t *testing.T, info common.EndpointInfo) {
 	key := info.Sandbox().Key()
 	sbNs, err := netns.GetFromPath(key)
 	if err != nil {
@@ -220,7 +221,7 @@ func TestEndpointJoin(t *testing.T) {
 			"EnableIPMasquerade": true,
 		},
 	}
-	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
+	ipamV6ConfList := []*common.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
 	n1, err := controller.NewNetwork(bridgeNetType, "testnetwork1", "",
 		libnetwork.NetworkOptionGeneric(netOption),
 		libnetwork.NetworkOptionEnableIPv6(true),
@@ -567,7 +568,7 @@ func TestEnableIPv6(t *testing.T) {
 			"BridgeName": "testnetwork",
 		},
 	}
-	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "fe99::/64", Gateway: "fe99::9"}}
+	ipamV6ConfList := []*common.IpamConf{{PreferredPool: "fe99::/64", Gateway: "fe99::9"}}
 
 	n, err := createTestNetwork("bridge", "testnetwork", netOption, nil, ipamV6ConfList)
 	if err != nil {
@@ -840,7 +841,7 @@ func TestResolvConf(t *testing.T) {
 	}
 }
 
-func parallelJoin(t *testing.T, rc libnetwork.Sandbox, ep libnetwork.Endpoint, thrNumber int) {
+func parallelJoin(t *testing.T, rc common.Sandbox, ep common.Endpoint, thrNumber int) {
 	debugf("J%d.", thrNumber)
 	var err error
 
@@ -857,7 +858,7 @@ func parallelJoin(t *testing.T, rc libnetwork.Sandbox, ep libnetwork.Endpoint, t
 	debugf("JD%d.", thrNumber)
 }
 
-func parallelLeave(t *testing.T, rc libnetwork.Sandbox, ep libnetwork.Endpoint, thrNumber int) {
+func parallelLeave(t *testing.T, rc common.Sandbox, ep common.Endpoint, thrNumber int) {
 	debugf("L%d.", thrNumber)
 	var err error
 
@@ -876,8 +877,8 @@ func parallelLeave(t *testing.T, rc libnetwork.Sandbox, ep libnetwork.Endpoint, 
 
 func runParallelTests(t *testing.T, thrNumber int) {
 	var (
-		ep  libnetwork.Endpoint
-		sb  libnetwork.Sandbox
+		ep  common.Endpoint
+		sb  common.Sandbox
 		err error
 	)
 

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
+	"github.com/docker/libnetwork/types/common"
 	"github.com/vishvananda/netns"
 )
 
@@ -71,7 +72,7 @@ func createController() error {
 	return nil
 }
 
-func createTestNetwork(networkType, networkName string, netOption options.Generic, ipamV4Configs, ipamV6Configs []*libnetwork.IpamConf) (libnetwork.Network, error) {
+func createTestNetwork(networkType, networkName string, netOption options.Generic, ipamV4Configs, ipamV6Configs []*common.IpamConf) (common.Network, error) {
 	return controller.NewNetwork(networkType, networkName, "",
 		libnetwork.NetworkOptionGeneric(netOption),
 		libnetwork.NetworkOptionIpam(ipamapi.DefaultIPAM, "", ipamV4Configs, ipamV6Configs, nil))
@@ -153,8 +154,8 @@ func TestBridge(t *testing.T) {
 			"EnableIPMasquerade": true,
 		},
 	}
-	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24", Gateway: "192.168.100.1"}}
-	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
+	ipamV4ConfList := []*common.IpamConf{{PreferredPool: "192.168.100.0/24", Gateway: "192.168.100.1"}}
+	ipamV6ConfList := []*common.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
 
 	network, err := createTestNetwork(bridgeNetType, "testnetwork", netOption, ipamV4ConfList, ipamV6ConfList)
 	if err != nil {
@@ -402,7 +403,7 @@ func TestUnknownEndpoint(t *testing.T) {
 	option := options.Generic{
 		netlabel.GenericData: netOption,
 	}
-	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24"}}
+	ipamV4ConfList := []*common.IpamConf{{PreferredPool: "192.168.100.0/24"}}
 
 	network, err := createTestNetwork(bridgeNetType, "testnetwork", option, ipamV4ConfList, nil)
 	if err != nil {
@@ -489,8 +490,8 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 
 	// Test Endpoint Walk method
 	var epName string
-	var epWanted libnetwork.Endpoint
-	wlk := func(ep libnetwork.Endpoint) bool {
+	var epWanted common.Endpoint
+	wlk := func(ep common.Endpoint) bool {
 		if ep.Name() == epName {
 			epWanted = ep
 			return true
@@ -534,8 +535,8 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 
 	// Test Network Walk method
 	var netName string
-	var netWanted libnetwork.Network
-	nwWlk := func(nw libnetwork.Network) bool {
+	var netWanted common.Network
+	nwWlk := func(nw common.Network) bool {
 		if nw.Name() == netName {
 			netWanted = nw
 			return true
@@ -823,7 +824,7 @@ func (f *fakeSandbox) Statistics() (map[string]*types.InterfaceStatistics, error
 	return nil, nil
 }
 
-func (f *fakeSandbox) Refresh(opts ...libnetwork.SandboxOption) error {
+func (f *fakeSandbox) Refresh(opts ...common.SandboxOption) error {
 	return nil
 }
 
@@ -851,7 +852,7 @@ func (f *fakeSandbox) ResolveService(name string) ([]*net.SRV, []net.IP) {
 	return nil, nil
 }
 
-func (f *fakeSandbox) Endpoints() []libnetwork.Endpoint {
+func (f *fakeSandbox) Endpoints() []common.Endpoint {
 	return nil
 }
 
@@ -1315,7 +1316,7 @@ var (
 	done   = make(chan chan struct{}, numThreads-1)
 	origns = netns.None()
 	testns = netns.None()
-	sboxes = make([]libnetwork.Sandbox, numThreads)
+	sboxes = make([]common.Sandbox, numThreads)
 )
 
 const (

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/armon/go-radix"
 	"github.com/docker/go-events"
+	dbtypes "github.com/docker/libnetwork/networkdb/types"
 	"github.com/docker/libnetwork/types"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/serf"
@@ -88,12 +89,6 @@ type NetworkDB struct {
 
 	// Reference to the memberlist's keyring to add & remove keys
 	keyring *memberlist.Keyring
-}
-
-// PeerInfo represents the peer (gossip cluster) nodes of a network
-type PeerInfo struct {
-	Name string
-	IP   string
 }
 
 type node struct {
@@ -206,12 +201,12 @@ func (nDB *NetworkDB) Close() {
 }
 
 // Peers returns the gossip peers for a given network.
-func (nDB *NetworkDB) Peers(nid string) []PeerInfo {
+func (nDB *NetworkDB) Peers(nid string) []dbtypes.PeerInfo {
 	nDB.RLock()
 	defer nDB.RUnlock()
-	peers := make([]PeerInfo, 0, len(nDB.networkNodes[nid]))
+	peers := make([]dbtypes.PeerInfo, 0, len(nDB.networkNodes[nid]))
 	for _, nodeName := range nDB.networkNodes[nid] {
-		peers = append(peers, PeerInfo{
+		peers = append(peers, dbtypes.PeerInfo{
 			Name: nDB.nodes[nodeName].Name,
 			IP:   nDB.nodes[nodeName].Addr.String(),
 		})

--- a/networkdb/types/peer.go
+++ b/networkdb/types/peer.go
@@ -1,0 +1,7 @@
+package types
+
+// PeerInfo represents the peer (gossip cluster) nodes of a network
+type PeerInfo struct {
+	Name string
+	IP   string
+}

--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/libnetwork/etchosts"
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/docker/libnetwork/types"
+	"github.com/docker/libnetwork/types/common"
 )
 
 const (
@@ -136,7 +137,7 @@ func (sb *sandbox) deleteHostsEntries(recs []etchosts.Record) {
 }
 
 func (sb *sandbox) updateParentHosts() error {
-	var pSb Sandbox
+	var pSb common.Sandbox
 
 	for _, update := range sb.config.parentUpdates {
 		sb.controller.WalkSandboxes(SandboxContainerWalker(&pSb, update.cid))

--- a/sandbox_externalkey_unix.go
+++ b/sandbox_externalkey_unix.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/types"
+	"github.com/docker/libnetwork/types/common"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
@@ -162,7 +163,7 @@ func (c *controller) processExternalKey(conn net.Conn) error {
 		return err
 	}
 
-	var sandbox Sandbox
+	var sandbox common.Sandbox
 	search := SandboxContainerWalker(&sandbox, s.ContainerID)
 	c.WalkSandboxes(search)
 	if sandbox == nil {

--- a/sandbox_store.go
+++ b/sandbox_store.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/types/common"
 )
 
 const (
@@ -215,7 +216,7 @@ func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 			msg = ""
 			sb.isStub = false
 			isRestore = true
-			opts := val.([]SandboxOption)
+			opts := val.([]common.SandboxOption)
 			sb.processOptions(opts...)
 			sb.restorePath()
 			create = !sb.config.useDefaultSandBox

--- a/sandbox_test.go
+++ b/sandbox_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/osl"
 	"github.com/docker/libnetwork/testutils"
+	"github.com/docker/libnetwork/types/common"
 )
 
-func getTestEnv(t *testing.T, numNetworks int) (NetworkController, []Network) {
+func getTestEnv(t *testing.T, numNetworks int) (NetworkController, []common.Network) {
 	netType := "bridge"
 
 	option := options.Generic{
@@ -33,7 +34,7 @@ func getTestEnv(t *testing.T, numNetworks int) (NetworkController, []Network) {
 		return c, nil
 	}
 
-	nwList := make([]Network, 0, numNetworks)
+	nwList := make([]common.Network, 0, numNetworks)
 	for i := 0; i < numNetworks; i++ {
 		name := fmt.Sprintf("test_nw_%d", i)
 		netOption := options.Generic{

--- a/service_linux.go
+++ b/service_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/ipvs"
 	"github.com/docker/libnetwork/ns"
+	"github.com/docker/libnetwork/types/common"
 	"github.com/gogo/protobuf/proto"
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
@@ -119,7 +120,7 @@ func (sb *sandbox) populateLoadbalancers(ep *endpoint) {
 // this network. If needed add the service as well, as specified by
 // the addService bool.
 func (n *network) addLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*PortConfig, addService bool) {
-	n.WalkEndpoints(func(e Endpoint) bool {
+	n.WalkEndpoints(func(e common.Endpoint) bool {
 		ep := e.(*endpoint)
 		if sb, ok := ep.getSandbox(); ok {
 			if !sb.isEndpointPopulated(ep) {
@@ -150,7 +151,7 @@ func (n *network) addLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*Po
 // connection to this network. If needed remove the service entry as
 // well, as specified by the rmService bool.
 func (n *network) rmLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*PortConfig, rmService bool) {
-	n.WalkEndpoints(func(e Endpoint) bool {
+	n.WalkEndpoints(func(e common.Endpoint) bool {
 		ep := e.(*endpoint)
 		if sb, ok := ep.getSandbox(); ok {
 			if !sb.isEndpointPopulated(ep) {

--- a/store.go
+++ b/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/libkv/store/etcd"
 	"github.com/docker/libkv/store/zookeeper"
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/types/common"
 )
 
 func registerKVStores() {
@@ -473,7 +474,7 @@ func (c *controller) networkCleanup() {
 	}
 }
 
-var populateSpecial NetworkWalker = func(nw Network) bool {
+var populateSpecial NetworkWalker = func(nw common.Network) bool {
 	if n := nw.(*network); n.hasSpecialDriver() {
 		if err := n.getController().addNetwork(n); err != nil {
 			logrus.Warnf("Failed to populate network %q with driver %q", nw.Name(), nw.Type())

--- a/store_linux_test.go
+++ b/store_linux_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/libkv/store"
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/types/common"
 )
 
 func TestBoltdbBackend(t *testing.T) {
@@ -30,7 +31,7 @@ func TestNoPersist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating default \"host\" network: %v", err)
 	}
-	ep, err := nw.CreateEndpoint("newendpoint", []EndpointOption{}...)
+	ep, err := nw.CreateEndpoint("newendpoint", []common.EndpointOption{}...)
 	if err != nil {
 		t.Fatalf("Error creating endpoint: %v", err)
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/options"
+	"github.com/docker/libnetwork/types/common"
 )
 
 func testZooKeeperBackend(t *testing.T) {
@@ -49,7 +50,7 @@ func testLocalBackend(t *testing.T, provider, url string, storeConfig *store.Con
 	if err != nil {
 		t.Fatalf("Error creating default \"host\" network: %v", err)
 	}
-	ep, err := nw.CreateEndpoint("newendpoint", []EndpointOption{}...)
+	ep, err := nw.CreateEndpoint("newendpoint", []common.EndpointOption{}...)
 	if err != nil {
 		t.Fatalf("Error creating endpoint: %v", err)
 	}

--- a/types/common/endpoint.go
+++ b/types/common/endpoint.go
@@ -1,0 +1,38 @@
+package common
+
+// EndpointOption is an option setter function type used to pass various options to Network
+// and Endpoint interfaces methods. The various setter functions of type EndpointOption are
+// provided by libnetwork, they look like <Create|Join|Leave>Option[...](...)
+type EndpointOption func(ep Endpoint)
+
+// EndpointWalker is a client provided function which will be used to walk the Endpoints.
+// When the function returns true, the walk will stop.
+type EndpointWalker func(ep Endpoint) bool
+
+// Endpoint represents a logical connection between a network and a sandbox.
+type Endpoint interface {
+	// A system generated id for this endpoint.
+	ID() string
+
+	// Name returns the name of this endpoint.
+	Name() string
+
+	// Network returns the name of the network to which this endpoint is attached.
+	Network() string
+
+	// Join joins the sandbox to the endpoint and populates into the sandbox
+	// the network resources allocated for the endpoint.
+	Join(sandbox Sandbox, options ...EndpointOption) error
+
+	// Leave detaches the network resources populated in the sandbox.
+	Leave(sandbox Sandbox, options ...EndpointOption) error
+
+	// Return certain operational data belonging to this endpoint
+	Info() EndpointInfo
+
+	// DriverInfo returns a collection of driver operational data related to this endpoint retrieved from the driver
+	DriverInfo() (map[string]interface{}, error)
+
+	// Delete and detaches this endpoint from the network.
+	Delete(force bool) error
+}

--- a/types/common/endpoint_info.go
+++ b/types/common/endpoint_info.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"net"
+
+	"github.com/docker/libnetwork/types"
+)
+
+// EndpointInfo provides an interface to retrieve network resources bound to the endpoint.
+type EndpointInfo interface {
+	// Iface returns InterfaceInfo, go interface that can be used
+	// to get more information on the interface which was assigned to
+	// the endpoint by the driver. This can be used after the
+	// endpoint has been created.
+	Iface() InterfaceInfo
+
+	// Gateway returns the IPv4 gateway assigned by the driver.
+	// This will only return a valid value if a container has joined the endpoint.
+	Gateway() net.IP
+
+	// GatewayIPv6 returns the IPv6 gateway assigned by the driver.
+	// This will only return a valid value if a container has joined the endpoint.
+	GatewayIPv6() net.IP
+
+	// StaticRoutes returns the list of static routes configured by the network
+	// driver when the container joins a network
+	StaticRoutes() []*types.StaticRoute
+
+	// Sandbox returns the attached sandbox if there, nil otherwise.
+	Sandbox() Sandbox
+}
+
+// InterfaceInfo provides an interface to retrieve interface addresses bound to the endpoint.
+type InterfaceInfo interface {
+	// MacAddress returns the MAC address assigned to the endpoint.
+	MacAddress() net.HardwareAddr
+
+	// Address returns the IPv4 address assigned to the endpoint.
+	Address() *net.IPNet
+
+	// AddressIPv6 returns the IPv6 address assigned to the endpoint.
+	AddressIPv6() *net.IPNet
+
+	// LinkLocalAddresses returns the list of link-local (IPv4/IPv6) addresses assigned to the endpoint.
+	LinkLocalAddresses() []*net.IPNet
+}

--- a/types/common/ipam.go
+++ b/types/common/ipam.go
@@ -1,0 +1,117 @@
+package common
+
+import (
+	"encoding/json"
+	"net"
+
+	"github.com/docker/libnetwork/driverapi"
+	"github.com/docker/libnetwork/types"
+)
+
+// IpamConf contains all the ipam related configurations for a network
+type IpamConf struct {
+	// The master address pool for containers and network interfaces
+	PreferredPool string
+	// A subset of the master pool. If specified,
+	// this becomes the container pool
+	SubPool string
+	// Preferred Network Gateway address (optional)
+	Gateway string
+	// Auxiliary addresses for network driver. Must be within the master pool.
+	// libnetwork will reserve them if they fall into the container pool
+	AuxAddresses map[string]string
+}
+
+// Validate checks whether the configuration is valid
+func (c *IpamConf) Validate() error {
+	if c.Gateway != "" && nil == net.ParseIP(c.Gateway) {
+		return types.BadRequestErrorf("invalid gateway address %s in Ipam configuration", c.Gateway)
+	}
+	return nil
+}
+
+// IpamInfo contains all the ipam related operational info for a network
+type IpamInfo struct {
+	PoolID string
+	Meta   map[string]string
+	driverapi.IPAMData
+}
+
+// MarshalJSON encodes IpamInfo into json message
+func (i *IpamInfo) MarshalJSON() ([]byte, error) {
+	m := map[string]interface{}{
+		"PoolID": i.PoolID,
+	}
+	v, err := json.Marshal(&i.IPAMData)
+	if err != nil {
+		return nil, err
+	}
+	m["IPAMData"] = string(v)
+
+	if i.Meta != nil {
+		m["Meta"] = i.Meta
+	}
+	return json.Marshal(m)
+}
+
+// UnmarshalJSON decodes json message into PoolData
+func (i *IpamInfo) UnmarshalJSON(data []byte) error {
+	var (
+		m   map[string]interface{}
+		err error
+	)
+	if err = json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	i.PoolID = m["PoolID"].(string)
+	if v, ok := m["Meta"]; ok {
+		b, _ := json.Marshal(v)
+		if err = json.Unmarshal(b, &i.Meta); err != nil {
+			return err
+		}
+	}
+	if v, ok := m["IPAMData"]; ok {
+		if err = json.Unmarshal([]byte(v.(string)), &i.IPAMData); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CopyTo deep copies to the destination IpamConfig
+func (c *IpamConf) CopyTo(dstC *IpamConf) error {
+	dstC.PreferredPool = c.PreferredPool
+	dstC.SubPool = c.SubPool
+	dstC.Gateway = c.Gateway
+	if c.AuxAddresses != nil {
+		dstC.AuxAddresses = make(map[string]string, len(c.AuxAddresses))
+		for k, v := range c.AuxAddresses {
+			dstC.AuxAddresses[k] = v
+		}
+	}
+	return nil
+}
+
+// CopyTo deep copies to the destination IpamInfo
+func (i *IpamInfo) CopyTo(dstI *IpamInfo) error {
+	dstI.PoolID = i.PoolID
+	if i.Meta != nil {
+		dstI.Meta = make(map[string]string)
+		for k, v := range i.Meta {
+			dstI.Meta[k] = v
+		}
+	}
+
+	dstI.AddressSpace = i.AddressSpace
+	dstI.Pool = types.GetIPNetCopy(i.Pool)
+	dstI.Gateway = types.GetIPNetCopy(i.Gateway)
+
+	if i.AuxAddresses != nil {
+		dstI.AuxAddresses = make(map[string]*net.IPNet)
+		for k, v := range i.AuxAddresses {
+			dstI.AuxAddresses[k] = types.GetIPNetCopy(v)
+		}
+	}
+
+	return nil
+}

--- a/types/common/network.go
+++ b/types/common/network.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"time"
+
+	networkdbtypes "github.com/docker/libnetwork/networkdb/types"
+)
+
+// Network represents a logical connectivity zone that containers may
+// join using the Link method. A Network is managed by a specific driver.
+type Network interface {
+	// A user chosen name for this network.
+	Name() string
+
+	// A system generated id for this network.
+	ID() string
+
+	// The type of network, which corresponds to its managing driver.
+	Type() string
+
+	// Create a new endpoint to this network symbolically identified by the
+	// specified unique name. The options parameter carries driver specific options.
+	CreateEndpoint(name string, options ...EndpointOption) (Endpoint, error)
+
+	// Delete the network.
+	Delete() error
+
+	// Endpoints returns the list of Endpoint(s) in this network.
+	Endpoints() []Endpoint
+
+	// WalkEndpoints uses the provided function to walk the Endpoints
+	WalkEndpoints(walker EndpointWalker)
+
+	// EndpointByName returns the Endpoint which has the passed name. If not found, the error ErrNoSuchEndpoint is returned.
+	EndpointByName(name string) (Endpoint, error)
+
+	// EndpointByID returns the Endpoint which has the passed id. If not found, the error ErrNoSuchEndpoint is returned.
+	EndpointByID(id string) (Endpoint, error)
+
+	// Return certain operational data belonging to this network
+	Info() NetworkInfo
+}
+
+// NetworkInfo returns some configuration and operational information about the network
+type NetworkInfo interface {
+	IpamConfig() (string, map[string]string, []*IpamConf, []*IpamConf)
+	IpamInfo() ([]*IpamInfo, []*IpamInfo)
+	DriverOptions() map[string]string
+	Scope() string
+	IPv6Enabled() bool
+	Internal() bool
+	Labels() map[string]string
+	Dynamic() bool
+	Created() time.Time
+	// Peers returns a slice of PeerInfo structures which has the information about the peer
+	// nodes participating in the same overlay network. This is currently the per-network
+	// gossip cluster. For non-dynamic overlay networks and bridge networks it returns an
+	// empty slice
+	Peers() []networkdbtypes.PeerInfo
+}

--- a/types/common/sandbox.go
+++ b/types/common/sandbox.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"net"
+
+	"github.com/docker/libnetwork/types"
+)
+
+// Sandbox provides the control over the network container entity. It is a one to one mapping with the container.
+type Sandbox interface {
+	// ID returns the ID of the sandbox
+	ID() string
+	// Key returns the sandbox's key
+	Key() string
+	// ContainerID returns the container id associated to this sandbox
+	ContainerID() string
+	// Labels returns the sandbox's labels
+	Labels() map[string]interface{}
+	// Statistics retrieves the interfaces' statistics for the sandbox
+	Statistics() (map[string]*types.InterfaceStatistics, error)
+	// Refresh leaves all the endpoints, resets and re-applies the options,
+	// re-joins all the endpoints without destroying the osl sandbox
+	Refresh(options ...SandboxOption) error
+	// SetKey updates the Sandbox Key
+	SetKey(key string) error
+	// Rename changes the name of all attached Endpoints
+	Rename(name string) error
+	// Delete destroys this container after detaching it from all connected endpoints.
+	Delete() error
+	// Endpoints returns all the endpoints connected to the sandbox
+	Endpoints() []Endpoint
+	// ResolveService returns all the backend details about the containers or hosts
+	// backing a service. Its purpose is to satisfy an SRV query
+	ResolveService(name string) ([]*net.SRV, []net.IP)
+	// EnableService  makes a managed container's service available by adding the
+	// endpoint to the service load balancer and service discovery
+	EnableService() error
+	// DisableService removes a managed contianer's endpoints from the load balancer
+	// and service discovery
+	DisableService() error
+}
+
+// SandboxOption is an option setter function type used to pass various options to
+// NewNetContainer method. The various setter functions of type SandboxOption are
+// provided by libnetwork, they look like ContainerOptionXXXX(...)
+type SandboxOption func(sb Sandbox)


### PR DESCRIPTION
This decouples code that needs to import these interfaces with the rest
of the libnetwork codebase.

I noticed this originally working on Docker's container object and
seeing:

1. It takes a *really* long time to load, partially due to libnetwork
2. lots of platform dependent code from libnetwork makes the container
object not possible to compile except on target platforms, making the
test cycle a bit more difficult... this is even though the container
object is only dealing with these interfaces/common types.

Before this PR, the depdency tree just to use any of these interfaces
means importing serf, memberlist, protobuf, boltdb, consul/zk/etcd libs,
etc.

One thing this split is highlighting is that the interfaces for
`Sandbox`, and `Endpoint`, are very much tied to a specific
implementation.
This would be a nice future work to decouple further.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>