### PR TITLE
optimise endpoint cnt atomic increase

### DIFF
--- a/endpoint_cnt.go
+++ b/endpoint_cnt.go
@@ -3,7 +3,9 @@ package libnetwork
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"sync"
+	"time"
 
 	"github.com/docker/libnetwork/datastore"
 )
@@ -160,6 +162,7 @@ retry:
 				return fmt.Errorf("could not update the kvobject to latest when trying to atomic add endpoint count: %v", err)
 			}
 
+			time.Sleep(time.Duration(50+int(rand.Float32()*100)) * time.Millisecond)
 			goto retry
 		}
 


### PR DESCRIPTION
Avoid endpoint count update store conflict when starting containers in one network concurrency.