### PR TITLE
should omit type int from declaration of var start

### DIFF
--- a/drivers/windows/overlay/overlay.pb.go
+++ b/drivers/windows/overlay/overlay.pb.go
@@ -407,7 +407,7 @@ func skipOverlay(data []byte) (n int, err error) {
 		case 3:
 			for {
 				var innerWire uint64
-				var start int = iNdEx
+				var start = iNdEx
 				for shift := uint(0); ; shift += 7 {
 					if shift >= 64 {
 						return 0, ErrIntOverflowOverlay


### PR DESCRIPTION
Signed-off-by: yupengzte <yu.peng36@zte.com.cn>

it will be inferred from the right-hand side