### PR TITLE
Gracefully handle redundant ipvs service create failures

### DIFF
--- a/service_linux.go
+++ b/service_linux.go
@@ -192,7 +192,7 @@ func (sb *sandbox) addLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*P
 			return
 		}
 
-		if err := i.NewService(s); err != nil {
+		if err := i.NewService(s); err != nil && err != syscall.EEXIST {
 			logrus.Errorf("Failed to create a new service for vip %s fwmark %d: %v", vip, fwMark, err)
 			return
 		}


### PR DESCRIPTION
On service create with multiple replicas or on service scale,
multiple concurrent calls to `addLBBackend()` happens, all trying to
create the same service. One succeeds, the other ones get the file exists error,
generating this misleading log:

```
ERRO[0539] Failed to create a new service for vip 10.0.0.2 fwmark 256: file exists 
```

Signed-off-by: Alessandro Boch <aboch@docker.com>