### PR TITLE
proxy: fix an issue about half-closing net.TCPConn after io.Copy()

### DIFF
--- a/cmd/proxy/tcp_proxy.go
+++ b/cmd/proxy/tcp_proxy.go
@@ -48,7 +48,8 @@ func (proxy *TCPProxy) clientLoop(client *net.TCPConn, quit chan bool) {
 				from.CloseWrite()
 			}
 		}
-		to.CloseRead()
+		from.CloseRead()
+		to.CloseWrite()
 		wg.Done()
 	}
 


### PR DESCRIPTION
Related to docker/docker#27539

After `io.Copy(to, from)`, we should call `to.CloseWrite()`, not `to.CloseRead()`.

Without this fix, `TestTCP4ProxyHalfClose` (newly added in this commit) fails as
follows:

```
--- FAIL: TestTCP4ProxyHalfClose (0.00s)
            network_proxy_test.go:135: EOF
```

In this test, the client calls `Write()`, `CloseWrite()`, then `Read()`, and the server calls `ReadAll()`, then `Write()`.

Without the fix, the client fails to `Read()` because of `EOF`.


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>