### PR TITLE
Add a filter chain to allow persistent rules

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -844,6 +844,10 @@ addToStore:
 		c.Unlock()
 	}
 
+	c.Lock()
+	arrangeUserFilterRule()
+	c.Unlock()
+
 	return network, nil
 }
 

--- a/firewall_linux.go
+++ b/firewall_linux.go
@@ -1,0 +1,29 @@
+package libnetwork
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/libnetwork/iptables"
+)
+
+const userChain = "DOCKER-USER"
+
+// This chain allow users to configure firewall policies in a way that persists
+// docker operations/restarts. Docker will not delete or modify any pre-existing
+// rules from the DOCKER-USER filter chain.
+func arrangeUserFilterRule() {
+	_, err := iptables.NewChain(userChain, iptables.Filter, false)
+	if err != nil {
+		logrus.Warnf("Failed to create %s chain: %v", userChain, err)
+		return
+	}
+
+	if err = iptables.AddReturnRule(userChain); err != nil {
+		logrus.Warnf("Failed to add the RETURN rule for %s: %v", userChain, err)
+		return
+	}
+
+	err = iptables.EnsureJumpRule("FORWARD", userChain)
+	if err != nil {
+		logrus.Warnf("Failed to ensure the jump rule for %s: %v", userChain, err)
+	}
+}

--- a/firewall_others.go
+++ b/firewall_others.go
@@ -1,0 +1,6 @@
+// +build !linux
+
+package libnetwork
+
+func arrangeUserFilterRule() {
+}

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -498,3 +498,44 @@ func parseVersionNumbers(input string) (major, minor, micro int) {
 func supportsCOption(mj, mn, mc int) bool {
 	return mj > 1 || (mj == 1 && (mn > 4 || (mn == 4 && mc >= 11)))
 }
+
+// AddReturnRule adds a return rule for the chain in the filter table
+func AddReturnRule(chain string) error {
+	var (
+		table = Filter
+		args  = []string{"-j", "RETURN"}
+	)
+
+	if Exists(table, chain, args...) {
+		return nil
+	}
+
+	err := RawCombinedOutput(append([]string{"-A", chain}, args...)...)
+	if err != nil {
+		return fmt.Errorf("unable to add return rule in %s chain: %s", chain, err.Error())
+	}
+
+	return nil
+}
+
+// EnsureJumpRule ensures the jump rule is on top
+func EnsureJumpRule(fromChain, toChain string) error {
+	var (
+		table = Filter
+		args  = []string{"-j", toChain}
+	)
+
+	if Exists(table, fromChain, args...) {
+		err := RawCombinedOutput(append([]string{"-D", fromChain}, args...)...)
+		if err != nil {
+			return fmt.Errorf("unable to remove jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
+		}
+	}
+
+	err := RawCombinedOutput(append([]string{"-I", fromChain}, args...)...)
+	if err != nil {
+		return fmt.Errorf("unable to insert jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
+	}
+
+	return nil
+}


### PR DESCRIPTION
Allow users to configure firewall policies in way that persists
docker operations/restarts. Docker will not delete or modify any
pre-existing rules from the DOCKER-FORWARD-TOP filter chain. This
allows the user to create in advance any rules required to further
restrict access from/to the containers.

Fixes docker/docker/issues/29184
Fixes docker/docker/issues/23987
Related to docker/docker/issues/24848

Signed-off-by: Jacob Wen <jian.w.wen@oracle.com>