### PR TITLE
Add a nil check before accessing sandbox.osSbox

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -427,7 +427,13 @@ func (sb *sandbox) ResolveIP(ip string) string {
 }
 
 func (sb *sandbox) ExecFunc(f func()) error {
-	return sb.osSbox.InvokeFunc(f)
+	sb.Lock()
+	osSbox := sb.osSbox
+	sb.Unlock()
+	if osSbox != nil {
+		return osSbox.InvokeFunc(f)
+	}
+	return fmt.Errorf("osl sandbox unavailable in ExecFunc for %v", sb.ContainerID())
 }
 
 func (sb *sandbox) ResolveService(name string) ([]*net.SRV, []net.IP) {


### PR DESCRIPTION
Following panic was reported by one of the docker users..

```
Nov 14 18:43:17 docker-demo9-d dockerd[1732]: panic: runtime error: invalid memory address or nil pointer dereference
Nov 14 18:43:17 docker-demo9-d dockerd[1732]: [signal 0xb code=0x1 addr=0x58 pc=0x8c1b44]
Nov 14 18:43:17 docker-demo9-d dockerd[1732]: goroutine 52749 [running]:
Nov 14 18:43:17 docker-demo9-d dockerd[1732]: panic(0x1a9cb40, 0xc82000a080)
Nov 14 18:43:17 docker-demo9-d dockerd[1732]: /usr/local/go/src/runtime/panic.go:481 +0x3e6
Nov 14 18:43:17 docker-demo9-d dockerd[1732]: github.com/docker/libnetwork.(*sandbox).execFunc(0xc82026c000, 0xc820fae450)
Nov 14 18:43:17 docker-demo9-d dockerd[1732]: /root/rpmbuild/BUILD/docker-engine/vendor/src/github.com/docker/libnetwork/sandbox.go:440 +0x44
Nov 14 18:43:17 docker-demo9-d dockerd[1732]: github.com/docker/libnetwork.(*resolver).ServeDNS(0xc820427a70, 0x7fd91c0d5120, 0xc820e19810, 0xc820294120)
Nov 14 18:43:17 docker-demo9-d dockerd[1732]: /root/rpmbuild/BUILD/docker-engine/vendor/src/github.com/docker/libnetwork/resolver.go:357 +0x665
Nov 14 18:43:17 docker-demo9-d dockerd[1732]: github.com/miekg/dns.(*Server).serve(0xc821492820, 0x7fd9218f7a08, 0xc82158a120, 0x7fd91c0d4378, 0xc820427a70, 0xc8210d7200, 0x26, 0x200, 0xc82015e390, 0xc821b862a0, ...)
```

Its not clear in what can situation sb.osSbox can be nil for a running container. One possibility is the container going down while the query is still being processed. Added a error message which should help in identifying the specific case.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>