### PR TITLE
Fix incorrect debug message

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -418,8 +418,12 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			}
 
 			execErr := r.backend.ExecFunc(extConnect)
-			if execErr != nil || err != nil {
-				logrus.Debugf("Connect failed, %s", err)
+			if execErr != nil {
+				logrus.Warn(execErr)
+				continue
+			}
+			if err != nil {
+				logrus.Warnf("Connect failed: %s", err)
 				continue
 			}
 			logrus.Debugf("Query %s[%d] from %s, forwarding to %s:%s", name, query.Question[0].Qtype,


### PR DESCRIPTION
#1556 Fixes a panic when sandbox.osSbox is nil. But the error message returned is not getting displayed correctly. Fixed it and also changed it to a warning so that such errors won't go unnoticed.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>