### PR TITLE
Fix GetNameServerAsCIDR

### DIFF
--- a/resolvconf/resolvconf.go
+++ b/resolvconf/resolvconf.go
@@ -178,7 +178,14 @@ func GetNameservers(resolvConf []byte, kind int) []string {
 func GetNameserversAsCIDR(resolvConf []byte) []string {
 	nameservers := []string{}
 	for _, nameserver := range GetNameservers(resolvConf, types.IP) {
-		nameservers = append(nameservers, nameserver+"/32")
+		var address string
+		// If IPv6, strip zone if present
+		if strings.Contains(nameserver, ":") {
+			address = strings.Split(nameserver, "%")[0] + "/128"
+		} else {
+			address = nameserver + "/32"
+		}
+		nameservers = append(nameservers, address)
 	}
 	return nameservers
 }


### PR DESCRIPTION
- the function is broken as it does not strip the
  zone id from an IPv6 nameserver address, and it
  returns the IPv6 address with /32

In presence of zoned ipv6 nameservers in resolv.conf, `CheckNameserverOverlaps()` will fail 
to parse the CIDR and the calling funtion `FindAvailableNetwork()` will assume that all the 
predefined address pools overlaps with some nameserver.

Because of the change in #1590 this issue is now exposed.

Related to docker/docker/issues/30295

Signed-off-by: Alessandro Boch <aboch@docker.com>