### PR TITLE
Ignore previous serf user events to avoid wrong fdb programming

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -644,6 +644,9 @@ func (n *network) watchMiss(nlSock *nl.NetlinkSocket) {
 			}
 
 			if neigh.IP.To4() == nil {
+				if neigh.HardwareAddr != nil {
+					logrus.Debugf("Miss notification, l2 mac %v", neigh.HardwareAddr)
+				}
 				continue
 			}
 

--- a/osl/neigh_linux.go
+++ b/osl/neigh_linux.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
 
@@ -96,6 +97,7 @@ func (n *networkNamespace) AddNeighbor(dstIP net.IP, dstMac net.HardwareAddr, op
 
 	nh := n.findNeighbor(dstIP, dstMac)
 	if nh != nil {
+		logrus.Debugf("Neighbor entry already present for IP %v, mac %v", dstIP, dstMac)
 		// If it exists silently return
 		return nil
 	}


### PR DESCRIPTION
When deploying classic swarm with overlay network and using `on-node-failure` reschedule policy randomly some containers might have connectivity issues with other containers in the same network.

To illustrate: One container C1 with three worker nodes W1, W2 and W3.

Container interface's mac is built from the IP address. 
Let say C1 has 10.0.0.2 and mac 02:42:0a:00:00:02. If its initially scheduled on W1 the reachability info will be distributed to other nodes will be 
`<join 10.0.0.2, 02:42:0a:00:00:02, VTEP IP of W1>`

If W1 goes through a failure and the container gets rescheduled to W2  the results events will be
`<leave 10.0.0.2, 02:42:0a:00:00:02, VTEP IP of W1>`
`<join 10.0.0.2, 02:42:0a:00:00:02, VTEP IP of W2>`

At this point if W3's daemon is restarted serf replays all the previous events. But they can be delivered out of order to the client. So libnetwork could end up getting the following..

`<join 10.0.0.2, 02:42:0a:00:00:02, VTEP IP of W2>`
`<leave 10.0.0.2, 02:42:0a:00:00:02, VTEP IP of W1>`
`<join 10.0.0.2, 02:42:0a:00:00:02, VTEP IP of W1>`

W3 ends up with incorrect forwarding info.

The change is to avoid getting the older events from serf when joining the gossip cluster. Hence for the containers that are already running in the network the miss notification and query mechanism will be used to program the neighbor entry/FDB.

Also added some debugs to help in debugging.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>