### PR TITLE
Correct regexp to match v6 addresses with zone ID

### DIFF
--- a/resolvconf/resolvconf.go
+++ b/resolvconf/resolvconf.go
@@ -25,7 +25,7 @@ var (
 	// -- e.g. other link-local types -- either won't work in containers or are unnecessary.
 	// For readability and sufficiency for Docker purposes this seemed more reasonable than a
 	// 1000+ character regexp with exact and complete IPv6 validation
-	ipv6Address = `([0-9A-Fa-f]{0,4}:){2,7}([0-9A-Fa-f]{0,4})`
+	ipv6Address = `([0-9A-Fa-f]{0,4}:){2,7}([0-9A-Fa-f]{0,4})(%\w+)?`
 
 	localhostNSRegexp = regexp.MustCompile(`(?m)^nameserver\s+` + dns.IPLocalhost + `\s*\n*`)
 	nsIPv6Regexp      = regexp.MustCompile(`(?m)^nameserver\s+` + ipv6Address + `\s*\n*`)

--- a/resolvconf/resolvconf_test.go
+++ b/resolvconf/resolvconf_test.go
@@ -271,6 +271,14 @@ func TestFilterResolvDns(t *testing.T) {
 		}
 	}
 
+	// with IPv6 disabled (false param), the IPv6 link-local nameserver with zone ID should be removed
+	ns1 = "nameserver 10.16.60.14\nnameserver FE80::BB1%1\nnameserver FE80::BB1%eth0\nnameserver 10.16.60.21\n"
+	if result, _ := FilterResolvDNS([]byte(ns1), false); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed Localhost+IPv6 off: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+
 	// with IPv6 enabled, the IPv6 nameserver should be preserved
 	ns0 = "nameserver 10.16.60.14\nnameserver 2002:dead:beef::1\nnameserver 10.16.60.21\n"
 	ns1 = "nameserver 10.16.60.14\nnameserver 2002:dead:beef::1\nnameserver 10.16.60.21\nnameserver ::1"


### PR DESCRIPTION
Related to [docker #28172](https://github.com/docker/docker/issues/28172)

IPv6 link local addresses can have a Zone id in the `%number` or `%interface name` format to disambiguate the right interface. Corrected the regexp to filter such addresses.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>