### PR TITLE
Check for node's presence in networkDB's node map before accessing.

### DIFF
--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -211,10 +211,12 @@ func (nDB *NetworkDB) Peers(nid string) []PeerInfo {
 	defer nDB.RUnlock()
 	peers := make([]PeerInfo, 0, len(nDB.networkNodes[nid]))
 	for _, nodeName := range nDB.networkNodes[nid] {
-		peers = append(peers, PeerInfo{
-			Name: nDB.nodes[nodeName].Name,
-			IP:   nDB.nodes[nodeName].Addr.String(),
-		})
+		if node, ok := nDB.nodes[nodeName]; ok {
+			peers = append(peers, PeerInfo{
+				Name: node.Name,
+				IP:   node.Addr.String(),
+			})
+		}
 	}
 	return peers
 }


### PR DESCRIPTION
Related to [docker #28931](https://github.com/docker/docker/issues/28931)

This happens if swarm nodes running 1.12.3 are upgraded to 1.13.0-rc2 by installing the deb (could happens with rpm as well). I couldn't replicate the issue when replacing the binaries manually and restarting the daemon. 

When the daemon restarts, the gossip cluster-id changes. This issue happens when the old name of the node gets removed from the `nDB.nodes` map but its still present in the per network node list. This change avoids the panic by having a nil check for the node in `nDB.nodes`. I am looking into why the per network list still has the node. 

Signed-off-by: Santhosh Manohar <santhosh@docker.com>