### PR TITLE
networkdb: Properly format memberlist logs

### DIFF
--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"math/big"
 	rnd "math/rand"
 	"net"
@@ -27,15 +28,20 @@ type logWriter struct{}
 
 func (l *logWriter) Write(p []byte) (int, error) {
 	str := string(p)
+	str = strings.TrimSuffix(str, "\n")
 
 	switch {
-	case strings.Contains(str, "[WARN]"):
+	case strings.HasPrefix(str, "[WARN] "):
+		str = strings.TrimPrefix(str, "[WARN] ")
 		logrus.Warn(str)
-	case strings.Contains(str, "[DEBUG]"):
+	case strings.HasPrefix(str, "[DEBUG] "):
+		str = strings.TrimPrefix(str, "[DEBUG] ")
 		logrus.Debug(str)
-	case strings.Contains(str, "[INFO]"):
+	case strings.HasPrefix(str, "[INFO] "):
+		str = strings.TrimPrefix(str, "[INFO] ")
 		logrus.Info(str)
-	case strings.Contains(str, "[ERR]"):
+	case strings.HasPrefix(str, "[ERR] "):
+		str = strings.TrimPrefix(str, "[ERR] ")
 		logrus.Warn(str)
 	}
 
@@ -104,7 +110,9 @@ func (nDB *NetworkDB) clusterInit() error {
 	config.ProtocolVersion = memberlist.ProtocolVersionMax
 	config.Delegate = &delegate{nDB: nDB}
 	config.Events = &eventDelegate{nDB: nDB}
-	config.LogOutput = &logWriter{}
+	// custom logger that does not add time or date, so they are not
+	// duplicated by logrus
+	config.Logger = log.New(&logWriter{}, "", 0)
 
 	var err error
 	if len(nDB.config.Keys) > 0 {


### PR DESCRIPTION
Right now, items logged by memberlist end up as a complete log line
embedded inside another log line, like the following:

    Nov 22 16:34:16 hostname dockerd: time="2016-11-22T16:34:16.802103258-08:00" level=info msg="2016/11/22 16:34:16 [INFO] memberlist: Marking xyz-1d1ec2dfa053 as failed, suspect timeout reached\n"

This has two time and date stamps, and an escaped newline inside the
"msg" field of the outer log message.

To fix this, define a custom logger that only prints the message itself.
Capture this message in logWriter, strip off the log level (added
directly by memberlist), and route to the appropriate logrus method.

Relevant issue: https://github.com/docker/docker/issues/28969