### PR TITLE
ResolveName should return copy of IPs

### DIFF
--- a/network.go
+++ b/network.go
@@ -1645,7 +1645,9 @@ func (n *network) ResolveName(req string, ipType int) ([]net.IP, bool) {
 	}
 
 	if ip != nil {
-		return ip, false
+		ipLocal := make([]net.IP, len(ip))
+		copy(ipLocal, ip)
+		return ipLocal, false
 	}
 
 	return nil, ipv6Miss


### PR DESCRIPTION
Related to [docker #28836](https://github.com/docker/docker/issues/28836)

`ResolveName` returns a slice of IP addresses from the service DB. Since the callers can modify the slice (currently the resolver shuffles the entries which can be racy in case of concurrent calls) `ResolveName` should return a copy of the IP addresses.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>