### PR TITLE
Reverting the strict network name check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,11 +17,11 @@ import (
 	"github.com/docker/libnetwork/osl"
 )
 
-// restrictedNameRegex represents the regular expression which regulates the allowed network or endpoint names.
-const restrictedNameRegex = `^[\w]+[\w-. ]*[\w]+$`
+// RestrictedNameChars collects the characters allowed to represent a network or endpoint name.
+const restrictedNameChars = `[a-zA-Z0-9][a-zA-Z0-9_.-]`
 
 // RestrictedNamePattern is a regular expression to validate names against the collection of restricted characters.
-var restrictedNamePattern = regexp.MustCompile(restrictedNameRegex)
+var restrictedNamePattern = regexp.MustCompile(`^/?` + restrictedNameChars + `+$`)
 
 // Config encapsulates configurations of various Libnetwork components
 type Config struct {
@@ -243,7 +243,7 @@ func (c *Config) ProcessOptions(options ...Option) {
 // ValidateName validates configuration objects supported by libnetwork
 func ValidateName(name string) error {
 	if !restrictedNamePattern.MatchString(name) {
-		return fmt.Errorf("%q includes invalid characters, resource name has to conform to %q", name, restrictedNameRegex)
+		return fmt.Errorf("%s includes invalid characters, only %q are allowed", name, restrictedNameChars)
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -16,12 +14,6 @@ import (
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/osl"
 )
-
-// RestrictedNameChars collects the characters allowed to represent a network or endpoint name.
-const restrictedNameChars = `[a-zA-Z0-9][a-zA-Z0-9_.-]`
-
-// RestrictedNamePattern is a regular expression to validate names against the collection of restricted characters.
-var restrictedNamePattern = regexp.MustCompile(`^/?` + restrictedNameChars + `+$`)
 
 // Config encapsulates configurations of various Libnetwork components
 type Config struct {
@@ -240,12 +232,12 @@ func (c *Config) ProcessOptions(options ...Option) {
 	}
 }
 
-// ValidateName validates configuration objects supported by libnetwork
-func ValidateName(name string) error {
-	if !restrictedNamePattern.MatchString(name) {
-		return fmt.Errorf("%s includes invalid characters, only %q are allowed", name, restrictedNameChars)
+// IsValidName validates configuration objects supported by libnetwork
+func IsValidName(name string) bool {
+	if strings.TrimSpace(name) == "" {
+		return false
 	}
-	return nil
+	return true
 }
 
 // OptionLocalKVProvider function returns an option setter for kvstore provider

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,16 +46,13 @@ func TestOptionsLabels(t *testing.T) {
 }
 
 func TestValidName(t *testing.T) {
-	if err := ValidateName("test"); err != nil {
+	if !IsValidName("test") {
 		t.Fatal("Name validation fails for a name that must be accepted")
 	}
-	if err := ValidateName(""); err == nil {
+	if IsValidName("") {
 		t.Fatal("Name validation succeeds for a case when it is expected to fail")
 	}
-	if err := ValidateName("   "); err == nil {
-		t.Fatal("Name validation succeeds for a case when it is expected to fail")
-	}
-	if err := ValidateName("<>$$^"); err == nil {
+	if IsValidName("   ") {
 		t.Fatal("Name validation succeeds for a case when it is expected to fail")
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,37 +46,17 @@ func TestOptionsLabels(t *testing.T) {
 }
 
 func TestValidName(t *testing.T) {
-	assertName(t, "test", true)
-	assertName(t, "test1", true)
-	assertName(t, "test1.2_3", true)
-	assertName(t, "_test", true)
-	assertName(t, "test_", true)
-	assertName(t, "looks-good", true)
-	assertName(t, " test", false)
-	assertName(t, "test ", false)
-	assertName(t, "test.", false)
-	assertName(t, ".test", false)
-	assertName(t, "", false)
-	assertName(t, "   ", false)
-	assertName(t, "<>$$^", false)
-	assertName(t, "this is a good network name", true)
-	assertName(t, "this is also-good", true)
-	assertName(t, " this is a not good network name", false)
-	assertName(t, "this is a not either ", false)
-	assertName(t, "this one\nis not good", false)
-	assertName(t, "this one\tis not good", false)
-	assertName(t, "this one\ris not good", false)
-	assertName(t, "this one\vis not good", false)
-	assertName(t, "this one\fis not good", false)
-}
-func assertName(t *testing.T, name string, mustSucceed bool) {
-	msg := "Name validation succeeds for a case when it is expected to fail"
-	if mustSucceed {
-		msg = "Name validation fails for a name that must be accepted"
+	if err := ValidateName("test"); err != nil {
+		t.Fatal("Name validation fails for a name that must be accepted")
 	}
-	err := ValidateName(name)
-	if (err == nil) != mustSucceed {
-		t.Fatalf("%s: %s", msg, name)
+	if err := ValidateName(""); err == nil {
+		t.Fatal("Name validation succeeds for a case when it is expected to fail")
+	}
+	if err := ValidateName("   "); err == nil {
+		t.Fatal("Name validation succeeds for a case when it is expected to fail")
+	}
+	if err := ValidateName("<>$$^"); err == nil {
+		t.Fatal("Name validation succeeds for a case when it is expected to fail")
 	}
 }
 

--- a/controller.go
+++ b/controller.go
@@ -647,8 +647,8 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 		}
 	}
 
-	if err := config.ValidateName(name); err != nil {
-		return nil, ErrInvalidName(err.Error())
+	if !config.IsValidName(name) {
+		return nil, ErrInvalidName(name)
 	}
 
 	if id == "" {

--- a/error.go
+++ b/error.go
@@ -69,7 +69,7 @@ func (ii ErrInvalidID) Error() string {
 func (ii ErrInvalidID) BadRequest() {}
 
 // ErrInvalidName is returned when a query-by-name or resource create method is
-// invoked with an invalid name parameter
+// invoked with an empty name parameter
 type ErrInvalidName string
 
 func (in ErrInvalidName) Error() string {

--- a/network.go
+++ b/network.go
@@ -879,9 +879,8 @@ func (n *network) addEndpoint(ep *endpoint) error {
 
 func (n *network) CreateEndpoint(name string, options ...EndpointOption) (Endpoint, error) {
 	var err error
-
-	if err = config.ValidateName(name); err != nil {
-		return nil, ErrInvalidName(err.Error())
+	if !config.IsValidName(name) {
+		return nil, ErrInvalidName(name)
 	}
 
 	if _, err = n.EndpointByName(name); err == nil {


### PR DESCRIPTION
Reverting the strict network name check until we find a backward compatible way of introducing this change.
Pls refer to the discussion in  https://github.com/docker/docker/issues/29829 for more details.