### PR TITLE
Add support in embedded DNS server for host loopback resolver

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -918,6 +918,7 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (s
 			populatedEndpoints: map[string]struct{}{},
 			config:             containerConfig{},
 			controller:         c,
+			extDNS:             []extDNSEntry{},
 		}
 	}
 	sBox = sb

--- a/resolvconf/dns/resolvconf.go
+++ b/resolvconf/dns/resolvconf.go
@@ -4,14 +4,23 @@ import (
 	"regexp"
 )
 
-// IPLocalhost is a regex patter for localhost IP address range.
+// IPLocalhost is a regex pattern for IPv4 or IPv6 loopback range.
 const IPLocalhost = `((127\.([0-9]{1,3}\.){2}[0-9]{1,3})|(::1)$)`
 
+// IPv4Localhost is a regex pattern for IPv4 localhost address range.
+const IPv4Localhost = `(127\.([0-9]{1,3}\.){2}[0-9]{1,3})`
+
 var localhostIPRegexp = regexp.MustCompile(IPLocalhost)
+var localhostIPv4Regexp = regexp.MustCompile(IPv4Localhost)
 
 // IsLocalhost returns true if ip matches the localhost IP regular expression.
 // Used for determining if nameserver settings are being passed which are
 // localhost addresses
 func IsLocalhost(ip string) bool {
 	return localhostIPRegexp.MatchString(ip)
+}
+
+// IsIPv4Localhost returns true if ip matches the IPv4 localhost regular expression.
+func IsIPv4Localhost(ip string) bool {
+	return localhostIPv4Regexp.MatchString(ip)
 }

--- a/sandbox.go
+++ b/sandbox.go
@@ -69,7 +69,7 @@ type sandbox struct {
 	id                 string
 	containerID        string
 	config             containerConfig
-	extDNS             []string
+	extDNS             []extDNSEntry
 	osSbox             osl.Sandbox
 	controller         *controller
 	resolver           Resolver

--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/etchosts"
 	"github.com/docker/libnetwork/resolvconf"
+	"github.com/docker/libnetwork/resolvconf/dns"
 	"github.com/docker/libnetwork/types"
 )
 
@@ -161,6 +162,20 @@ func (sb *sandbox) restorePath() {
 	}
 }
 
+func (sb *sandbox) setExternalResolvers(content []byte, addrType int, checkLoopback bool) {
+	servers := resolvconf.GetNameservers(content, addrType)
+	for _, ip := range servers {
+		hostLoopback := false
+		if checkLoopback {
+			hostLoopback = dns.IsIPv4Localhost(ip)
+		}
+		sb.extDNS = append(sb.extDNS, extDNSEntry{
+			ipStr:        ip,
+			hostLoopback: hostLoopback,
+		})
+	}
+}
+
 func (sb *sandbox) setupDNS() error {
 	var newRC *resolvconf.File
 
@@ -208,7 +223,17 @@ func (sb *sandbox) setupDNS() error {
 		if err != nil {
 			return err
 		}
+		// After building the resolv.conf from the user config save the
+		// external resolvers in the sandbox. Note that --dns 127.0.0.x
+		// config refers to the loopback in the container namespace
+		sb.setExternalResolvers(newRC.Content, types.IPv4, false)
 	} else {
+		// If the host resolv.conf file has 127.0.0.x container should
+		// use the host restolver for queries. This is supported by the
+		// docker embedded DNS server. Hence save the external resolvers
+		// before filtering it out.
+		sb.setExternalResolvers(currRC.Content, types.IPv4, true)
+
 		// Replace any localhost/127.* (at this point we have no info about ipv6, pass it as true)
 		if newRC, err = resolvconf.FilterResolvDNS(currRC.Content, true); err != nil {
 			return err
@@ -297,7 +322,6 @@ func (sb *sandbox) updateDNS(ipv6Enabled bool) error {
 
 // Embedded DNS server has to be enabled for this sandbox. Rebuild the container's
 // resolv.conf by doing the following
-// - Save the external name servers in resolv.conf in the sandbox
 // - Add only the embedded server's IP to container's resolv.conf
 // - If the embedded server needs any resolv.conf options add it to the current list
 func (sb *sandbox) rebuildDNS() error {
@@ -306,10 +330,9 @@ func (sb *sandbox) rebuildDNS() error {
 		return err
 	}
 
-	// localhost entries have already been filtered out from the list
-	// retain only the v4 servers in sb for forwarding the DNS queries
-	sb.extDNS = resolvconf.GetNameservers(currRC.Content, types.IPv4)
-
+	if len(sb.extDNS) == 0 {
+		sb.setExternalResolvers(currRC.Content, types.IPv4, false)
+	}
 	var (
 		dnsList        = []string{sb.resolver.NameServer()}
 		dnsOptionsList = resolvconf.GetOptions(currRC.Content)

--- a/sandbox_store.go
+++ b/sandbox_store.go
@@ -27,7 +27,7 @@ type sbState struct {
 	dbExists   bool
 	Eps        []epState
 	EpPriority map[string]int
-	ExtDNS     []string
+	ExtDNS     []extDNSEntry
 }
 
 func (sbs *sbState) Key() []string {


### PR DESCRIPTION
Currently the loopback address from host's resolv.conf is filtered out. If that was the only nameserver available docker adds Google DNS servers by default for the containers. This is not ideal in many cases 
- google DNS servers are not reachable
- external DNS server to be used has a white list of acceptable clients
- DNSSEC enabled local resolvers

This PR adds support handling the external resolver available at the host loopback address. If the host resolv.conf has other external resolvers after 127.0.0.x, embedded server will continue to try them after first trying to resolve using the host resolver.  The current behavior of using a resolver local to the container using `--dns 127.0.0.x` will also continue to work.

related to 
[docker #23910](https://github.com/docker/docker/issues/23910)
[docker #14627](https://github.com/docker/docker/issues/14627)
[docker #6388](https://github.com/docker/docker/issues/6388)

Signed-off-by: Santhosh Manohar <santhosh@docker.com>