### PR TITLE
ingress sandbox hosts and resolve.conf files location didn't respect the custom daemon root directory

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -47,6 +47,7 @@ import (
 	"container/heap"
 	"fmt"
 	"net"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -957,6 +958,8 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (s
 
 	if sb.ingress {
 		c.ingressSandbox = sb
+		sb.config.hostsPath = filepath.Join(c.cfg.Daemon.DataDir, "/network/files/hosts")
+		sb.config.resolvConfPath = filepath.Join(c.cfg.Daemon.DataDir, "/network/files/resolv.conf")
 		sb.id = "ingress_sbox"
 	}
 	c.Unlock()


### PR DESCRIPTION
Signed-off-by: Krasi Georgiev <krasi@vip-consult.solutions>

a follow up from https://github.com/docker/docker/pull/31690

Related to  https://github.com/docker/docker/issues/31610

**- What I did**
when the docker daemon uses a non default folder as root set custom location for the sandbox files created for the ingress sandbox
**- How I did it**
added them in the ingress config struct when creating the sandbox
**- How to verify it**
dockerd -g /tmp/docker
docker swarm init
ls /tmp/docker/network/files/

ls /var/lib/docker 
should be empty

https://github.com/docker/docker/blob/master/vendor/github.com/docker/libnetwork/sandbox_dns_unix.go#L22

additionally I think I should also change 
defaultPrefix = cfg.Daemon.DataDir+"/network/files"
instead of 
defaultPrefix = "/var/lib/docker/network/files"

please review and let me know