### PR TITLE
Support NDP proxying on bridge networks

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -1030,7 +1030,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	if config.NDPProxyInterface != "" && config.EnableIPv6 {
 		link, err := d.nlh.LinkByName(config.NDPProxyInterface)
 		if err != nil {
-			return err
+			return fmt.Errorf("could not find link for ndp proxy interface %q: %v", config.NDPProxyInterface, err)
 		}
 		neighbor := netlink.Neigh{
 			LinkIndex:    link.Attrs().Index,
@@ -1109,7 +1109,9 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 	// Also make sure defer does not see this error either.
 	if n.config.NDPProxyInterface != "" && n.config.EnableIPv6 {
 		link, err := d.nlh.LinkByName(n.config.NDPProxyInterface)
-		if err == nil {
+		if err != nil {
+			Logrus.Warnf("could not remove ndp neighbour, because could not find link for ndp proxy interface %q: %v", config.NDPProxyInterface, err)
+		} else {			
 			neighbor := netlink.Neigh{
 				LinkIndex:    link.Attrs().Index,
 				Family:       netlink.FAMILY_V6,

--- a/drivers/bridge/bridge_store.go
+++ b/drivers/bridge/bridge_store.go
@@ -136,6 +136,7 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap["BridgeName"] = ncfg.BridgeName
 	nMap["EnableIPv6"] = ncfg.EnableIPv6
 	nMap["EnableIPMasquerade"] = ncfg.EnableIPMasquerade
+	nMap["NDPProxyInterface"] = ncfg.NDPProxyInterface
 	nMap["EnableICC"] = ncfg.EnableICC
 	nMap["Mtu"] = ncfg.Mtu
 	nMap["Internal"] = ncfg.Internal
@@ -185,6 +186,9 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 	ncfg.BridgeName = nMap["BridgeName"].(string)
 	ncfg.EnableIPv6 = nMap["EnableIPv6"].(bool)
 	ncfg.EnableIPMasquerade = nMap["EnableIPMasquerade"].(bool)
+	if v, ok := nMap["NDPProxyInterface"]; ok {
+		ncfg.NDPProxyInterface = v.(string)
+	}
 	ncfg.EnableICC = nMap["EnableICC"].(bool)
 	ncfg.Mtu = int(nMap["Mtu"].(float64))
 	if v, ok := nMap["Internal"]; ok {

--- a/drivers/bridge/labels.go
+++ b/drivers/bridge/labels.go
@@ -7,6 +7,9 @@ const (
 	// EnableIPMasquerade label for bridge driver
 	EnableIPMasquerade = "com.docker.network.bridge.enable_ip_masquerade"
 
+	// NDPProxyInterface label for bridge driver
+	NDPProxyInterface = "com.docker.network.bridge.ndp_proxy_interface"
+
 	// EnableICC label
 	EnableICC = "com.docker.network.bridge.enable_icc"
 

--- a/drivers/bridge/setup_ipv6.go
+++ b/drivers/bridge/setup_ipv6.go
@@ -18,6 +18,9 @@ const (
 	ipv6ForwardConfPerm    = 0644
 	ipv6ForwardConfDefault = "/proc/sys/net/ipv6/conf/default/forwarding"
 	ipv6ForwardConfAll     = "/proc/sys/net/ipv6/conf/all/forwarding"
+	ndpProxyConfPerm       = 0644
+	ndpProxyConfDefault    = "/proc/sys/net/ipv6/conf/default/proxy_ndp"
+	ndpProxyConfAll        = "/proc/sys/net/ipv6/conf/all/proxy_ndp"
 )
 
 func init() {
@@ -112,6 +115,34 @@ func setupIPv6Forwarding(config *networkConfiguration, i *bridgeInterface) error
 	if ipv6ForwardDataAll[0] != '1' {
 		if err := ioutil.WriteFile(ipv6ForwardConfAll, []byte{'1', '\n'}, ipv6ForwardConfPerm); err != nil {
 			logrus.Warnf("Unable to enable IPv6 all forwarding: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func setupNDPProxying(config *networkConfiguration, i *bridgeInterface) error {
+	// Get current NDP default proxying setup
+	ndpProxyDataDefault, err := ioutil.ReadFile(ndpProxyConfDefault)
+	if err != nil {
+		return fmt.Errorf("Cannot read NDP default proxying setup: %v", err)
+	}
+	// Enable NDP default proxying only if it is not already enabled
+	if ndpProxyDataDefault[0] != '1' {
+		if err := ioutil.WriteFile(ndpProxyConfDefault, []byte{'1', '\n'}, ndpProxyConfPerm); err != nil {
+			logrus.Warnf("Unable to enable NDP default proxying: %v", err)
+		}
+	}
+
+	// Get current NDP all proxying setup
+	ndpProxyDataAll, err := ioutil.ReadFile(ndpProxyConfAll)
+	if err != nil {
+		return fmt.Errorf("Cannot read NDP all proxying setup: %v", err)
+	}
+	// Enable NDP all proxying only if it is not already enabled
+	if ndpProxyDataAll[0] != '1' {
+		if err := ioutil.WriteFile(ndpProxyConfAll, []byte{'1', '\n'}, ndpProxyConfPerm); err != nil {
+			logrus.Warnf("Unable to enable NDP all proxying: %v", err)
 		}
 	}
 

--- a/drivers/bridge/setup_ipv6.go
+++ b/drivers/bridge/setup_ipv6.go
@@ -20,7 +20,6 @@ const (
 	ipv6ForwardConfAll     = "/proc/sys/net/ipv6/conf/all/forwarding"
 	ndpProxyConfPerm       = 0644
 	ndpProxyConfDefault    = "/proc/sys/net/ipv6/conf/default/proxy_ndp"
-	ndpProxyConfAll        = "/proc/sys/net/ipv6/conf/all/proxy_ndp"
 )
 
 func init() {
@@ -134,15 +133,15 @@ func setupNDPProxying(config *networkConfiguration, i *bridgeInterface) error {
 		}
 	}
 
-	// Get current NDP all proxying setup
-	ndpProxyDataAll, err := ioutil.ReadFile(ndpProxyConfAll)
+	// Get interface with proxy_ndp enabled.
+	ndpProxyConfPath := fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/proxy_ndp", config.NDPProxyInterface)
 	if err != nil {
-		return fmt.Errorf("Cannot read NDP all proxying setup: %v", err)
+		return fmt.Errorf("Unable to enable NDP proxying for interface %s: %v", config.NDPProxyInterface,err)
 	}
-	// Enable NDP all proxying only if it is not already enabled
-	if ndpProxyDataAll[0] != '1' {
-		if err := ioutil.WriteFile(ndpProxyConfAll, []byte{'1', '\n'}, ndpProxyConfPerm); err != nil {
-			logrus.Warnf("Unable to enable NDP all proxying: %v", err)
+	// Enable NDP proxying only if it is not already enabled
+	if ndpProxyConfPerm[0] != '1' {
+		if err := ioutil.WriteFile(ndpProxyConfPath, []byte{'1', '\n'}, ndpProxyConfPerm); err != nil {
+			logrus.Warnf("Unable to enable NDP proxying for interface %s: %v", config.NDPProxyInterface,err)
 		}
 	}
 


### PR DESCRIPTION
Proxying is enabled via the network label com.docker.network.bridge.ndp_proxy_interface=

Closes https://github.com/docker/libnetwork/issues/1159
Overrides https://github.com/docker/libnetwork/pull/1316