### PR TITLE
Defer PTR queries to external servers based on A/AAAA response

### DIFF
--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -380,7 +380,7 @@ func TestSRVServiceQuery(t *testing.T) {
 	sr := svcInfo{
 		svcMap:     make(map[string][]net.IP),
 		svcIPv6Map: make(map[string][]net.IP),
-		ipMap:      make(map[string]string),
+		ipMap:      make(map[string]*ipInfo),
 		service:    make(map[string][]servicePorts),
 	}
 	// backing container for the service

--- a/sandbox.go
+++ b/sandbox.go
@@ -411,6 +411,13 @@ func (sb *sandbox) updateGateway(ep *endpoint) error {
 	return nil
 }
 
+func (sb *sandbox) HandleQueryResp(name string, ip net.IP) {
+	for _, ep := range sb.getConnectedEndpoints() {
+		n := ep.getNetwork()
+		n.HandleQueryResp(name, ip)
+	}
+}
+
 func (sb *sandbox) ResolveIP(ip string) string {
 	var svc string
 	logrus.Debugf("IP To resolve %v", ip)


### PR DESCRIPTION
Related to [docker #22004](https://github.com/docker/docker/issues/22004) 

For service discovery an external DNS based mechanism can be used. Its naming scheme could be different from that of Docker's service discovery provided by embedded DNS server. In such cases A/AAAA queries will be forwarded to the external server if the name can't be resolved by the docker server. But the PTR queries will be responded to by the docker DNS server. This change provides a fix to defer the PTR queries also to external server. Embedded server looks at the A/AAAA record responses;  if the IP is present in docker domain its marked with a flag and is used to defer the PTR queries. Hence for this to work correctly there has to be a forward lookup at least once. Nevertheless, it could be useful for some apps and simple use cases like ping.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>