### PR TITLE
Cherry-pick for 1.12.x: Run API check to assert xfrm modules

### DIFF
--- a/ns/init_linux.go
+++ b/ns/init_linux.go
@@ -76,8 +76,10 @@ func NlHandle() *netlink.Handle {
 func getSupportedNlFamilies() []int {
 	fams := []int{syscall.NETLINK_ROUTE}
 	if err := loadXfrmModules(); err != nil {
-		log.Warnf("Could not load necessary modules for IPSEC rules: %v", err)
-		return fams
+		if checkXfrmSocket() != nil {
+			log.Warnf("Could not load necessary modules for IPSEC rules: %v", err)
+			return fams
+		}
 	}
 	return append(fams, syscall.NETLINK_XFRM)
 }
@@ -89,5 +91,15 @@ func loadXfrmModules() error {
 	if out, err := exec.Command("modprobe", "-va", "xfrm_algo").CombinedOutput(); err != nil {
 		return fmt.Errorf("Running modprobe xfrm_algo failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
 	}
+	return nil
+}
+
+// API check on required xfrm modules (xfrm_user, xfrm_algo)
+func checkXfrmSocket() error {
+	fd, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, syscall.NETLINK_XFRM)
+	if err != nil {
+		return err
+	}
+	syscall.Close(fd)
 	return nil
 }


### PR DESCRIPTION
- When docker is run inside a container, the infrastructure
  needed by modprobe is not always available, causing the
  xfrm module load to fail even when these modules are already
  loaded or builtin in the kernel.
- In case of probe failure, before declaring the failure,
  run an API check by attempting the creation of
  a NETLINK_XFRM socket.

Signed-off-by: Alessandro Boch <aboch@docker.com>