### PR TITLE
Fix the data model inconsistency that breaks upgrade to 1.14-dev

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -72,8 +72,8 @@ const (
 )
 
 type extDNSEntry struct {
-	ipStr        string
-	hostLoopback bool
+	IPStr        string
+	HostLoopback bool
 }
 
 // resolver implements the Resolver interface
@@ -413,15 +413,15 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 	} else {
 		for i := 0; i < maxExtDNS; i++ {
 			extDNS := &r.extDNSList[i]
-			if extDNS.ipStr == "" {
+			if extDNS.IPStr == "" {
 				break
 			}
 			extConnect := func() {
-				addr := fmt.Sprintf("%s:%d", extDNS.ipStr, 53)
+				addr := fmt.Sprintf("%s:%d", extDNS.IPStr, 53)
 				extConn, err = net.DialTimeout(proto, addr, extIOTimeout)
 			}
 
-			if extDNS.hostLoopback {
+			if extDNS.HostLoopback {
 				extConnect()
 			} else {
 				execErr := r.backend.ExecFunc(extConnect)
@@ -435,7 +435,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 				continue
 			}
 			logrus.Debugf("Query %s[%d] from %s, forwarding to %s:%s", name, query.Question[0].Qtype,
-				extConn.LocalAddr().String(), proto, extDNS.ipStr)
+				extConn.LocalAddr().String(), proto, extDNS.IPStr)
 
 			// Timeout has to be set for every IO operation.
 			extConn.SetDeadline(time.Now().Add(extIOTimeout))

--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -174,8 +174,8 @@ func (sb *sandbox) setExternalResolvers(content []byte, addrType int, checkLoopb
 			hostLoopback = dns.IsIPv4Localhost(ip)
 		}
 		sb.extDNS = append(sb.extDNS, extDNSEntry{
-			ipStr:        ip,
-			hostLoopback: hostLoopback,
+			IPStr:        ip,
+			HostLoopback: hostLoopback,
 		})
 	}
 }

--- a/sandbox_store.go
+++ b/sandbox_store.go
@@ -27,7 +27,12 @@ type sbState struct {
 	dbExists   bool
 	Eps        []epState
 	EpPriority map[string]int
-	ExtDNS     []extDNSEntry
+	// external servers have to be persisted so that on restart of a live-restore
+	// enabled daemon we get the external servers for the running containers.
+	// We have two versions of ExtDNS to support upgrade & downgrade of the daemon
+	// between >=1.14 and <1.14 versions.
+	ExtDNS  []string
+	ExtDNS2 []extDNSEntry
 }
 
 func (sbs *sbState) Key() []string {
@@ -114,8 +119,16 @@ func (sbs *sbState) CopyTo(o datastore.KVObject) error {
 		dstSbs.Eps = append(dstSbs.Eps, eps)
 	}
 
+	if len(sbs.ExtDNS2) > 0 {
+		for _, dns := range sbs.ExtDNS2 {
+			dstSbs.ExtDNS2 = append(dstSbs.ExtDNS2, dns)
+			dstSbs.ExtDNS = append(dstSbs.ExtDNS, dns.IPStr)
+		}
+		return nil
+	}
 	for _, dns := range sbs.ExtDNS {
 		dstSbs.ExtDNS = append(dstSbs.ExtDNS, dns)
+		dstSbs.ExtDNS2 = append(dstSbs.ExtDNS2, extDNSEntry{IPStr: dns})
 	}
 
 	return nil
@@ -131,7 +144,11 @@ func (sb *sandbox) storeUpdate() error {
 		ID:         sb.id,
 		Cid:        sb.containerID,
 		EpPriority: sb.epPriority,
-		ExtDNS:     sb.extDNS,
+		ExtDNS2:    sb.extDNS,
+	}
+
+	for _, ext := range sb.extDNS {
+		sbs.ExtDNS = append(sbs.ExtDNS, ext.IPStr)
 	}
 
 retry:
@@ -205,7 +222,15 @@ func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 			dbIndex:            sbs.dbIndex,
 			isStub:             true,
 			dbExists:           true,
-			extDNS:             sbs.ExtDNS,
+		}
+		// If we are restoring from a older version extDNSEntry won't have the
+		// HostLoopback field
+		if len(sbs.ExtDNS2) > 0 {
+			sb.extDNS = sbs.ExtDNS2
+		} else {
+			for _, dns := range sbs.ExtDNS {
+				sb.extDNS = append(sb.extDNS, extDNSEntry{IPStr: dns})
+			}
 		}
 
 		msg := " for cleanup"


### PR DESCRIPTION
#1595 introduced a change to the sandbox state that is persisted in boltdb. This results in container start failing when upgrading from 1.12.x to 1.14-dev. This error is seen on task/container start..

````
ERRO[0283] fatal task error                              error="starting container failed: failed to update the store state of sandbox: failed to update store for object type *libnetwork.sbState: json: cannot unmarshal string into Go value of type libnetwork.extDNSEntry" module="node/agent/taskmanager" task.id=6zenzorwcsjftn5clzdg4vw9e
````

This PR adds the required reconciliation to handle the data model change between the versions. Verified that 1.12.x to 1.14-dev and also 1.14-dev to 1.12 works (downgrade not supported in swarm mode though)

Signed-off-by: Santhosh Manohar <santhosh@docker.com>