### PR TITLE
Serialize non-atomic jump rule programming in bridge

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -714,7 +714,9 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 
 	joinCluster(network)
 	if !c.isDistributedControl() {
+		c.Lock()
 		arrangeIngressFilterRule()
+		c.Unlock()
 	}
 
 	return network, nil

--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -114,7 +114,10 @@ func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInt
 		n.portMapper.SetIptablesChain(natChain, n.getNetworkBridgeName())
 	}
 
-	if err := ensureJumpRule("FORWARD", IsolationChain); err != nil {
+	d.Lock()
+	err = ensureJumpRule("FORWARD", IsolationChain)
+	d.Unlock()
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Related to docker/docker/issues/25393

- The per-host same iptables rule programming done by `ensureJumpRule()` 
   is processed for each network create.
   Concurrent networks creations sometimes exposes the non-atomicity of the
   function causing the network creation to fail.
- I opted for a minimal impact fix which serializes the function executions.

Signed-off-by: Alessandro Boch <aboch@docker.com>