### PR TITLE
print name and id infomation  when  has active endpoints

### DIFF
--- a/error.go
+++ b/error.go
@@ -129,7 +129,7 @@ type ActiveEndpointsError struct {
 }
 
 func (aee *ActiveEndpointsError) Error() string {
-	return fmt.Sprintf("network %s has active endpoints", aee.name)
+	return fmt.Sprintf("network %s id %s has active endpoints", aee.name, aee.id)
 }
 
 // Forbidden denotes the type of this error


### PR DESCRIPTION
Signed-off-by: chchliang <chen.chuanliang@zte.com.cn>

- What I did
print name and id infomation when `docekr network rm` has active endpoints

- How I did it
func (aee *ActiveEndpointsError) Error() string {
return fmt.Sprintf("network %s id %s has active endpoints", aee.name, aee.id[0:12])
}

- How to verify it
`docekr network rm xxx` if network xxx has active endpoints, then print
Error response from daemon: network xxx id xxx has active endpoints