### PR TITLE
Fix xtables_lock message probe

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -45,6 +45,7 @@ var (
 	iptablesPath  string
 	supportsXlock = false
 	supportsCOpt  = false
+	xLockWaitMsg  = "Another app is currently holding the xtables lock; waiting"
 	// used to lock iptables commands if xtables lock is not supported
 	bestEffortLock sync.Mutex
 	// ErrIptablesNotFound is returned when the rule is not found.
@@ -402,7 +403,7 @@ func raw(args ...string) ([]byte, error) {
 	}
 
 	// ignore iptables' message about xtables lock
-	if strings.Contains(string(output), "waiting for it to exit") {
+	if strings.Contains(string(output), xLockWaitMsg) {
 		output = []byte("")
 	}
 


### PR DESCRIPTION
- iptables pkg functions are coded to discard the xtables_lock error message about acquiring the lock, because all the calls are done with the wait logic. So they just need to wait. But the error message has  slightly changed between iptables 1.4.x and 1.6:

https://git.netfilter.org/iptables/tree/iptables/xshared.c?h=v1.4.21:
```
fprintf(stderr, "Another app is currently holding the xtables lock; "
				"waiting for it to exit...\n");
```

https://git.netfilter.org/iptables/tree/iptables/xshared.c?h=v1.6.0:
```
fprintf(stderr, "Another app is currently holding the xtables lock; "
				"waiting (%ds) for it to exit...\n", waited);
```

This lead to false positives causing docker network create to fail in presence of concurrent calls.

Related to https://github.com/docker/docker/issues/26111

To reproduce:
- You need iptables 1.6 version installed
- Concurrently create 20 bridge network or so

Signed-off-by: Alessandro Boch <aboch@docker.com>