### PR TITLE
Create vxlan-id space from 0 instead of starting from 1

### DIFF
--- a/drivers/overlay/ovmanager/ovmanager.go
+++ b/drivers/overlay/ovmanager/ovmanager.go
@@ -57,7 +57,7 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 		config:   config,
 	}
 
-	d.vxlanIdm, err = idm.New(nil, "vxlan-id", 1, vxlanIDEnd)
+	d.vxlanIdm, err = idm.New(nil, "vxlan-id", 0, vxlanIDEnd)
 	if err != nil {
 		return fmt.Errorf("failed to initialize vxlan id manager: %v", err)
 	}


### PR DESCRIPTION
With the introduction of GetIDInRange function in IDM and using it in
ovmanager, the idm.New was modified to start from 1. But that causes
issues when the network is removed which results in releasing the
vxlan-id from IDM. With the offset of 1, the Release call incorrectly
releases a bit which could be in use by another network and this results
in the infamous "error creating vxlan interface: file exists" errors
when another network is created with this freed bit.

Signed-off-by: Madhu Venugopal <madhu@docker.com>