### PR TITLE
Let drvRegistry to override remote plugin

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -79,6 +79,9 @@ type NetworkController interface {
 	// BuiltinDrivers returns list of builtin drivers
 	BuiltinDrivers() []string
 
+	// BuiltinIPAMDrivers returns list of builtin ipam drivers
+	BuiltinIPAMDrivers() []string
+
 	// Config method returns the bootup configuration for the controller
 	Config() config.Config
 
@@ -476,12 +479,23 @@ func (c *controller) ID() string {
 
 func (c *controller) BuiltinDrivers() []string {
 	drivers := []string{}
-	for _, i := range getInitializers(c.cfg.Daemon.Experimental) {
-		if i.ntype == "remote" {
-			continue
+	c.drvRegistry.WalkDrivers(func(name string, driver driverapi.Driver, capability driverapi.Capability) bool {
+		if driver.IsBuiltIn() {
+			drivers = append(drivers, name)
 		}
-		drivers = append(drivers, i.ntype)
-	}
+		return false
+	})
+	return drivers
+}
+
+func (c *controller) BuiltinIPAMDrivers() []string {
+	drivers := []string{}
+	c.drvRegistry.WalkIPAMs(func(name string, driver ipamapi.Ipam, cap *ipamapi.Capability) bool {
+		if driver.IsBuiltIn() {
+			drivers = append(drivers, name)
+		}
+		return false
+	})
 	return drivers
 }
 

--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -74,6 +74,9 @@ type Driver interface {
 
 	// Type returns the the type of this driver, the network type this driver manages
 	Type() string
+
+	// IsBuiltIn returns true if it is a built-in driver
+	IsBuiltIn() bool
 }
 
 // NetworkInfo provides a go interface for drivers to provide network

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -1424,6 +1424,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil

--- a/drivers/host/host.go
+++ b/drivers/host/host.go
@@ -86,6 +86,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil

--- a/drivers/ipvlan/ipvlan.go
+++ b/drivers/ipvlan/ipvlan.go
@@ -84,6 +84,10 @@ func (d *driver) Type() string {
 	return ipvlanType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
 	return nil
 }

--- a/drivers/macvlan/macvlan.go
+++ b/drivers/macvlan/macvlan.go
@@ -86,6 +86,10 @@ func (d *driver) Type() string {
 	return macvlanType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
 	return nil
 }

--- a/drivers/null/null.go
+++ b/drivers/null/null.go
@@ -86,6 +86,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -211,6 +211,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 func validateSelf(node string) error {
 	advIP := net.ParseIP(node)
 	if advIP == nil {

--- a/drivers/overlay/ovmanager/ovmanager.go
+++ b/drivers/overlay/ovmanager/ovmanager.go
@@ -229,6 +229,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return types.NotImplementedErrorf("not implemented")

--- a/drivers/remote/driver.go
+++ b/drivers/remote/driver.go
@@ -312,6 +312,10 @@ func (d *driver) Type() string {
 	return d.networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return false
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	if dType != discoverapi.NodeDiscovery {

--- a/drivers/solaris/bridge/bridge.go
+++ b/drivers/solaris/bridge/bridge.go
@@ -916,6 +916,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil

--- a/drivers/solaris/overlay/overlay.go
+++ b/drivers/solaris/overlay/overlay.go
@@ -200,6 +200,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 func validateSelf(node string) error {
 	advIP := net.ParseIP(node)
 	if advIP == nil {

--- a/drivers/solaris/overlay/ovmanager/ovmanager.go
+++ b/drivers/solaris/overlay/ovmanager/ovmanager.go
@@ -229,6 +229,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return types.NotImplementedErrorf("not implemented")

--- a/drivers/windows/overlay/overlay_windows.go
+++ b/drivers/windows/overlay/overlay_windows.go
@@ -176,6 +176,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 func validateSelf(node string) error {
 	advIP := net.ParseIP(node)
 	if advIP == nil {

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -698,6 +698,10 @@ func (d *driver) Type() string {
 	return d.name
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil

--- a/drvregistry/drvregistry.go
+++ b/drvregistry/drvregistry.go
@@ -164,10 +164,10 @@ func (r *DrvRegistry) RegisterDriver(ntype string, driver driverapi.Driver, capa
 	}
 
 	r.Lock()
-	_, ok := r.drivers[ntype]
+	dd, ok := r.drivers[ntype]
 	r.Unlock()
 
-	if ok {
+	if ok && dd.driver.IsBuiltIn() {
 		return driverapi.ErrActiveRegistration(ntype)
 	}
 
@@ -192,9 +192,9 @@ func (r *DrvRegistry) registerIpamDriver(name string, driver ipamapi.Ipam, caps 
 	}
 
 	r.Lock()
-	_, ok := r.ipamDrivers[name]
+	dd, ok := r.ipamDrivers[name]
 	r.Unlock()
-	if ok {
+	if ok && dd.driver.IsBuiltIn() {
 		return types.ForbiddenErrorf("ipam driver %q already registered", name)
 	}
 

--- a/drvregistry/drvregistry_test.go
+++ b/drvregistry/drvregistry_test.go
@@ -68,6 +68,10 @@ func (m *mockDriver) Type() string {
 	return mockDriverName
 }
 
+func (m *mockDriver) IsBuiltIn() bool {
+	return true
+}
+
 func (m *mockDriver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
 	return nil
 }

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -594,3 +594,8 @@ func (a *Allocator) DumpDatabase() string {
 
 	return s
 }
+
+// IsBuiltIn returns true for builtin drivers
+func (a *Allocator) IsBuiltIn() bool {
+	return true
+}

--- a/ipamapi/contract.go
+++ b/ipamapi/contract.go
@@ -80,6 +80,9 @@ type Ipam interface {
 	RequestAddress(string, net.IP, map[string]string) (*net.IPNet, map[string]string, error)
 	// Release the address from the specified pool ID
 	ReleaseAddress(string, net.IP) error
+
+	//IsBuiltIn returns true if it is a built-in driver.
+	IsBuiltIn() bool
 }
 
 // Capability represents the requirements and capabilities of the IPAM driver

--- a/ipams/null/null.go
+++ b/ipams/null/null.go
@@ -65,6 +65,10 @@ func (a *allocator) DiscoverDelete(dType discoverapi.DiscoveryType, data interfa
 	return nil
 }
 
+func (a *allocator) IsBuiltIn() bool {
+	return true
+}
+
 // Init registers a remote ipam when its plugin is activated
 func Init(ic ipamapi.Callback, l, g interface{}) error {
 	return ic.RegisterIpamDriver(ipamapi.NullIPAM, &allocator{})

--- a/ipams/remote/remote.go
+++ b/ipams/remote/remote.go
@@ -149,3 +149,7 @@ func (a *allocator) DiscoverNew(dType discoverapi.DiscoveryType, data interface{
 func (a *allocator) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }
+
+func (a *allocator) IsBuiltIn() bool {
+	return false
+}

--- a/ipams/windowsipam/windowsipam.go
+++ b/ipams/windowsipam/windowsipam.go
@@ -101,3 +101,7 @@ func (a *allocator) DiscoverNew(dType discoverapi.DiscoveryType, data interface{
 func (a *allocator) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }
+
+func (a *allocator) IsBuiltIn() bool {
+	return true
+}

--- a/libnetwork_internal_test.go
+++ b/libnetwork_internal_test.go
@@ -544,6 +544,9 @@ func (b *badDriver) DiscoverDelete(dType discoverapi.DiscoveryType, data interfa
 func (b *badDriver) Type() string {
 	return badDriverName
 }
+func (b *badDriver) IsBuiltIn() bool {
+	return false
+}
 func (b *badDriver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
 	return nil
 }


### PR DESCRIPTION

Addresses https://github.com/docker/docker/issues/29473

drvRegistry isnt aware if a plugin is v1 or v2. Plugin-v2 provides a way
for user to disable and remove plugins. But unfortunately, there isnt
any api to advertise the removal to drvRegistry. Hence there is no way
to handle "docker plugin rm" of installed plugin. In order to support
the case of "docker plugin install x" followed by "docker plugin rm x"
followed by reinstalling of plugin "docker plugin install x",
drvRegistry must allow overriding any existing plugin with the same
name. The protection in plugin infra will prevent willful override of
existing plugin.