### PR TITLE
Remove unnecessary string formats

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -147,7 +147,7 @@ func TestSandboxOptionParser(t *testing.T) {
 	}
 
 	if len(sb.parseOptions()) != 9 {
-		t.Fatalf("Failed to generate all libnetwork.SandboxOption methods")
+		t.Fatal("Failed to generate all libnetwork.SandboxOption methods")
 	}
 }
 
@@ -205,7 +205,7 @@ func TestCreateDeleteNetwork(t *testing.T) {
 	vars := make(map[string]string)
 	_, errRsp := procCreateNetwork(c, nil, badBody)
 	if errRsp == &createdResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("Expected StatusBadRequest status code, got: %v", errRsp)
@@ -218,7 +218,7 @@ func TestCreateDeleteNetwork(t *testing.T) {
 
 	_, errRsp = procCreateNetwork(c, vars, incompleteBody)
 	if errRsp == &createdResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("Expected StatusBadRequest status code, got: %v", errRsp)
@@ -240,13 +240,13 @@ func TestCreateDeleteNetwork(t *testing.T) {
 	vars[urlNwName] = ""
 	_, errRsp = procDeleteNetwork(c, vars, nil)
 	if errRsp == &successResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 
 	vars[urlNwName] = "abc"
 	_, errRsp = procDeleteNetwork(c, vars, nil)
 	if errRsp == &successResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 
 	vars[urlNwName] = "network_1"
@@ -406,7 +406,7 @@ func TestGetNetworksAndEndpoints(t *testing.T) {
 		t.Fatalf("Did not return the expected number (2) of endpoint resources: %d", len(epList))
 	}
 	if "sh" != epList[0].Network || "sh" != epList[1].Network {
-		t.Fatalf("Did not find expected network name in endpoint resources")
+		t.Fatal("Did not find expected network name in endpoint resources")
 	}
 
 	vars = make(map[string]string)
@@ -458,7 +458,7 @@ func TestGetNetworksAndEndpoints(t *testing.T) {
 	}
 	netList := i2nL(iList)
 	if len(netList) != 1 {
-		t.Fatalf("Did not return the expected number of network resources")
+		t.Fatal("Did not return the expected number of network resources")
 	}
 	if nid != netList[0].ID {
 		t.Fatalf("Did not find expected network %s: %v", nid, netList)
@@ -509,7 +509,7 @@ func TestGetNetworksAndEndpoints(t *testing.T) {
 	}
 	netList = i2nL(iList)
 	if len(netList) != 0 {
-		t.Fatalf("Did not return the expected number of network resources")
+		t.Fatal("Did not return the expected number of network resources")
 	}
 }
 
@@ -700,7 +700,7 @@ func TestProcGetService(t *testing.T) {
 	vars := map[string]string{urlEpID: ""}
 	_, errRsp := procGetService(c, vars, nil)
 	if errRsp.isOK() {
-		t.Fatalf("Expected failure, but succeeded")
+		t.Fatal("Expected failure, but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("Expected %d, but got: %d", http.StatusBadRequest, errRsp.StatusCode)
@@ -709,7 +709,7 @@ func TestProcGetService(t *testing.T) {
 	vars[urlEpID] = "unknown-service-id"
 	_, errRsp = procGetService(c, vars, nil)
 	if errRsp.isOK() {
-		t.Fatalf("Expected failure, but succeeded")
+		t.Fatal("Expected failure, but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusNotFound {
 		t.Fatalf("Expected %d, but got: %d. (%v)", http.StatusNotFound, errRsp.StatusCode, errRsp)
@@ -750,7 +750,7 @@ func TestProcPublishUnpublishService(t *testing.T) {
 	}
 	_, errRsp := procPublishService(c, vars, vbad)
 	if errRsp == &createdResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("Expected %d. Got: %v", http.StatusBadRequest, errRsp)
@@ -762,7 +762,7 @@ func TestProcPublishUnpublishService(t *testing.T) {
 	}
 	_, errRsp = procPublishService(c, vars, b)
 	if errRsp == &createdResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("Expected %d. Got: %v", http.StatusBadRequest, errRsp)
@@ -774,7 +774,7 @@ func TestProcPublishUnpublishService(t *testing.T) {
 	}
 	_, errRsp = procPublishService(c, vars, b)
 	if errRsp == &createdResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("Expected %d. Got: %v", http.StatusBadRequest, errRsp)
@@ -786,7 +786,7 @@ func TestProcPublishUnpublishService(t *testing.T) {
 	}
 	_, errRsp = procPublishService(c, vars, b)
 	if errRsp == &createdResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusNotFound {
 		t.Fatalf("Expected %d. Got: %v", http.StatusNotFound, errRsp)
@@ -798,7 +798,7 @@ func TestProcPublishUnpublishService(t *testing.T) {
 	}
 	_, errRsp = procPublishService(c, vars, b)
 	if errRsp == &createdResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("Expected %d. Got: %v", http.StatusBadRequest, errRsp)
@@ -830,7 +830,7 @@ func TestProcPublishUnpublishService(t *testing.T) {
 	vars[urlEpID] = ""
 	_, errRsp = procUnpublishService(c, vars, nil)
 	if errRsp.isOK() {
-		t.Fatalf("Expected failure but succeeded")
+		t.Fatal("Expected failure but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("Expected %d. Got: %v", http.StatusBadRequest, errRsp)
@@ -839,7 +839,7 @@ func TestProcPublishUnpublishService(t *testing.T) {
 	vars[urlEpID] = "unknown-service-id"
 	_, errRsp = procUnpublishService(c, vars, nil)
 	if errRsp.isOK() {
-		t.Fatalf("Expected failure but succeeded")
+		t.Fatal("Expected failure but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusNotFound {
 		t.Fatalf("Expected %d. Got: %v", http.StatusNotFound, errRsp)
@@ -853,7 +853,7 @@ func TestProcPublishUnpublishService(t *testing.T) {
 
 	_, errRsp = procGetService(c, vars, nil)
 	if errRsp.isOK() {
-		t.Fatalf("Expected failure, but succeeded")
+		t.Fatal("Expected failure, but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusNotFound {
 		t.Fatalf("Expected %d, but got: %d. (%v)", http.StatusNotFound, errRsp.StatusCode, errRsp)
@@ -942,7 +942,7 @@ func TestAttachDetachBackend(t *testing.T) {
 
 	_, errRsp = procUnpublishService(c, vars, nil)
 	if errRsp.isOK() {
-		t.Fatalf("Expected failure but succeeded")
+		t.Fatal("Expected failure but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusForbidden {
 		t.Fatalf("Expected %d. Got: %v", http.StatusForbidden, errRsp)
@@ -1046,7 +1046,7 @@ func TestFindNetworkUtil(t *testing.T) {
 
 	_, errRsp := findNetwork(c, "", byName)
 	if errRsp == &successResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("Expected %d, but got: %d", http.StatusBadRequest, errRsp.StatusCode)
@@ -1057,7 +1057,7 @@ func TestFindNetworkUtil(t *testing.T) {
 		t.Fatalf("Unexpected failure: %v", errRsp)
 	}
 	if n == nil {
-		t.Fatalf("Unexpected nil libnetwork.Network")
+		t.Fatal("Unexpected nil libnetwork.Network")
 	}
 	if nid != n.ID() {
 		t.Fatalf("Incorrect libnetwork.Network resource. It has different id: %v", n)
@@ -1071,7 +1071,7 @@ func TestFindNetworkUtil(t *testing.T) {
 		t.Fatalf("Unexpected failure: %v", errRsp)
 	}
 	if n == nil {
-		t.Fatalf("Unexpected nil libnetwork.Network")
+		t.Fatal("Unexpected nil libnetwork.Network")
 	}
 	if nid != n.ID() {
 		t.Fatalf("Incorrect libnetwork.Network resource. It has different id: %v", n)
@@ -1086,7 +1086,7 @@ func TestFindNetworkUtil(t *testing.T) {
 
 	_, errRsp = findNetwork(c, nid, byID)
 	if errRsp == &successResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusNotFound {
 		t.Fatalf("Expected %d, but got: %d", http.StatusNotFound, errRsp.StatusCode)
@@ -1094,7 +1094,7 @@ func TestFindNetworkUtil(t *testing.T) {
 
 	_, errRsp = findNetwork(c, "network", byName)
 	if errRsp == &successResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 	if errRsp.StatusCode != http.StatusNotFound {
 		t.Fatalf("Expected %d, but got: %d", http.StatusNotFound, errRsp.StatusCode)
@@ -1134,7 +1134,7 @@ func TestCreateDeleteEndpoints(t *testing.T) {
 	vars[urlNwName] = "firstNet"
 	_, errRsp = procCreateEndpoint(c, vars, vbad)
 	if errRsp == &createdResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 
 	b, err := json.Marshal(endpointCreate{Name: ""})
@@ -1145,7 +1145,7 @@ func TestCreateDeleteEndpoints(t *testing.T) {
 	vars[urlNwName] = "secondNet"
 	_, errRsp = procCreateEndpoint(c, vars, b)
 	if errRsp == &createdResponse {
-		t.Fatalf("Expected to fail but succeeded")
+		t.Fatal("Expected to fail but succeeded")
 	}
 
 	vars[urlNwName] = "firstNet"
@@ -1318,7 +1318,7 @@ func TestJoinLeave(t *testing.T) {
 
 	keyStr := i2s(key)
 	if keyStr == "" {
-		t.Fatalf("Empty sandbox key")
+		t.Fatal("Empty sandbox key")
 	}
 	_, errRsp = procDeleteEndpoint(c, vars, nil)
 	if errRsp == &successResponse {
@@ -1460,7 +1460,7 @@ func TestFindEndpointUtil(t *testing.T) {
 
 	if ep0.ID() != ep1.ID() || ep0.ID() != ep2.ID() ||
 		ep0.ID() != ep3.ID() || ep0.ID() != ep4.ID() || ep0.ID() != ep5.ID() {
-		t.Fatalf("Diffenrent queries returned different endpoints")
+		t.Fatal("Diffenrent queries returned different endpoints")
 	}
 
 	ep.Delete(false)
@@ -1534,7 +1534,7 @@ func checkPanic(t *testing.T) {
 			panic(r)
 		}
 	} else {
-		t.Fatalf("Expected to panic, but succeeded")
+		t.Fatal("Expected to panic, but succeeded")
 	}
 }
 
@@ -1597,12 +1597,12 @@ func TestResponseStatus(t *testing.T) {
 
 	r := responseStatus{StatusCode: http.StatusOK}
 	if !r.isOK() {
-		t.Fatalf("isOK() failed")
+		t.Fatal("isOK() failed")
 	}
 
 	r = responseStatus{StatusCode: http.StatusCreated}
 	if !r.isOK() {
-		t.Fatalf("isOK() failed")
+		t.Fatal("isOK() failed")
 	}
 }
 
@@ -1623,7 +1623,7 @@ func (l *localReader) Read(p []byte) (n int, err error) {
 		return 0, errors.New("I am a bad reader")
 	}
 	if p == nil {
-		return -1, fmt.Errorf("nil buffer passed")
+		return -1, errors.New("nil buffer passed")
 	}
 	if l.data == nil || len(l.data) == 0 {
 		return 0, io.EOF
@@ -1647,7 +1647,7 @@ func (f *localResponseWriter) Header() http.Header {
 
 func (f *localResponseWriter) Write(data []byte) (int, error) {
 	if data == nil {
-		return -1, fmt.Errorf("nil data passed")
+		return -1, errors.New("nil data passed")
 	}
 
 	f.body = make([]byte, len(data))
@@ -1699,7 +1699,7 @@ func TestHttpHandlerUninit(t *testing.T) {
 	h := &httpHandler{c: c}
 	h.initRouter()
 	if h.r == nil {
-		t.Fatalf("initRouter() did not initialize the router")
+		t.Fatal("initRouter() did not initialize the router")
 	}
 
 	rsp := newWriter()
@@ -1745,10 +1745,10 @@ func TestHttpHandlerUninit(t *testing.T) {
 		t.Fatalf("Unexpectded failure: (%d): %s", rsp.statusCode, rsp.body)
 	}
 	if len(rsp.body) == 0 {
-		t.Fatalf("Empty list of networks")
+		t.Fatal("Empty list of networks")
 	}
 	if bytes.Equal(rsp.body, expected) {
-		t.Fatalf("Incorrect list of networks in response's body")
+		t.Fatal("Incorrect list of networks in response's body")
 	}
 }
 
@@ -1823,7 +1823,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatalf("Unexpectded status code. Expected (%d). Got (%d): %s.", http.StatusCreated, rsp.statusCode, string(rsp.body))
 	}
 	if len(rsp.body) == 0 {
-		t.Fatalf("Empty response body")
+		t.Fatal("Empty response body")
 	}
 
 	var nid string
@@ -1872,7 +1872,7 @@ func TestEndToEnd(t *testing.T) {
 	}
 
 	if !bytes.Equal(b0, rsp.body) {
-		t.Fatalf("Expected same body from GET /networks and GET /networks?name=<nw> when only network <nw> exist.")
+		t.Fatal("Expected same body from GET /networks and GET /networks?name=<nw> when only network <nw> exist.")
 	}
 
 	// Query network by name
@@ -1907,7 +1907,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(list) == 0 {
-		t.Fatalf("Expected non empty list")
+		t.Fatal("Expected non empty list")
 	}
 	if list[0].Name != "network-fiftyfive" || nid != list[0].ID {
 		t.Fatalf("Incongruent resource found: %v", list[0])
@@ -1930,7 +1930,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(list) == 0 {
-		t.Fatalf("Expected non empty list")
+		t.Fatal("Expected non empty list")
 	}
 	if list[0].Name != "network-fiftyfive" || nid != list[0].ID {
 		t.Fatalf("Incongruent resource found: %v", list[0])
@@ -1971,7 +1971,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatalf("Unexpectded status code. Expected (%d). Got (%d): %s.", http.StatusCreated, rsp.statusCode, string(rsp.body))
 	}
 	if len(rsp.body) == 0 {
-		t.Fatalf("Empty response body")
+		t.Fatal("Empty response body")
 	}
 
 	var eid string
@@ -2022,7 +2022,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(epList) == 0 {
-		t.Fatalf("Empty response body")
+		t.Fatal("Empty response body")
 	}
 	if epList[0].Name != "ep-TwentyTwo" || eid != epList[0].ID {
 		t.Fatalf("Incongruent resource found: %v", epList[0])
@@ -2045,7 +2045,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(epList) == 0 {
-		t.Fatalf("Empty response body")
+		t.Fatal("Empty response body")
 	}
 	if epList[0].Name != "ep-TwentyTwo" || eid != epList[0].ID {
 		t.Fatalf("Incongruent resource found: %v", epList[0])
@@ -2095,7 +2095,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatalf("Unexpectded status code. Expected (%d). Got (%d): %s.", http.StatusCreated, rsp.statusCode, string(rsp.body))
 	}
 	if len(rsp.body) == 0 {
-		t.Fatalf("Empty response body")
+		t.Fatal("Empty response body")
 	}
 	// Get sandbox id and partial id
 	var sid1 string
@@ -2122,7 +2122,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatalf("Unexpectded status code. Expected (%d). Got (%d): %s.", http.StatusCreated, rsp.statusCode, string(rsp.body))
 	}
 	if len(rsp.body) == 0 {
-		t.Fatalf("Empty response body")
+		t.Fatal("Empty response body")
 	}
 	// Get sandbox id and partial id
 	var sid2 string
@@ -2186,7 +2186,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(sbList) == 0 {
-		t.Fatalf("Empty response body")
+		t.Fatal("Empty response body")
 	}
 	if sbList[0].ID != sid2 {
 		t.Fatalf("Incongruent resource found: %v", sbList[0])
@@ -2207,7 +2207,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(sbList) == 0 {
-		t.Fatalf("Empty response body")
+		t.Fatal("Empty response body")
 	}
 	if sbList[0].ContainerID != cid2 {
 		t.Fatalf("Incongruent resource found: %v", sbList[0])
@@ -2228,7 +2228,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(sbList) == 0 {
-		t.Fatalf("Empty response body")
+		t.Fatal("Empty response body")
 	}
 	if sbList[0].ContainerID != cid1 {
 		t.Fatalf("Incongruent resource found: %v", sbList[0])
@@ -2259,11 +2259,11 @@ func TestEndToEndErrorMessage(t *testing.T) {
 	handleRequest(rsp, req)
 
 	if len(rsp.body) == 0 {
-		t.Fatalf("Empty response body.")
+		t.Fatal("Empty response body.")
 	}
 	empty := []byte("\"\"")
 	if bytes.Equal(empty, bytes.TrimSpace(rsp.body)) {
-		t.Fatalf("Empty response error message.")
+		t.Fatal("Empty response error message.")
 	}
 }
 
@@ -2324,35 +2324,35 @@ func (noc *notclassified) Error() string {
 
 func TestErrorConversion(t *testing.T) {
 	if convertNetworkError(new(bre)).StatusCode != http.StatusBadRequest {
-		t.Fatalf("Failed to recognize BadRequest error")
+		t.Fatal("Failed to recognize BadRequest error")
 	}
 
 	if convertNetworkError(new(nfe)).StatusCode != http.StatusNotFound {
-		t.Fatalf("Failed to recognize NotFound error")
+		t.Fatal("Failed to recognize NotFound error")
 	}
 
 	if convertNetworkError(new(forb)).StatusCode != http.StatusForbidden {
-		t.Fatalf("Failed to recognize Forbidden error")
+		t.Fatal("Failed to recognize Forbidden error")
 	}
 
 	if convertNetworkError(new(notimpl)).StatusCode != http.StatusNotImplemented {
-		t.Fatalf("Failed to recognize NotImplemented error")
+		t.Fatal("Failed to recognize NotImplemented error")
 	}
 
 	if convertNetworkError(new(inter)).StatusCode != http.StatusInternalServerError {
-		t.Fatalf("Failed to recognize Internal error")
+		t.Fatal("Failed to recognize Internal error")
 	}
 
 	if convertNetworkError(new(tout)).StatusCode != http.StatusRequestTimeout {
-		t.Fatalf("Failed to recognize Timeout error")
+		t.Fatal("Failed to recognize Timeout error")
 	}
 
 	if convertNetworkError(new(noserv)).StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("Failed to recognize No Service error")
+		t.Fatal("Failed to recognize No Service error")
 	}
 
 	if convertNetworkError(new(notclassified)).StatusCode != http.StatusInternalServerError {
-		t.Fatalf("Failed to recognize not classified error as Internal error")
+		t.Fatal("Failed to recognize not classified error as Internal error")
 	}
 }
 
@@ -2361,23 +2361,23 @@ func TestFieldRegex(t *testing.T) {
 	qr := regexp.MustCompile(`^` + qregx + `$`) // mux compiles it like this
 
 	if pr.MatchString("") {
-		t.Fatalf("Unexpected match")
+		t.Fatal("Unexpected match")
 	}
 	if !qr.MatchString("") {
-		t.Fatalf("Unexpected match failure")
+		t.Fatal("Unexpected match failure")
 	}
 
 	if pr.MatchString(":") {
-		t.Fatalf("Unexpected match")
+		t.Fatal("Unexpected match")
 	}
 	if qr.MatchString(":") {
-		t.Fatalf("Unexpected match")
+		t.Fatal("Unexpected match")
 	}
 
 	if pr.MatchString(".") {
-		t.Fatalf("Unexpected match")
+		t.Fatal("Unexpected match")
 	}
 	if qr.MatchString(".") {
-		t.Fatalf("Unexpected match")
+		t.Fatal("Unexpected match")
 	}
 }

--- a/bitseq/sequence.go
+++ b/bitseq/sequence.go
@@ -6,6 +6,7 @@ package bitseq
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -26,9 +27,9 @@ const (
 
 var (
 	// ErrNoBitAvailable is returned when no more bits are available to set
-	ErrNoBitAvailable = fmt.Errorf("no bit available")
+	ErrNoBitAvailable = errors.New("no bit available")
 	// ErrBitAllocated is returned when the specific bit requested is already set
-	ErrBitAllocated = fmt.Errorf("requested bit is already allocated")
+	ErrBitAllocated = errors.New("requested bit is already allocated")
 )
 
 // Handle contains the sequece representing the bitmask and its identifier
@@ -373,7 +374,7 @@ func (h *Handle) validateOrdinal(ordinal uint64) error {
 	h.Lock()
 	defer h.Unlock()
 	if ordinal >= h.bits {
-		return fmt.Errorf("bit does not belong to the sequence")
+		return errors.New("bit does not belong to the sequence")
 	}
 	return nil
 }
@@ -418,7 +419,7 @@ func (h *Handle) ToByteArray() ([]byte, error) {
 // FromByteArray reads his handle's data from a byte array
 func (h *Handle) FromByteArray(ba []byte) error {
 	if ba == nil {
-		return fmt.Errorf("nil byte array")
+		return errors.New("nil byte array")
 	}
 
 	nh := &sequence{}

--- a/bitseq/sequence_test.go
+++ b/bitseq/sequence_test.go
@@ -145,10 +145,10 @@ func TestSequenceCopy(t *testing.T) {
 	s := getTestSequence()
 	n := s.getCopy()
 	if !s.equal(n) {
-		t.Fatalf("copy of s failed")
+		t.Fatal("copy of s failed")
 	}
 	if n == s {
-		t.Fatalf("not true copy of s")
+		t.Fatal("not true copy of s")
 	}
 }
 
@@ -556,7 +556,7 @@ func TestSet(t *testing.T) {
 	}
 
 	if err := hnd.Set(0); err == nil {
-		t.Fatalf("Expected failure, but succeeded")
+		t.Fatal("Expected failure, but succeeded")
 	}
 
 	os, err := hnd.SetAny()
@@ -583,7 +583,7 @@ func TestSet(t *testing.T) {
 	}
 
 	if err := hnd.Set(last); err == nil {
-		t.Fatalf("Expected failure, but succeeded")
+		t.Fatal("Expected failure, but succeeded")
 	}
 }
 
@@ -595,10 +595,10 @@ func TestSetUnset(t *testing.T) {
 	}
 
 	if err := hnd.Set(uint64(32 * blockLen)); err == nil {
-		t.Fatalf("Expected failure, but succeeded")
+		t.Fatal("Expected failure, but succeeded")
 	}
 	if err := hnd.Unset(uint64(32 * blockLen)); err == nil {
-		t.Fatalf("Expected failure, but succeeded")
+		t.Fatal("Expected failure, but succeeded")
 	}
 
 	// set and unset all one by one
@@ -608,10 +608,10 @@ func TestSetUnset(t *testing.T) {
 		}
 	}
 	if _, err := hnd.SetAny(); err != ErrNoBitAvailable {
-		t.Fatalf("Expected error. Got success")
+		t.Fatal("Expected error. Got success")
 	}
 	if _, err := hnd.SetAnyInRange(10, 20); err != ErrNoBitAvailable {
-		t.Fatalf("Expected error. Got success")
+		t.Fatal("Expected error. Got success")
 	}
 	if err := hnd.Set(50); err != ErrBitAllocated {
 		t.Fatalf("Expected error. Got %v: %s", err, hnd)

--- a/client/client_service_test.go
+++ b/client/client_service_test.go
@@ -13,7 +13,7 @@ func TestClientServiceInvalidCommand(t *testing.T) {
 
 	err := cli.Cmd("docker", "service", "invalid")
 	if err == nil {
-		t.Fatalf("Passing invalid commands must fail")
+		t.Fatal("Passing invalid commands must fail")
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -114,7 +114,7 @@ func TestClientDummyCommand(t *testing.T) {
 
 	err := cli.Cmd("docker", "dummy")
 	if err == nil {
-		t.Fatalf("Incorrect Command must fail")
+		t.Fatal("Incorrect Command must fail")
 	}
 }
 
@@ -124,7 +124,7 @@ func TestClientNetworkInvalidCommand(t *testing.T) {
 
 	err := cli.Cmd("docker", "network", "invalid")
 	if err == nil {
-		t.Fatalf("Passing invalid commands must fail")
+		t.Fatal("Passing invalid commands must fail")
 	}
 }
 
@@ -144,7 +144,7 @@ func TestClientNetworkCreateWithDriver(t *testing.T) {
 
 	err := cli.Cmd("docker", "network", "create", "-f=dummy", mockNwName)
 	if err == nil {
-		t.Fatalf("Passing incorrect flags to the create command must fail")
+		t.Fatal("Passing incorrect flags to the create command must fail")
 	}
 
 	err = cli.Cmd("docker", "network", "create", "-d=dummy", mockNwName)

--- a/client/mflag/flag_test.go
+++ b/client/mflag/flag_test.go
@@ -72,7 +72,7 @@ func TestEverything(t *testing.T) {
 	m = make(map[string]*Flag)
 	Visit(visitor)
 	if len(m) != 0 {
-		t.Errorf("Visit sees unset flags")
+		t.Error("Visit sees unset flags")
 		for k, v := range m {
 			t.Log(k, *v)
 		}

--- a/client/service.go
+++ b/client/service.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -111,9 +112,9 @@ func lookupContainerID(cli *NetworkCli, cnNameID string) (string, error) {
 		if id, ok := iid.(string); ok {
 			return id, nil
 		}
-		return "", fmt.Errorf("Unexpected data type for container ID in json response")
+		return "", errors.New("Unexpected data type for container ID in json response")
 	}
-	return "", fmt.Errorf("Cannot find container ID in json response")
+	return "", errors.New("Cannot find container ID in json response")
 }
 
 func lookupSandboxID(cli *NetworkCli, containerID string) (string, error) {

--- a/cmd/dnet/cmd.go
+++ b/cmd/dnet/cmd.go
@@ -44,7 +44,7 @@ var (
 
 func runContainerCreate(c *cli.Context) {
 	if len(c.Args()) == 0 {
-		fmt.Print("Please provide container id argument\n")
+		fmt.Println("Please provide container id argument")
 		os.Exit(1)
 	}
 
@@ -70,7 +70,7 @@ func runContainerRm(c *cli.Context) {
 	var sbList []*client.SandboxResource
 
 	if len(c.Args()) == 0 {
-		fmt.Print("Please provide container id argument\n")
+		fmt.Println("Please provide container id argument")
 		os.Exit(1)
 	}
 

--- a/cmd/dnet/cmd.go
+++ b/cmd/dnet/cmd.go
@@ -44,7 +44,7 @@ var (
 
 func runContainerCreate(c *cli.Context) {
 	if len(c.Args()) == 0 {
-		fmt.Printf("Please provide container id argument\n")
+		fmt.Print("Please provide container id argument\n")
 		os.Exit(1)
 	}
 
@@ -70,7 +70,7 @@ func runContainerRm(c *cli.Context) {
 	var sbList []*client.SandboxResource
 
 	if len(c.Args()) == 0 {
-		fmt.Printf("Please provide container id argument\n")
+		fmt.Print("Please provide container id argument\n")
 		os.Exit(1)
 	}
 

--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -134,7 +134,7 @@ func processConfig(cfg *config.Config) []config.Option {
 
 func startDiscovery(cfg *config.ClusterCfg) ([]config.Option, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("discovery requires a valid configuration")
+		return nil, errors.New("discovery requires a valid configuration")
 	}
 
 	hb := time.Duration(cfg.Heartbeat) * time.Second
@@ -367,7 +367,7 @@ func startTestDriver() error {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	if server == nil {
-		return fmt.Errorf("Failed to start an HTTP Server")
+		return errors.New("Failed to start an HTTP Server")
 	}
 
 	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
@@ -377,37 +377,37 @@ func startTestDriver() error {
 
 	mux.HandleFunc(fmt.Sprintf("/%s.GetCapabilities", driverapi.NetworkPluginEndpointType), func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
-		fmt.Fprintf(w, `{"Scope":"global"}`)
+		fmt.Fprint(w, `{"Scope":"global"}`)
 	})
 
 	mux.HandleFunc(fmt.Sprintf("/%s.CreateNetwork", driverapi.NetworkPluginEndpointType), func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
-		fmt.Fprintf(w, "null")
+		fmt.Fprint(w, "null")
 	})
 
 	mux.HandleFunc(fmt.Sprintf("/%s.DeleteNetwork", driverapi.NetworkPluginEndpointType), func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
-		fmt.Fprintf(w, "null")
+		fmt.Fprint(w, "null")
 	})
 
 	mux.HandleFunc(fmt.Sprintf("/%s.CreateEndpoint", driverapi.NetworkPluginEndpointType), func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
-		fmt.Fprintf(w, "null")
+		fmt.Fprint(w, "null")
 	})
 
 	mux.HandleFunc(fmt.Sprintf("/%s.DeleteEndpoint", driverapi.NetworkPluginEndpointType), func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
-		fmt.Fprintf(w, "null")
+		fmt.Fprint(w, "null")
 	})
 
 	mux.HandleFunc(fmt.Sprintf("/%s.Join", driverapi.NetworkPluginEndpointType), func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
-		fmt.Fprintf(w, "null")
+		fmt.Fprint(w, "null")
 	})
 
 	mux.HandleFunc(fmt.Sprintf("/%s.Leave", driverapi.NetworkPluginEndpointType), func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
-		fmt.Fprintf(w, "null")
+		fmt.Fprint(w, "null")
 	})
 
 	if err := os.MkdirAll("/etc/docker/plugins", 0755); err != nil {
@@ -428,10 +428,10 @@ func newDnetConnection(val string) (*dnetConnection, error) {
 	}
 	protoAddrParts := strings.SplitN(url, "://", 2)
 	if len(protoAddrParts) != 2 {
-		return nil, fmt.Errorf("bad format, expected tcp://ADDR")
+		return nil, errors.New("bad format, expected tcp://ADDR")
 	}
 	if strings.ToLower(protoAddrParts[0]) != "tcp" {
-		return nil, fmt.Errorf("dnet currently only supports tcp transport")
+		return nil, errors.New("dnet currently only supports tcp transport")
 	}
 
 	return &dnetConnection{protoAddrParts[0], protoAddrParts[1], &NetworkOrchestration{}, make(chan struct{}, 10)}, nil

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"errors"
 	"net"
 )
 
@@ -32,6 +31,6 @@ func NewProxy(frontendAddr, backendAddr net.Addr) (Proxy, error) {
 	case *net.TCPAddr:
 		return NewTCPProxy(frontendAddr.(*net.TCPAddr), backendAddr.(*net.TCPAddr))
 	default:
-		panic(errors.New("Unsupported protocol"))
+		panic("Unsupported protocol")
 	}
 }

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"net"
 )
 
@@ -32,6 +32,6 @@ func NewProxy(frontendAddr, backendAddr net.Addr) (Proxy, error) {
 	case *net.TCPAddr:
 		return NewTCPProxy(frontendAddr.(*net.TCPAddr), backendAddr.(*net.TCPAddr))
 	default:
-		panic(fmt.Errorf("Unsupported protocol"))
+		panic(errors.New("Unsupported protocol"))
 	}
 }

--- a/cmd/readme_test/readme.go
+++ b/cmd/readme_test/readme.go
@@ -67,7 +67,7 @@ func main() {
 
 	macAddress, ok := epInfo[netlabel.MacAddress]
 	if !ok {
-		log.Fatalf("failed to get mac address from endpoint info")
+		log.Fatal("failed to get mac address from endpoint info")
 	}
 
 	fmt.Printf("Joined endpoint %s (%s) to sandbox %s (%s)\n", ep.Name(), macAddress, sbx.ContainerID(), sbx.Key())

--- a/datastore/cache.go
+++ b/datastore/cache.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -36,7 +37,7 @@ func (c *cache) kmap(kvObject KVObject) (kvMap, error) {
 	// Bail out right away if the kvObject does not implement KVConstructor
 	ctor, ok := kvObject.(KVConstructor)
 	if !ok {
-		return nil, fmt.Errorf("error while populating kmap, object does not implement KVConstructor interface")
+		return nil, errors.New("error while populating kmap, object does not implement KVConstructor interface")
 	}
 
 	kvList, err := c.ds.store.List(keyPrefix)
@@ -153,7 +154,7 @@ func (c *cache) get(key string, kvObject KVObject) error {
 
 	ctor, ok := o.(KVConstructor)
 	if !ok {
-		return fmt.Errorf("kvobject does not implement KVConstructor interface. could not get object")
+		return errors.New("kvobject does not implement KVConstructor interface. could not get object")
 	}
 
 	return ctor.CopyTo(kvObject)

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -61,7 +61,7 @@ func TestKVObjectFlatKey(t *testing.T) {
 	var n dummyObject
 	json.Unmarshal(data.Value, &n)
 	if n.Name != expected.Name {
-		t.Fatalf("Dummy object doesn't match the expected object")
+		t.Fatal("Dummy object doesn't match the expected object")
 	}
 }
 

--- a/driverapi/driverapi_test.go
+++ b/driverapi/driverapi_test.go
@@ -66,14 +66,14 @@ func TestValidateAndIsV6(t *testing.T) {
 
 	// Check ip version
 	if i.IsV6() {
-		t.Fatalf("incorrect ip version returned")
+		t.Fatal("incorrect ip version returned")
 	}
 	orig := i.Pool
 	if i.Pool, err = types.ParseCIDR("2001:db8::33/64"); err != nil {
 		t.Fatal(err)
 	}
 	if !i.IsV6() {
-		t.Fatalf("incorrect ip version returned")
+		t.Fatal("incorrect ip version returned")
 	}
 	i.Pool = orig
 
@@ -87,7 +87,7 @@ func TestValidateAndIsV6(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err = i.Validate(); err == nil {
-		t.Fatalf("expected error but succeeded")
+		t.Fatal("expected error but succeeded")
 	}
 	i.Gateway = nil
 
@@ -96,7 +96,7 @@ func TestValidateAndIsV6(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err = i.Validate(); err == nil {
-		t.Fatalf("expected error but succeeded")
+		t.Fatal("expected error but succeeded")
 	}
 	delete(i.AuxAddresses, "ip2")
 
@@ -105,7 +105,7 @@ func TestValidateAndIsV6(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err = i.Validate(); err == nil {
-		t.Fatalf("expected error but succeeded")
+		t.Fatal("expected error but succeeded")
 	}
 	i.Gateway = nil
 
@@ -114,6 +114,6 @@ func TestValidateAndIsV6(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err = i.Validate(); err == nil {
-		t.Fatalf("expected error but succeeded")
+		t.Fatal("expected error but succeeded")
 	}
 }

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -186,24 +186,24 @@ func (c *networkConfiguration) Validate() error {
 // Conflicts check if two NetworkConfiguration objects overlap
 func (c *networkConfiguration) Conflicts(o *networkConfiguration) error {
 	if o == nil {
-		return fmt.Errorf("same configuration")
+		return errors.New("same configuration")
 	}
 
 	// Also empty, because only one network with empty name is allowed
 	if c.BridgeName == o.BridgeName {
-		return fmt.Errorf("networks have same bridge name")
+		return errors.New("networks have same bridge name")
 	}
 
 	// They must be in different subnets
 	if (c.AddressIPv4 != nil && o.AddressIPv4 != nil) &&
 		(c.AddressIPv4.Contains(o.AddressIPv4.IP) || o.AddressIPv4.Contains(c.AddressIPv4.IP)) {
-		return fmt.Errorf("networks have overlapping IPv4")
+		return errors.New("networks have overlapping IPv4")
 	}
 
 	// They must be in different v6 subnets
 	if (c.AddressIPv6 != nil && o.AddressIPv6 != nil) &&
 		(c.AddressIPv6.Contains(o.AddressIPv6.IP) || o.AddressIPv6.Contains(c.AddressIPv6.IP)) {
-		return fmt.Errorf("networks have overlapping IPv6")
+		return errors.New("networks have overlapping IPv6")
 	}
 
 	return nil

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -300,23 +300,23 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 
 	nw, ok := d.networks["dummy"]
 	if !ok {
-		t.Fatalf("Cannot find dummy network in bridge driver")
+		t.Fatal("Cannot find dummy network in bridge driver")
 	}
 
 	if nw.config.BridgeName != DefaultBridgeName {
-		t.Fatalf("incongruent name in bridge network")
+		t.Fatal("incongruent name in bridge network")
 	}
 
 	if !nw.config.EnableIPv6 {
-		t.Fatalf("incongruent EnableIPv6 in bridge network")
+		t.Fatal("incongruent EnableIPv6 in bridge network")
 	}
 
 	if !nw.config.EnableICC {
-		t.Fatalf("incongruent EnableICC in bridge network")
+		t.Fatal("incongruent EnableICC in bridge network")
 	}
 
 	if !nw.config.EnableIPMasquerade {
-		t.Fatalf("incongruent EnableIPMasquerade in bridge network")
+		t.Fatal("incongruent EnableIPMasquerade in bridge network")
 	}
 
 	bndIP := net.ParseIP(bndIPs)
@@ -371,10 +371,10 @@ func TestCreate(t *testing.T) {
 
 	err := d.CreateNetwork("dummy", genericOption, nil, getIPv4Data(t, ""), nil)
 	if err == nil {
-		t.Fatalf("Expected bridge driver to refuse creation of second network with default name")
+		t.Fatal("Expected bridge driver to refuse creation of second network with default name")
 	}
 	if _, ok := err.(types.ForbiddenError); !ok {
-		t.Fatalf("Creation of second network with default name failed with unexpected error type")
+		t.Fatal("Creation of second network with default name failed with unexpected error type")
 	}
 }
 
@@ -662,18 +662,18 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 	}
 	pmd, ok := data[netlabel.PortMap]
 	if !ok {
-		t.Fatalf("Endpoint operational data does not contain port mapping data")
+		t.Fatal("Endpoint operational data does not contain port mapping data")
 	}
 	pm, ok := pmd.([]types.PortBinding)
 	if !ok {
-		t.Fatalf("Unexpected format for port mapping in endpoint operational data")
+		t.Fatal("Unexpected format for port mapping in endpoint operational data")
 	}
 	if len(ep.portMapping) != len(pm) {
-		t.Fatalf("Incomplete data for port mapping in endpoint operational data")
+		t.Fatal("Incomplete data for port mapping in endpoint operational data")
 	}
 	for i, pb := range ep.portMapping {
 		if !pb.Equal(&pm[i]) {
-			t.Fatalf("Unexpected data for port mapping in endpoint operational data")
+			t.Fatal("Unexpected data for port mapping in endpoint operational data")
 		}
 	}
 
@@ -757,7 +757,7 @@ func TestLinkContainers(t *testing.T) {
 
 	addr1 := te1.iface.addr
 	if addr1.IP.To4() == nil {
-		t.Fatalf("No Ipv4 address assigned to the endpoint:  ep1")
+		t.Fatal("No Ipv4 address assigned to the endpoint:  ep1")
 	}
 
 	te2 := newTestEndpoint(ipdList[0].Pool, 22)
@@ -768,7 +768,7 @@ func TestLinkContainers(t *testing.T) {
 
 	addr2 := te2.iface.addr
 	if addr2.IP.To4() == nil {
-		t.Fatalf("No Ipv4 address assigned to the endpoint:  ep2")
+		t.Fatal("No Ipv4 address assigned to the endpoint:  ep2")
 	}
 
 	sbOptions = make(map[string]interface{})
@@ -778,7 +778,7 @@ func TestLinkContainers(t *testing.T) {
 
 	err = d.Join("net1", "ep2", "", te2, sbOptions)
 	if err != nil {
-		t.Fatalf("Failed to link ep1 and ep2")
+		t.Fatal("Failed to link ep1 and ep2")
 	}
 
 	err = d.ProgramExternalConnectivity("net1", "ep2", sbOptions)
@@ -809,7 +809,7 @@ func TestLinkContainers(t *testing.T) {
 
 	err = d.Leave("net1", "ep2")
 	if err != nil {
-		t.Fatalf("Failed to unlink ep1 and ep2")
+		t.Fatal("Failed to unlink ep1 and ep2")
 	}
 
 	out, err = iptables.Raw("-L", DockerChain)
@@ -856,7 +856,7 @@ func TestLinkContainers(t *testing.T) {
 			}
 		}
 	} else {
-		t.Fatalf("Expected Join to fail given link conditions are not satisfied")
+		t.Fatal("Expected Join to fail given link conditions are not satisfied")
 	}
 }
 
@@ -869,13 +869,13 @@ func TestValidateConfig(t *testing.T) {
 	c := networkConfiguration{Mtu: -2}
 	err := c.Validate()
 	if err == nil {
-		t.Fatalf("Failed to detect invalid MTU number")
+		t.Fatal("Failed to detect invalid MTU number")
 	}
 
 	c.Mtu = 9000
 	err = c.Validate()
 	if err != nil {
-		t.Fatalf("unexpected validation error on MTU number")
+		t.Fatal("unexpected validation error on MTU number")
 	}
 
 	// Bridge network
@@ -893,13 +893,13 @@ func TestValidateConfig(t *testing.T) {
 	c.DefaultGatewayIPv4 = net.ParseIP("172.27.30.234")
 	err = c.Validate()
 	if err == nil {
-		t.Fatalf("Failed to detect invalid default gateway")
+		t.Fatal("Failed to detect invalid default gateway")
 	}
 
 	c.DefaultGatewayIPv4 = net.ParseIP("172.28.30.234")
 	err = c.Validate()
 	if err != nil {
-		t.Fatalf("Unexpected validation error on default gateway")
+		t.Fatal("Unexpected validation error on default gateway")
 	}
 
 	// Test v6 gw
@@ -911,25 +911,25 @@ func TestValidateConfig(t *testing.T) {
 	}
 	err = c.Validate()
 	if err == nil {
-		t.Fatalf("Failed to detect invalid v6 default gateway")
+		t.Fatal("Failed to detect invalid v6 default gateway")
 	}
 
 	c.DefaultGatewayIPv6 = net.ParseIP("2001:db8:ae:b004::bad:a55")
 	err = c.Validate()
 	if err != nil {
-		t.Fatalf("Unexpected validation error on v6 default gateway")
+		t.Fatal("Unexpected validation error on v6 default gateway")
 	}
 
 	c.AddressIPv6 = nil
 	err = c.Validate()
 	if err == nil {
-		t.Fatalf("Failed to detect invalid v6 default gateway")
+		t.Fatal("Failed to detect invalid v6 default gateway")
 	}
 
 	c.AddressIPv6 = nil
 	err = c.Validate()
 	if err == nil {
-		t.Fatalf("Failed to detect invalid v6 default gateway")
+		t.Fatal("Failed to detect invalid v6 default gateway")
 	}
 }
 
@@ -1068,6 +1068,6 @@ func TestCreateWithExistingBridge(t *testing.T) {
 	}
 
 	if _, err := netlink.LinkByName(brName); err != nil {
-		t.Fatalf("Deleting bridge network that using existing bridge interface unexpectedly deleted the bridge interface")
+		t.Fatal("Deleting bridge network that using existing bridge interface unexpectedly deleted the bridge interface")
 	}
 }

--- a/drivers/bridge/network_test.go
+++ b/drivers/bridge/network_test.go
@@ -39,7 +39,7 @@ func TestLinkCreate(t *testing.T) {
 			t.Fatalf("Failed with a wrong error :%s", err.Error())
 		}
 	} else {
-		t.Fatalf("Failed to detect invalid config")
+		t.Fatal("Failed to detect invalid config")
 	}
 
 	// Good endpoint creation
@@ -59,7 +59,7 @@ func TestLinkCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 	if mtu != sboxLnk.Attrs().MTU {
-		t.Fatalf("Sandbox endpoint interface did not inherit bridge interface MTU config")
+		t.Fatal("Sandbox endpoint interface did not inherit bridge interface MTU config")
 	}
 	// TODO: if we could get peer name from (sboxLnk.(*netlink.Veth)).PeerName
 	// then we could check the MTU on hostLnk as well.
@@ -67,7 +67,7 @@ func TestLinkCreate(t *testing.T) {
 	te1 := newTestEndpoint(ipdList[0].Pool, 11)
 	err = d.CreateEndpoint("dummy", "ep", te1.Interface(), nil)
 	if err == nil {
-		t.Fatalf("Failed to detect duplicate endpoint id on same network")
+		t.Fatal("Failed to detect duplicate endpoint id on same network")
 	}
 
 	if te.iface.dstName == "" {
@@ -137,7 +137,7 @@ func TestLinkCreateTwo(t *testing.T) {
 			t.Fatalf("Failed with a wrong error: %s", err.Error())
 		}
 	} else {
-		t.Fatalf("Expected to fail while trying to add same endpoint twice")
+		t.Fatal("Expected to fail while trying to add same endpoint twice")
 	}
 }
 
@@ -207,7 +207,7 @@ func TestLinkDelete(t *testing.T) {
 			t.Fatalf("Failed with a wrong error :%s", err.Error())
 		}
 	} else {
-		t.Fatalf("Failed to detect invalid config")
+		t.Fatal("Failed to detect invalid config")
 	}
 
 	err = d.DeleteEndpoint("dummy", "ep1")

--- a/drivers/bridge/port_mapping_test.go
+++ b/drivers/bridge/port_mapping_test.go
@@ -74,11 +74,11 @@ func TestPortMappingConfig(t *testing.T) {
 	}
 	if ep.portMapping[0].Proto != binding1.Proto || ep.portMapping[0].Port != binding1.Port ||
 		ep.portMapping[1].Proto != binding2.Proto || ep.portMapping[1].Port != binding2.Port {
-		t.Fatalf("bridgeEndpoint has incorrect port mapping values")
+		t.Fatal("bridgeEndpoint has incorrect port mapping values")
 	}
 	if ep.portMapping[0].HostIP == nil || ep.portMapping[0].HostPort == 0 ||
 		ep.portMapping[1].HostIP == nil || ep.portMapping[1].HostPort == 0 {
-		t.Fatalf("operational port mapping data not found on bridgeEndpoint")
+		t.Fatal("operational port mapping data not found on bridgeEndpoint")
 	}
 
 	// release host mapped ports

--- a/drivers/bridge/setup_bridgenetfiltering.go
+++ b/drivers/bridge/setup_bridgenetfiltering.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -37,7 +38,7 @@ func setupBridgeNetFiltering(config *networkConfiguration, i *bridgeInterface) e
 					logrus.Warnf("running inside docker container, ignoring missing kernel params: %v", err)
 					err = nil
 				} else {
-					err = fmt.Errorf("please ensure that br_netfilter kernel module is loaded")
+					err = errors.New("please ensure that br_netfilter kernel module is loaded")
 				}
 			}
 		}

--- a/drivers/bridge/setup_device_test.go
+++ b/drivers/bridge/setup_device_test.go
@@ -32,7 +32,7 @@ func TestSetupNewBridge(t *testing.T) {
 		t.Fatalf("Failed to retrieve bridge device: %v", err)
 	}
 	if br.Link.Attrs().Flags&net.FlagUp == net.FlagUp {
-		t.Fatalf("bridgeInterface should be created down")
+		t.Fatal("bridgeInterface should be created down")
 	}
 }
 
@@ -79,7 +79,7 @@ func TestSetupDeviceUp(t *testing.T) {
 
 	lnk, _ := nh.LinkByName(DefaultBridgeName)
 	if lnk.Attrs().Flags&net.FlagUp != net.FlagUp {
-		t.Fatalf("bridgeInterface should be up")
+		t.Fatal("bridgeInterface should be up")
 	}
 }
 

--- a/drivers/bridge/setup_ip_forwarding_test.go
+++ b/drivers/bridge/setup_ip_forwarding_test.go
@@ -24,7 +24,7 @@ func TestSetupIPForwarding(t *testing.T) {
 	// Read new setting
 	procSetting = readCurrentIPForwardingSetting(t)
 	if bytes.Compare(procSetting, []byte("1\n")) != 0 {
-		t.Fatalf("Failed to effectively setup IP forwarding")
+		t.Fatal("Failed to effectively setup IP forwarding")
 	}
 }
 

--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -17,7 +18,7 @@ const (
 func setupIPChains(config *configuration) (*iptables.ChainInfo, *iptables.ChainInfo, *iptables.ChainInfo, error) {
 	// Sanity check.
 	if config.EnableIPTables == false {
-		return nil, nil, nil, fmt.Errorf("cannot create new chains, EnableIPTable is disabled")
+		return nil, nil, nil, errors.New("cannot create new chains, EnableIPTable is disabled")
 	}
 
 	hairpinMode := !config.EnableUserlandProxy
@@ -68,7 +69,7 @@ func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInt
 
 	// Sanity check.
 	if driverConfig.EnableIPTables == false {
-		return fmt.Errorf("Cannot program chains, EnableIPTable is disabled")
+		return errors.New("Cannot program chains, EnableIPTable is disabled")
 	}
 
 	// Pickup this configuraton option from driver

--- a/drivers/bridge/setup_ipv4.go
+++ b/drivers/bridge/setup_ipv4.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -13,7 +14,7 @@ import (
 
 func selectIPv4Address(addresses []netlink.Addr, selector *net.IPNet) (netlink.Addr, error) {
 	if len(addresses) == 0 {
-		return netlink.Addr{}, fmt.Errorf("unable to select an address as the address pool is empty")
+		return netlink.Addr{}, errors.New("unable to select an address as the address pool is empty")
 	}
 	if selector != nil {
 		for _, addr := range addresses {

--- a/drivers/host/host_test.go
+++ b/drivers/host/host_test.go
@@ -11,7 +11,7 @@ func TestDriver(t *testing.T) {
 	d := &driver{}
 
 	if d.Type() != networkType {
-		t.Fatalf("Unexpected network type returned by driver")
+		t.Fatal("Unexpected network type returned by driver")
 	}
 
 	err := d.CreateNetwork("first", nil, nil, nil, nil)
@@ -20,31 +20,31 @@ func TestDriver(t *testing.T) {
 	}
 
 	if d.network != "first" {
-		t.Fatalf("Unexpected network id stored")
+		t.Fatal("Unexpected network id stored")
 	}
 
 	err = d.CreateNetwork("second", nil, nil, nil, nil)
 	if err == nil {
-		t.Fatalf("Second network creation should fail on this driver")
+		t.Fatal("Second network creation should fail on this driver")
 	}
 	if _, ok := err.(types.ForbiddenError); !ok {
-		t.Fatalf("Second network creation failed with unexpected error type")
+		t.Fatal("Second network creation failed with unexpected error type")
 	}
 
 	err = d.DeleteNetwork("first")
 	if err == nil {
-		t.Fatalf("network deletion should fail on this driver")
+		t.Fatal("network deletion should fail on this driver")
 	}
 	if _, ok := err.(types.ForbiddenError); !ok {
-		t.Fatalf("network deletion failed with unexpected error type")
+		t.Fatal("network deletion failed with unexpected error type")
 	}
 
 	// we don't really check if it is there or not, delete is not allowed for this driver, period.
 	err = d.DeleteNetwork("unknown")
 	if err == nil {
-		t.Fatalf("any network deletion should fail on this driver")
+		t.Fatal("any network deletion should fail on this driver")
 	}
 	if _, ok := err.(types.ForbiddenError); !ok {
-		t.Fatalf("any network deletion failed with unexpected error type")
+		t.Fatal("any network deletion failed with unexpected error type")
 	}
 }

--- a/drivers/remote/driver.go
+++ b/drivers/remote/driver.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -125,7 +126,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 
 func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	if ifInfo == nil {
-		return fmt.Errorf("must not be called with nil InterfaceInfo")
+		return errors.New("must not be called with nil InterfaceInfo")
 	}
 
 	reqIface := &api.EndpointInterface{}

--- a/drivers/remote/driver_test.go
+++ b/drivers/remote/driver_test.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -472,7 +473,7 @@ func TestDriverError(t *testing.T) {
 	driver := newDriver(plugin, p.Client())
 
 	if err := driver.CreateEndpoint("dummy", "dummy", &testEndpoint{t: t}, map[string]interface{}{}); err == nil {
-		t.Fatalf("Expected error from driver")
+		t.Fatal("Expected error from driver")
 	}
 }
 
@@ -528,11 +529,11 @@ func (r *rollbackEndpoint) AddressIPv6() *net.IPNet {
 }
 
 func (r *rollbackEndpoint) SetMacAddress(mac net.HardwareAddr) error {
-	return fmt.Errorf("invalid mac")
+	return errors.New("invalid mac")
 }
 
 func (r *rollbackEndpoint) SetIPAddress(ip *net.IPNet) error {
-	return fmt.Errorf("invalid ip")
+	return errors.New("invalid ip")
 }
 
 func TestRollback(t *testing.T) {
@@ -567,9 +568,9 @@ func TestRollback(t *testing.T) {
 	ep := &rollbackEndpoint{}
 
 	if err := driver.CreateEndpoint("dummy", "dummy", ep.Interface(), map[string]interface{}{}); err == nil {
-		t.Fatalf("Expected error from driver")
+		t.Fatal("Expected error from driver")
 	}
 	if !rolledback {
-		t.Fatalf("Expected to have had DeleteEndpoint called")
+		t.Fatal("Expected to have had DeleteEndpoint called")
 	}
 }

--- a/drvregistry/drvregistry.go
+++ b/drvregistry/drvregistry.go
@@ -1,6 +1,7 @@
 package drvregistry
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -160,7 +161,7 @@ func (r *DrvRegistry) GetPluginGetter() plugingetter.PluginGetter {
 // RegisterDriver registers the network driver when it gets discovered.
 func (r *DrvRegistry) RegisterDriver(ntype string, driver driverapi.Driver, capability driverapi.Capability) error {
 	if strings.TrimSpace(ntype) == "" {
-		return fmt.Errorf("network type string cannot be empty")
+		return errors.New("network type string cannot be empty")
 	}
 
 	r.Lock()
@@ -188,7 +189,7 @@ func (r *DrvRegistry) RegisterDriver(ntype string, driver driverapi.Driver, capa
 
 func (r *DrvRegistry) registerIpamDriver(name string, driver ipamapi.Ipam, caps *ipamapi.Capability) error {
 	if strings.TrimSpace(name) == "" {
-		return fmt.Errorf("ipam driver name string cannot be empty")
+		return errors.New("ipam driver name string cannot be empty")
 	}
 
 	r.Lock()

--- a/hostdiscovery/hostdiscovery_test.go
+++ b/hostdiscovery/hostdiscovery_test.go
@@ -46,7 +46,7 @@ func TestAddedCallback(t *testing.T) {
 	removed := false
 	hd.processCallback(update, func() {}, func(hosts []net.IP) { added = true }, func(hosts []net.IP) { removed = true })
 	if !added {
-		t.Fatalf("Expecting an Added callback notification. But none received")
+		t.Fatal("Expecting an Added callback notification. But none received")
 	}
 }
 
@@ -59,7 +59,7 @@ func TestRemovedCallback(t *testing.T) {
 	removed := false
 	hd.processCallback(update, func() {}, func(hosts []net.IP) { added = true }, func(hosts []net.IP) { removed = true })
 	if !removed {
-		t.Fatalf("Expecting a Removed callback notification. But none received")
+		t.Fatal("Expecting a Removed callback notification. But none received")
 	}
 }
 
@@ -72,6 +72,6 @@ func TestNoCallback(t *testing.T) {
 	removed := false
 	hd.processCallback(update, func() {}, func(hosts []net.IP) { added = true }, func(hosts []net.IP) { removed = true })
 	if added || removed {
-		t.Fatalf("Not expecting any callback notification. But received a callback")
+		t.Fatal("Not expecting any callback notification. But received a callback")
 	}
 }

--- a/idm/idm.go
+++ b/idm/idm.go
@@ -2,6 +2,7 @@
 package idm
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/docker/libnetwork/bitseq"
@@ -18,7 +19,7 @@ type Idm struct {
 // New returns an instance of id manager for a set of [start-end] numerical ids
 func New(ds datastore.DataStore, id string, start, end uint64) (*Idm, error) {
 	if id == "" {
-		return nil, fmt.Errorf("Invalid id")
+		return nil, errors.New("Invalid id")
 	}
 	if end <= start {
 		return nil, fmt.Errorf("Invalid set range: [%d, %d]", start, end)
@@ -35,7 +36,7 @@ func New(ds datastore.DataStore, id string, start, end uint64) (*Idm, error) {
 // GetID returns the first available id in the set
 func (i *Idm) GetID() (uint64, error) {
 	if i.handle == nil {
-		return 0, fmt.Errorf("ID set is not initialized")
+		return 0, errors.New("ID set is not initialized")
 	}
 	ordinal, err := i.handle.SetAny()
 	return i.start + ordinal, err
@@ -44,11 +45,11 @@ func (i *Idm) GetID() (uint64, error) {
 // GetSpecificID tries to reserve the specified id
 func (i *Idm) GetSpecificID(id uint64) error {
 	if i.handle == nil {
-		return fmt.Errorf("ID set is not initialized")
+		return errors.New("ID set is not initialized")
 	}
 
 	if id < i.start || id > i.end {
-		return fmt.Errorf("Requested id does not belong to the set")
+		return errors.New("Requested id does not belong to the set")
 	}
 
 	return i.handle.Set(id - i.start)
@@ -57,11 +58,11 @@ func (i *Idm) GetSpecificID(id uint64) error {
 // GetIDInRange returns the first available id in the set within a range
 func (i *Idm) GetIDInRange(start, end uint64) (uint64, error) {
 	if i.handle == nil {
-		return 0, fmt.Errorf("ID set is not initialized")
+		return 0, errors.New("ID set is not initialized")
 	}
 
 	if start < i.start || end > i.end {
-		return 0, fmt.Errorf("Requested range does not belong to the set")
+		return 0, errors.New("Requested range does not belong to the set")
 	}
 
 	return i.handle.SetAnyInRange(start, end-start)

--- a/idm/idm_test.go
+++ b/idm/idm_test.go
@@ -9,12 +9,12 @@ import (
 func TestNew(t *testing.T) {
 	_, err := New(nil, "", 0, 1)
 	if err == nil {
-		t.Fatalf("Expected failure, but succeeded")
+		t.Fatal("Expected failure, but succeeded")
 	}
 
 	_, err = New(nil, "myset", 1<<10, 0)
 	if err == nil {
-		t.Fatalf("Expected failure, but succeeded")
+		t.Fatal("Expected failure, but succeeded")
 	}
 
 	i, err := New(nil, "myset", 0, 10)
@@ -22,13 +22,13 @@ func TestNew(t *testing.T) {
 		t.Fatalf("Unexpected failure: %v", err)
 	}
 	if i.handle == nil {
-		t.Fatalf("set is not initialized")
+		t.Fatal("set is not initialized")
 	}
 	if i.start != 0 {
-		t.Fatalf("unexpected start")
+		t.Fatal("unexpected start")
 	}
 	if i.end != 10 {
-		t.Fatalf("unexpected end")
+		t.Fatal("unexpected end")
 	}
 }
 
@@ -39,11 +39,11 @@ func TestAllocate(t *testing.T) {
 	}
 
 	if err = i.GetSpecificID(49); err == nil {
-		t.Fatalf("Expected failure but succeeded")
+		t.Fatal("Expected failure but succeeded")
 	}
 
 	if err = i.GetSpecificID(53); err == nil {
-		t.Fatalf("Expected failure but succeeded")
+		t.Fatal("Expected failure but succeeded")
 	}
 
 	o, err := i.GetID()
@@ -87,7 +87,7 @@ func TestAllocate(t *testing.T) {
 		t.Fatal(err)
 	}
 	if o != 50 {
-		t.Fatalf("Unexpected id returned")
+		t.Fatal("Unexpected id returned")
 	}
 
 	i.Release(52)
@@ -101,10 +101,10 @@ func TestUninitialized(t *testing.T) {
 	i := &Idm{}
 
 	if _, err := i.GetID(); err == nil {
-		t.Fatalf("Expected failure but succeeded")
+		t.Fatal("Expected failure but succeeded")
 	}
 
 	if err := i.GetSpecificID(44); err == nil {
-		t.Fatalf("Expected failure but succeeded")
+		t.Fatal("Expected failure but succeeded")
 	}
 }

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -76,16 +76,16 @@ func TestInt2IP2IntConversion(t *testing.T) {
 
 func TestGetAddressVersion(t *testing.T) {
 	if v4 != getAddressVersion(net.ParseIP("172.28.30.112")) {
-		t.Fatalf("Failed to detect IPv4 version")
+		t.Fatal("Failed to detect IPv4 version")
 	}
 	if v4 != getAddressVersion(net.ParseIP("0.0.0.1")) {
-		t.Fatalf("Failed to detect IPv4 version")
+		t.Fatal("Failed to detect IPv4 version")
 	}
 	if v6 != getAddressVersion(net.ParseIP("ff01::1")) {
-		t.Fatalf("Failed to detect IPv6 version")
+		t.Fatal("Failed to detect IPv6 version")
 	}
 	if v6 != getAddressVersion(net.ParseIP("2001:db8::76:51")) {
-		t.Fatalf("Failed to detect IPv6 version")
+		t.Fatal("Failed to detect IPv6 version")
 	}
 }
 
@@ -165,7 +165,7 @@ func TestPoolDataMarshal(t *testing.T) {
 	}
 
 	if q.Range != nil {
-		t.Fatalf("Unexpected Range")
+		t.Fatal("Unexpected Range")
 	}
 }
 
@@ -225,7 +225,7 @@ func TestAddSubnets(t *testing.T) {
 
 	pid0, _, _, err := a.RequestPool(localAddressSpace, "10.0.0.0/8", "", nil, false)
 	if err != nil {
-		t.Fatalf("Unexpected failure in adding subnet")
+		t.Fatal("Unexpected failure in adding subnet")
 	}
 
 	pid1, _, _, err := a.RequestPool("abc", "10.0.0.0/8", "", nil, false)
@@ -234,7 +234,7 @@ func TestAddSubnets(t *testing.T) {
 	}
 
 	if pid0 == pid1 {
-		t.Fatalf("returned same pool id for same subnets in different namespaces")
+		t.Fatal("returned same pool id for same subnets in different namespaces")
 	}
 
 	pid, _, _, err := a.RequestPool("abc", "10.0.0.0/8", "", nil, false)
@@ -242,12 +242,12 @@ func TestAddSubnets(t *testing.T) {
 		t.Fatalf("Unexpected failure requesting existing subnet: %v", err)
 	}
 	if pid != pid1 {
-		t.Fatalf("returned different pool id for same subnet requests")
+		t.Fatal("returned different pool id for same subnet requests")
 	}
 
 	_, _, _, err = a.RequestPool("abc", "10.128.0.0/9", "", nil, false)
 	if err == nil {
-		t.Fatalf("Expected failure on adding overlapping base subnet")
+		t.Fatal("Expected failure on adding overlapping base subnet")
 	}
 
 	pid2, _, _, err := a.RequestPool("abc", "10.0.0.0/8", "10.128.0.0/9", nil, false)
@@ -259,17 +259,17 @@ func TestAddSubnets(t *testing.T) {
 		t.Fatalf("Unexpected failure on adding overlapping sub pool: %v", err)
 	}
 	if pid2 != pid3 {
-		t.Fatalf("returned different pool id for same sub pool requests")
+		t.Fatal("returned different pool id for same sub pool requests")
 	}
 
 	pid, _, _, err = a.RequestPool(localAddressSpace, "10.20.2.0/24", "", nil, false)
 	if err == nil {
-		t.Fatalf("Failed to detect overlapping subnets")
+		t.Fatal("Failed to detect overlapping subnets")
 	}
 
 	_, _, _, err = a.RequestPool(localAddressSpace, "10.128.0.0/9", "", nil, false)
 	if err == nil {
-		t.Fatalf("Failed to detect overlapping subnets")
+		t.Fatal("Failed to detect overlapping subnets")
 	}
 
 	_, _, _, err = a.RequestPool(localAddressSpace, "1003:1:2:3:4:5:6::/112", "", nil, false)
@@ -279,7 +279,7 @@ func TestAddSubnets(t *testing.T) {
 
 	_, _, _, err = a.RequestPool(localAddressSpace, "1003:1:2:3::/64", "", nil, false)
 	if err == nil {
-		t.Fatalf("Failed to detect overlapping v6 subnet")
+		t.Fatal("Failed to detect overlapping v6 subnet")
 	}
 }
 
@@ -299,7 +299,7 @@ func TestAddReleasePoolID(t *testing.T) {
 	subnets := aSpace.subnets
 	pid0, _, _, err := a.RequestPool(localAddressSpace, "10.0.0.0/8", "", nil, false)
 	if err != nil {
-		t.Fatalf("Unexpected failure in adding pool")
+		t.Fatal("Unexpected failure in adding pool")
 	}
 	if err := k0.FromString(pid0); err != nil {
 		t.Fatal(err)
@@ -318,7 +318,7 @@ func TestAddReleasePoolID(t *testing.T) {
 
 	pid1, _, _, err := a.RequestPool(localAddressSpace, "10.0.0.0/8", "10.0.0.0/16", nil, false)
 	if err != nil {
-		t.Fatalf("Unexpected failure in adding sub pool")
+		t.Fatal("Unexpected failure in adding sub pool")
 	}
 	if err := k1.FromString(pid1); err != nil {
 		t.Fatal(err)
@@ -336,7 +336,7 @@ func TestAddReleasePoolID(t *testing.T) {
 
 	pid2, _, _, err := a.RequestPool(localAddressSpace, "10.0.0.0/8", "10.0.0.0/16", nil, false)
 	if err != nil {
-		t.Fatalf("Unexpected failure in adding sub pool")
+		t.Fatal("Unexpected failure in adding sub pool")
 	}
 	if pid0 == pid1 || pid0 == pid2 || pid1 != pid2 {
 		t.Fatalf("Incorrect poolIDs returned %s, %s, %s", pid0, pid1, pid2)
@@ -388,10 +388,10 @@ func TestAddReleasePoolID(t *testing.T) {
 
 	pid00, _, _, err := a.RequestPool(localAddressSpace, "10.0.0.0/8", "", nil, false)
 	if err != nil {
-		t.Fatalf("Unexpected failure in adding pool")
+		t.Fatal("Unexpected failure in adding pool")
 	}
 	if pid00 != pid0 {
-		t.Fatalf("main pool should still exist")
+		t.Fatal("main pool should still exist")
 	}
 
 	aSpace, err = a.getAddrSpace(localAddressSpace)
@@ -434,7 +434,7 @@ func TestAddReleasePoolID(t *testing.T) {
 
 	_, _, _, err = a.RequestPool(localAddressSpace, "10.0.0.0/8", "", nil, false)
 	if err != nil {
-		t.Fatalf("Unexpected failure in adding pool")
+		t.Fatal("Unexpected failure in adding pool")
 	}
 
 	aSpace, err = a.getAddrSpace(localAddressSpace)
@@ -455,7 +455,7 @@ func TestPredefinedPool(t *testing.T) {
 	}
 
 	if _, err := a.getPredefinedPool("blue", false); err == nil {
-		t.Fatalf("Expected failure for non default addr space")
+		t.Fatal("Expected failure for non default addr space")
 	}
 
 	pid, nw, _, err := a.RequestPool(localAddressSpace, "", "", nil, false)
@@ -729,17 +729,17 @@ func TestRequestSyntaxCheck(t *testing.T) {
 
 	_, _, _, err = a.RequestPool("", pool, "", nil, false)
 	if err == nil {
-		t.Fatalf("Failed to detect wrong request: empty address space")
+		t.Fatal("Failed to detect wrong request: empty address space")
 	}
 
 	_, _, _, err = a.RequestPool("", pool, subPool, nil, false)
 	if err == nil {
-		t.Fatalf("Failed to detect wrong request: empty address space")
+		t.Fatal("Failed to detect wrong request: empty address space")
 	}
 
 	_, _, _, err = a.RequestPool(as, "", subPool, nil, false)
 	if err == nil {
-		t.Fatalf("Failed to detect wrong request: subPool specified and no pool")
+		t.Fatal("Failed to detect wrong request: subPool specified and no pool")
 	}
 
 	pid, _, _, err := a.RequestPool(as, pool, subPool, nil, false)
@@ -749,13 +749,13 @@ func TestRequestSyntaxCheck(t *testing.T) {
 
 	_, _, err = a.RequestAddress("", nil, nil)
 	if err == nil {
-		t.Fatalf("Failed to detect wrong request: no pool id specified")
+		t.Fatal("Failed to detect wrong request: no pool id specified")
 	}
 
 	ip := net.ParseIP("172.17.0.23")
 	_, _, err = a.RequestAddress(pid, ip, nil)
 	if err == nil {
-		t.Fatalf("Failed to detect wrong request: requested IP from different subnet")
+		t.Fatal("Failed to detect wrong request: requested IP from different subnet")
 	}
 
 	ip = net.ParseIP("192.168.0.50")
@@ -766,12 +766,12 @@ func TestRequestSyntaxCheck(t *testing.T) {
 
 	err = a.ReleaseAddress("", ip)
 	if err == nil {
-		t.Fatalf("Failed to detect wrong request: no pool id specified")
+		t.Fatal("Failed to detect wrong request: no pool id specified")
 	}
 
 	err = a.ReleaseAddress(pid, nil)
 	if err == nil {
-		t.Fatalf("Failed to detect wrong request: no pool id specified")
+		t.Fatal("Failed to detect wrong request: no pool id specified")
 	}
 
 	err = a.ReleaseAddress(pid, ip)

--- a/ipams/builtin/builtin_unix.go
+++ b/ipams/builtin/builtin_unix.go
@@ -3,7 +3,7 @@
 package builtin
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/ipam"
@@ -20,13 +20,13 @@ func Init(ic ipamapi.Callback, l, g interface{}) error {
 
 	if l != nil {
 		if localDs, ok = l.(datastore.DataStore); !ok {
-			return fmt.Errorf("incorrect local datastore passed to built-in ipam init")
+			return errors.New("incorrect local datastore passed to built-in ipam init")
 		}
 	}
 
 	if g != nil {
 		if globalDs, ok = g.(datastore.DataStore); !ok {
-			return fmt.Errorf("incorrect global datastore passed to built-in ipam init")
+			return errors.New("incorrect global datastore passed to built-in ipam init")
 		}
 	}
 

--- a/ipams/builtin/builtin_windows.go
+++ b/ipams/builtin/builtin_windows.go
@@ -3,7 +3,7 @@
 package builtin
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/ipam"
@@ -22,13 +22,13 @@ func InitDockerDefault(ic ipamapi.Callback, l, g interface{}) error {
 
 	if l != nil {
 		if localDs, ok = l.(datastore.DataStore); !ok {
-			return fmt.Errorf("incorrect local datastore passed to built-in ipam init")
+			return errors.New("incorrect local datastore passed to built-in ipam init")
 		}
 	}
 
 	if g != nil {
 		if globalDs, ok = g.(datastore.DataStore); !ok {
-			return fmt.Errorf("incorrect global datastore passed to built-in ipam init")
+			return errors.New("incorrect global datastore passed to built-in ipam init")
 		}
 	}
 

--- a/ipams/null/null_test.go
+++ b/ipams/null/null_test.go
@@ -23,22 +23,22 @@ func TestPoolRequest(t *testing.T) {
 
 	_, _, _, err = a.RequestPool("default", "", "", nil, false)
 	if err == nil {
-		t.Fatalf("Unexpected success")
+		t.Fatal("Unexpected success")
 	}
 
 	_, _, _, err = a.RequestPool(defaultAS, "192.168.0.0/16", "", nil, false)
 	if err == nil {
-		t.Fatalf("Unexpected success")
+		t.Fatal("Unexpected success")
 	}
 
 	_, _, _, err = a.RequestPool(defaultAS, "", "192.168.0.0/24", nil, false)
 	if err == nil {
-		t.Fatalf("Unexpected success")
+		t.Fatal("Unexpected success")
 	}
 
 	_, _, _, err = a.RequestPool(defaultAS, "", "", nil, true)
 	if err == nil {
-		t.Fatalf("Unexpected success")
+		t.Fatal("Unexpected success")
 	}
 }
 
@@ -55,7 +55,7 @@ func TestOtherRequests(t *testing.T) {
 
 	_, _, err = a.RequestAddress("anypid", nil, nil)
 	if err == nil {
-		t.Fatalf("Unexpected success")
+		t.Fatal("Unexpected success")
 	}
 
 }

--- a/ipams/remote/remote_test.go
+++ b/ipams/remote/remote_test.go
@@ -179,14 +179,14 @@ func TestRemoteDriver(t *testing.T) {
 
 	handle(t, mux, "ReleasePool", func(msg map[string]interface{}) interface{} {
 		if _, ok := msg["PoolID"]; !ok {
-			t.Fatalf("Missing PoolID in Release request")
+			t.Fatal("Missing PoolID in Release request")
 		}
 		return map[string]interface{}{}
 	})
 
 	handle(t, mux, "RequestAddress", func(msg map[string]interface{}) interface{} {
 		if _, ok := msg["PoolID"]; !ok {
-			t.Fatalf("Missing PoolID in address request")
+			t.Fatal("Missing PoolID in address request")
 		}
 		prefAddr := ""
 		if v, ok := msg["Address"]; ok {
@@ -204,10 +204,10 @@ func TestRemoteDriver(t *testing.T) {
 
 	handle(t, mux, "ReleaseAddress", func(msg map[string]interface{}) interface{} {
 		if _, ok := msg["PoolID"]; !ok {
-			t.Fatalf("Missing PoolID in address request")
+			t.Fatal("Missing PoolID in address request")
 		}
 		if _, ok := msg["Address"]; !ok {
-			t.Fatalf("Missing Address in release address request")
+			t.Fatal("Missing Address in release address request")
 		}
 		return map[string]interface{}{}
 	})
@@ -251,7 +251,7 @@ func TestRemoteDriver(t *testing.T) {
 		t.Fatalf("Unexpected pool: %s", pool2)
 	}
 	if dns, ok := ops["DNS"]; !ok || dns != "8.8.8.8" {
-		t.Fatalf("Missing options")
+		t.Fatal("Missing options")
 	}
 
 	// Request specific pool and subpool

--- a/iptables/firewalld_test.go
+++ b/iptables/firewalld_test.go
@@ -52,7 +52,7 @@ func TestReloaded(t *testing.T) {
 		"-j", "ACCEPT"}
 
 	if !Exists(fwdChain.Table, fwdChain.Name, rule1...) {
-		t.Fatalf("rule1 does not exist")
+		t.Fatal("rule1 does not exist")
 	}
 
 	// flush all rules
@@ -62,7 +62,7 @@ func TestReloaded(t *testing.T) {
 
 	// make sure the rules have been recreated
 	if !Exists(fwdChain.Table, fwdChain.Name, rule1...) {
-		t.Fatalf("rule1 hasn't been recreated")
+		t.Fatal("rule1 hasn't been recreated")
 	}
 }
 
@@ -79,7 +79,7 @@ func TestPassthrough(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !Exists(Filter, "INPUT", rule1...) {
-			t.Fatalf("rule1 does not exist")
+			t.Fatal("rule1 does not exist")
 		}
 	}
 

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -130,7 +130,7 @@ func NewChain(name string, table Table, hairpinMode bool) (*ChainInfo, error) {
 // ProgramChain is used to add rules to a chain
 func ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) error {
 	if c.Name == "" {
-		return fmt.Errorf("Could not program chain, missing chain name")
+		return errors.New("Could not program chain, missing chain name")
 	}
 
 	switch c.Table {

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -57,7 +57,7 @@ func TestForward(t *testing.T) {
 	}
 
 	if !Exists(natChain.Table, natChain.Name, dnatRule...) {
-		t.Fatalf("DNAT rule does not exist")
+		t.Fatal("DNAT rule does not exist")
 	}
 
 	filterRule := []string{
@@ -70,7 +70,7 @@ func TestForward(t *testing.T) {
 	}
 
 	if !Exists(filterChain.Table, filterChain.Name, filterRule...) {
-		t.Fatalf("filter rule does not exist")
+		t.Fatal("filter rule does not exist")
 	}
 
 	masqRule := []string{
@@ -82,7 +82,7 @@ func TestForward(t *testing.T) {
 	}
 
 	if !Exists(natChain.Table, "POSTROUTING", masqRule...) {
-		t.Fatalf("MASQUERADE rule does not exist")
+		t.Fatal("MASQUERADE rule does not exist")
 	}
 }
 
@@ -110,7 +110,7 @@ func TestLink(t *testing.T) {
 		"-j", "ACCEPT"}
 
 	if !Exists(filterChain.Table, filterChain.Name, rule1...) {
-		t.Fatalf("rule1 does not exist")
+		t.Fatal("rule1 does not exist")
 	}
 
 	rule2 := []string{
@@ -123,7 +123,7 @@ func TestLink(t *testing.T) {
 		"-j", "ACCEPT"}
 
 	if !Exists(filterChain.Table, filterChain.Name, rule2...) {
-		t.Fatalf("rule2 does not exist")
+		t.Fatal("rule2 does not exist")
 	}
 }
 
@@ -138,7 +138,7 @@ func TestPrerouting(t *testing.T) {
 	}
 
 	if !Exists(natChain.Table, "PREROUTING", args...) {
-		t.Fatalf("rule does not exist")
+		t.Fatal("rule does not exist")
 	}
 
 	delRule := append([]string{"-D", "PREROUTING", "-t", string(Nat)}, args...)
@@ -158,7 +158,7 @@ func TestOutput(t *testing.T) {
 	}
 
 	if !Exists(natChain.Table, "OUTPUT", args...) {
-		t.Fatalf("rule does not exist")
+		t.Fatal("rule does not exist")
 	}
 
 	delRule := append([]string{"-D", "OUTPUT", "-t",
@@ -285,7 +285,7 @@ func TestExistsRaw(t *testing.T) {
 func TestGetVersion(t *testing.T) {
 	mj, mn, mc := parseVersionNumbers("iptables v1.4.19.1-alpha")
 	if mj != 1 || mn != 4 || mc != 19 {
-		t.Fatalf("Failed to parse version numbers")
+		t.Fatal("Failed to parse version numbers")
 	}
 }
 

--- a/netutils/utils.go
+++ b/netutils/utils.go
@@ -173,7 +173,7 @@ func ReverseIP(IP string) string {
 // ParseAlias parses and validates the specified string as an alias format (name:alias)
 func ParseAlias(val string) (string, string, error) {
 	if val == "" {
-		return "", "", fmt.Errorf("empty string specified for alias")
+		return "", "", errors.New("empty string specified for alias")
 	}
 	arr := strings.Split(val, ":")
 	if len(arr) > 2 {

--- a/netutils/utils_test.go
+++ b/netutils/utils_test.go
@@ -61,7 +61,7 @@ func TestCheckRouteOverlaps(t *testing.T) {
 
 	_, netX, _ = net.ParseCIDR("10.0.2.0/24")
 	if err := CheckRouteOverlaps(netX); err == nil {
-		t.Fatalf("10.0.2.0/24 and 10.0.2.0 should overlap but it doesn't")
+		t.Fatal("10.0.2.0/24 and 10.0.2.0 should overlap but it doesn't")
 	}
 }
 
@@ -279,11 +279,11 @@ func TestElectInterfaceAddressMultipleAddresses(t *testing.T) {
 	}
 
 	if len(ipv4NwList) == 0 {
-		t.Fatalf("unexpected empty ipv4 network addresses")
+		t.Fatal("unexpected empty ipv4 network addresses")
 	}
 
 	if len(ipv6NwList) == 0 {
-		t.Fatalf("unexpected empty ipv6 network addresses")
+		t.Fatal("unexpected empty ipv6 network addresses")
 	}
 
 	nwList := []string{}
@@ -316,11 +316,11 @@ func TestElectInterfaceAddress(t *testing.T) {
 	}
 
 	if len(ipv4Nw) == 0 {
-		t.Fatalf("unexpected empty ipv4 network addresses")
+		t.Fatal("unexpected empty ipv4 network addresses")
 	}
 
 	if len(ipv6Nw) == 0 {
-		t.Fatalf("unexpected empty ipv6 network addresses")
+		t.Fatal("unexpected empty ipv6 network addresses")
 	}
 
 	if nws != ipv4Nw[0].String() {

--- a/networkdb/broadcast.go
+++ b/networkdb/broadcast.go
@@ -1,7 +1,7 @@
 package networkdb
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/hashicorp/memberlist"
@@ -90,7 +90,7 @@ func (nDB *NetworkDB) sendNodeEvent(event NodeEvent_Type) error {
 	select {
 	case <-notifyCh:
 	case <-time.After(broadcastTimeout):
-		return fmt.Errorf("timed out broadcasting node event")
+		return errors.New("timed out broadcasting node event")
 	}
 
 	return nil

--- a/networkdb/networkdb_test.go
+++ b/networkdb/networkdb_test.go
@@ -426,6 +426,6 @@ func TestNetworkDBCRUDMediumCluster(t *testing.T) {
 		dbs[i].verifyEntryExistence(t, "test_table", "network1", "test_key", "", false)
 	}
 
-	log.Printf("Closing DB instances...")
+	log.Print("Closing DB instances...")
 	closeNetworkDBInstances(dbs)
 }


### PR DESCRIPTION
For ```fmt.Errorf``` if no arguments passed, replace it with ```errors.New```.
For ```t.Fatalf``` if no arguments passed, replace it with ```t.Fatal```.
For ```t.Errorf``` if no arguments passed, replace it with ```t.Error```.
For ```fmt.Fprintf``` if no arguments passed, replace it with ```fmt.Fprint```.
For ```fmt.Printf``` if no arguments passed, replace it with ```fmt.Print```.
For ```log.Printf``` if no arguments passed, replace it with ```log.Print```.

Because the previous ```*f``` are almost calls the function without format internally and do format before output, but if no arguments passed, the format is unnecessary.

Happy to hear your comments. Thanks.
