### PR TITLE
Handle the case of registering active plugins during remote init

### DIFF
--- a/ipams/remote/remote.go
+++ b/ipams/remote/remote.go
@@ -31,12 +31,7 @@ func newAllocator(name string, client *plugins.Client) ipamapi.Ipam {
 // Init registers a remote ipam when its plugin is activated
 func Init(cb ipamapi.Callback, l, g interface{}) error {
 
-	// Unit test code is unaware of a true PluginStore. So we fall back to v1 plugins.
-	handleFunc := plugins.Handle
-	if pg := cb.GetPluginGetter(); pg != nil {
-		handleFunc = pg.Handle
-	}
-	handleFunc(ipamapi.PluginEndpointType, func(name string, client *plugins.Client) {
+	newPluginHandler := func(name string, client *plugins.Client) {
 		a := newAllocator(name, client)
 		if cps, err := a.(*allocator).getCapabilities(); err == nil {
 			if err := cb.RegisterIpamDriverWithCapabilities(name, a, cps); err != nil {
@@ -49,7 +44,18 @@ func Init(cb ipamapi.Callback, l, g interface{}) error {
 				logrus.Errorf("error registering remote ipam driver %s due to %v", name, err)
 			}
 		}
-	})
+	}
+
+	// Unit test code is unaware of a true PluginStore. So we fall back to v1 plugins.
+	handleFunc := plugins.Handle
+	if pg := cb.GetPluginGetter(); pg != nil {
+		handleFunc = pg.Handle
+		activePlugins, _ := pg.GetAllByCap(ipamapi.PluginEndpointType)
+		for _, ap := range activePlugins {
+			newPluginHandler(ap.Name(), ap.Client())
+		}
+	}
+	handleFunc(ipamapi.PluginEndpointType, newPluginHandler)
 	return nil
 }
 


### PR DESCRIPTION
With Plugin-V2, plugins can get activated before remote driver is
Initialized. Those plugins fails to get registered with drvRegistry.

This fix handles that scenario.

** Reproduction steps **

1. Install network-plugin and create a network.

```
$ sudo docker plugin install tiborvass/test-docker-netplugin
Plugin "tiborvass/test-docker-netplugin" is requesting the following privileges:
 - network: [host]
Do you grant the above permissions? [y/N] y
tiborvass/test-docker-netplugin

$ sudo docker network create -d tiborvass/test-docker-netplugin:latest testnet2
16262841d23a96d287c58b4569d2ba3f6205d29f7eeff5fa658f882a32e89111

```

2. Restart the daemon, make sure the plugin still exists and create another network. Without this PR, the network creation will fail.

```
{{ RESTART DAEMON }}

$ sudo docker plugin ls
ID                  NAME                              TAG                 DESCRIPTION                      ENABLED
fedd8eb3d5fb        tiborvass/test-docker-netplugin   latest              Test network plugin for Docker   true

$ sudo docker network create -d tiborvass/test-docker-netplugin:latest testnet3
Error response from daemon: could not resolve driver tiborvass/test-docker-netplugin:latest in registry

```

Signed-off-by: Madhu Venugopal <madhu@docker.com>