### PR TITLE
Do not walk drivers again in agentDriverNotify

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -340,18 +340,12 @@ func (c *controller) agentDriverNotify(d driverapi.Driver) {
 	})
 
 	drvEnc := discoverapi.DriverEncryptionConfig{}
-	keys, tags := c.getKeys(subsysIPSec)
-	drvEnc.Keys = keys
-	drvEnc.Tags = tags
+	drvEnc.Keys, drvEnc.Tags = c.getKeys(subsysIPSec)
 
-	c.drvRegistry.WalkDrivers(func(name string, driver driverapi.Driver, capability driverapi.Capability) bool {
-		err := driver.DiscoverNew(discoverapi.EncryptionKeysConfig, drvEnc)
-		if err != nil {
-			logrus.Warnf("Failed to set datapath keys in driver %s: %v", name, err)
-		}
-		return false
-	})
-
+	err := d.DiscoverNew(discoverapi.EncryptionKeysConfig, drvEnc)
+	if err != nil {
+		logrus.Warnf("Failed to set datapath keys in driver %q: %v", d.Type(), err)
+	}
 }
 
 func (c *controller) agentClose() {


### PR DESCRIPTION
- when programming the encryption keys

`agentDriverNotify` is already being called in a driver walk, it is being called once per driver.

Signed-off-by: Alessandro Boch <aboch@docker.com>