### PR TITLE
Redo "Enable ping for service vip address"

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -1148,20 +1148,3 @@ func (c *controller) cleanupLocalEndpoints() {
 		}
 	}
 }
-
-func (ep *endpoint) setAliasIP(sb *sandbox, ip net.IP, add bool) error {
-	sb.Lock()
-	sbox := sb.osSbox
-	sb.Unlock()
-
-	for _, i := range sbox.Info().Interfaces() {
-		if ep.hasInterface(i.SrcName()) {
-			ipNet := &net.IPNet{IP: ip, Mask: []byte{255, 255, 255, 255}}
-			if err := i.SetAliasIP(ipNet, add); err != nil {
-				return err
-			}
-			break
-		}
-	}
-	return nil
-}

--- a/osl/options_linux.go
+++ b/osl/options_linux.go
@@ -66,6 +66,12 @@ func (n *networkNamespace) LinkLocalAddresses(list []*net.IPNet) IfaceOption {
 	}
 }
 
+func (n *networkNamespace) IPAliases(list []*net.IPNet) IfaceOption {
+	return func(i *nwIface) {
+		i.ipAliases = list
+	}
+}
+
 func (n *networkNamespace) Routes(routes []*net.IPNet) IfaceOption {
 	return func(i *nwIface) {
 		i.routes = routes

--- a/osl/sandbox.go
+++ b/osl/sandbox.go
@@ -91,6 +91,9 @@ type IfaceOptionSetter interface {
 	// LinkLocalAddresses returns an option setter to set the link-local IP addresses.
 	LinkLocalAddresses([]*net.IPNet) IfaceOption
 
+	// IPAliases returns an option setter to set IP address Aliases
+	IPAliases([]*net.IPNet) IfaceOption
+
 	// Master returns an option setter to set the master interface if any for this
 	// interface. The master interface name should refer to the srcname of a
 	// previously added interface of type bridge.
@@ -147,6 +150,9 @@ type Interface interface {
 	// LinkLocalAddresses returns the link-local IP addresses assigned to the interface.
 	LinkLocalAddresses() []*net.IPNet
 
+	// IPAliases returns the IP address aliases assigned to the interface.
+	IPAliases() []*net.IPNet
+
 	// IP routes for the interface.
 	Routes() []*net.IPNet
 
@@ -159,10 +165,6 @@ type Interface interface {
 	// Remove an interface from the sandbox by renaming to original name
 	// and moving it out of the sandbox.
 	Remove() error
-
-	// SetAliasIP adds or deletes the passed IP as an alias on the interface.
-	// ex: set the vip of services in the same network as secondary IP.
-	SetAliasIP(ip *net.IPNet, add bool) error
 
 	// Statistics returns the statistics for this interface
 	Statistics() (*types.InterfaceStatistics, error)

--- a/sandbox.go
+++ b/sandbox.go
@@ -761,6 +761,10 @@ func (sb *sandbox) restoreOslSandbox() error {
 		if len(i.llAddrs) != 0 {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().LinkLocalAddresses(i.llAddrs))
 		}
+		if len(ep.virtualIP) != 0 {
+			vipAlias := &net.IPNet{IP: ep.virtualIP, Mask: net.CIDRMask(32, 32)}
+			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().IPAliases([]*net.IPNet{vipAlias}))
+		}
 		Ifaces[fmt.Sprintf("%s+%s", i.srcName, i.dstPrefix)] = ifaceOptions
 		if joinInfo != nil {
 			for _, r := range joinInfo.StaticRoutes {
@@ -813,6 +817,10 @@ func (sb *sandbox) populateNetworkResources(ep *endpoint) error {
 		}
 		if len(i.llAddrs) != 0 {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().LinkLocalAddresses(i.llAddrs))
+		}
+		if len(ep.virtualIP) != 0 {
+			vipAlias := &net.IPNet{IP: ep.virtualIP, Mask: net.CIDRMask(32, 32)}
+			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().IPAliases([]*net.IPNet{vipAlias}))
 		}
 		if i.mac != nil {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().MacAddress(i.mac))

--- a/service_linux.go
+++ b/service_linux.go
@@ -101,14 +101,6 @@ func (sb *sandbox) populateLoadbalancers(ep *endpoint) {
 		for _, ip := range lb.backEnds {
 			sb.addLBBackend(ip, lb.vip, lb.fwMark, lb.service.ingressPorts,
 				eIP, gwIP, addService, n.ingress)
-			// For a new service program the vip as an alias on the task's sandbox interface
-			// connected to this network.
-			if !addService {
-				continue
-			}
-			if err := ep.setAliasIP(sb, lb.vip, true); err != nil {
-				logrus.Errorf("Adding Service VIP %v to ep %v(%v) failed: %v", lb.vip, ep.ID(), ep.Name(), err)
-			}
 			addService = false
 		}
 		lb.service.Unlock()
@@ -132,16 +124,8 @@ func (n *network) addLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*Po
 			}
 
 			sb.addLBBackend(ip, vip, fwMark, ingressPorts, ep.Iface().Address(), gwIP, addService, n.ingress)
-
-			// For a new service program the vip as an alias on the task's sandbox interface
-			// connected to this network.
-			if !addService {
-				return false
-			}
-			if err := ep.setAliasIP(sb, vip, true); err != nil {
-				logrus.Errorf("Adding Service VIP %v to ep %v(%v) failed: %v", vip, ep.ID(), ep.Name(), err)
-			}
 		}
+
 		return false
 	})
 }
@@ -163,16 +147,8 @@ func (n *network) rmLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*Por
 			}
 
 			sb.rmLBBackend(ip, vip, fwMark, ingressPorts, ep.Iface().Address(), gwIP, rmService, n.ingress)
-
-			// If the service is being remove its vip alias on on the task's sandbox interface
-			// has to be removed as well.
-			if !rmService {
-				return false
-			}
-			if err := ep.setAliasIP(sb, vip, false); err != nil {
-				logrus.Errorf("Removing Service VIP %v from ep %v(%v) failed: %v", vip, ep.ID(), ep.Name(), err)
-			}
 		}
+
 		return false
 	})
 }

--- a/service_linux.go
+++ b/service_linux.go
@@ -654,6 +654,9 @@ func fwMarker() {
 	rule := strings.Fields(fmt.Sprintf("-t mangle %s OUTPUT -d %s/32 -j MARK --set-mark %d", addDelOpt, vip, fwMark))
 	rules = append(rules, rule)
 
+	rule = strings.Fields(fmt.Sprintf("-t nat %s OUTPUT -p icmp --icmp echo-request -d %s -j DNAT --to 127.0.0.1", addDelOpt, vip))
+	rules = append(rules, rule)
+
 	for _, rule := range rules {
 		if err := iptables.RawCombinedOutputNative(rule...); err != nil {
 			logrus.Errorf("setting up rule failed, %v: %v", rule, err)


### PR DESCRIPTION
This PR reverts #1501 because it causes docker/docker#28358.

Instead, (thanks to @jpetazzo) we will a ICMP reply NAT rule to the Service VIP which will do exactly what #1501 tried to achieve.

If we agree on this approach, we can close https://github.com/docker/libnetwork/pull/1565.