### PR TITLE
Update the local VTEP in peerdb on receiving self discovery

### DIFF
--- a/drivers/overlay/peerdb.go
+++ b/drivers/overlay/peerdb.go
@@ -367,3 +367,12 @@ func (d *driver) pushLocalDb() {
 		return false
 	})
 }
+
+func (d *driver) peerDBUpdateSelf() {
+	d.peerDbWalk(func(nid string, pkey *peerKey, pEntry *peerEntry) bool {
+		if pEntry.isLocal {
+			pEntry.vtep = net.ParseIP(d.advertiseAddress)
+		}
+		return false
+	})
+}


### PR DESCRIPTION
On a daemon or node restart containers with restart `always` policy can come up before the self discovery event is received by libnetwork. In such cases the peer DB entry would have been updated with `nil` VTEP IP. It has to be corrected when we get the discovery event. Otherwise if a peer restarts and then queries for this IP it will not get the right VTEP.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>