### PR TITLE
Make use of GetAllManagedPluginsForCap to avoid loading v1-plugins

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -143,8 +143,8 @@
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/plugingetter",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-1985-gfebf53d",
-			"Rev": "febf53d91a43fe13fbb802d9e6b7b6732183cf21"
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-4185-ge4512d2",
+			"Rev": "e4512d264741e83e954a19f9ef5e3cb06c5856b6"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/plugins",

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/plugingetter/getter.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/plugingetter/getter.go
@@ -5,22 +5,31 @@ import "github.com/docker/docker/pkg/plugins"
 const (
 	// LOOKUP doesn't update RefCount
 	LOOKUP = 0
-	// CREATE increments RefCount
-	CREATE = 1
-	// REMOVE decrements RefCount
-	REMOVE = -1
+	// ACQUIRE increments RefCount
+	ACQUIRE = 1
+	// RELEASE decrements RefCount
+	RELEASE = -1
 )
 
-// CompatPlugin is a abstraction to handle both v2(new) and v1(legacy) plugins.
+// CompatPlugin is an abstraction to handle both v2(new) and v1(legacy) plugins.
 type CompatPlugin interface {
 	Client() *plugins.Client
 	Name() string
+	BasePath() string
 	IsV1() bool
+}
+
+// CountedPlugin is a plugin which is reference counted.
+type CountedPlugin interface {
+	Acquire()
+	Release()
+	CompatPlugin
 }
 
 // PluginGetter is the interface implemented by Store
 type PluginGetter interface {
 	Get(name, capability string, mode int) (CompatPlugin, error)
 	GetAllByCap(capability string) ([]CompatPlugin, error)
+	GetAllManagedPluginsByCap(capability string) []CompatPlugin
 	Handle(capability string, callback func(string, *plugins.Client))
 }

--- a/drivers/remote/driver.go
+++ b/drivers/remote/driver.go
@@ -46,7 +46,7 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 	handleFunc := plugins.Handle
 	if pg := dc.GetPluginGetter(); pg != nil {
 		handleFunc = pg.Handle
-		activePlugins, _ := pg.GetAllByCap(driverapi.NetworkPluginEndpointType)
+		activePlugins := pg.GetAllManagedPluginsByCap(driverapi.NetworkPluginEndpointType)
 		for _, ap := range activePlugins {
 			newPluginHandler(ap.Name(), ap.Client())
 		}

--- a/ipams/remote/remote.go
+++ b/ipams/remote/remote.go
@@ -50,7 +50,7 @@ func Init(cb ipamapi.Callback, l, g interface{}) error {
 	handleFunc := plugins.Handle
 	if pg := cb.GetPluginGetter(); pg != nil {
 		handleFunc = pg.Handle
-		activePlugins, _ := pg.GetAllByCap(ipamapi.PluginEndpointType)
+		activePlugins := pg.GetAllManagedPluginsByCap(ipamapi.PluginEndpointType)
 		for _, ap := range activePlugins {
 			newPluginHandler(ap.Name(), ap.Client())
 		}


### PR DESCRIPTION
For more details : https://github.com/docker/docker/pull/29665 and https://github.com/docker/docker/pull/29556