### PR TITLE
Lock linux namespace structure when adding neighbors

### DIFF
--- a/osl/neigh_linux.go
+++ b/osl/neigh_linux.go
@@ -147,7 +147,9 @@ func (n *networkNamespace) AddNeighbor(dstIP net.IP, dstMac net.HardwareAddr, op
 		return fmt.Errorf("could not add neighbor entry: %v", err)
 	}
 
+	n.Lock()
 	n.neighbors = append(n.neighbors, nh)
+	n.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
Aquire the linux network namespace lock before adding neighbors. neighbor deletion code takes the lock correctly.

kernel's watch miss notification and the serf events are handled in two different go routines. So its possible to end up with concurrent AddNeighbor and DeleteNeighbor calls. Racy behavior here can lead to a situation where the fdb entry for the peer has been removed from the kernel but not removed from `networkNamespace.neighbors`. This can result in a permanent loss of connectivity for any container that gets that particular IP address. Such a symptom has been reported by an UCP customer.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>