### PR TITLE
Fix rename for containers on swarm network

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -576,39 +576,64 @@ func doUpdateHostsFile(n *network, sb *sandbox) bool {
 }
 
 func (ep *endpoint) rename(name string) error {
-	var err error
+	var (
+		err      error
+		netWatch *netWatch
+		ok       bool
+	)
+
 	n := ep.getNetwork()
 	if n == nil {
 		return fmt.Errorf("network not connected for ep %q", ep.name)
 	}
 
-	n.getController().Lock()
-	netWatch, ok := n.getController().nmap[n.ID()]
-	n.getController().Unlock()
+	c := n.getController()
 
-	if !ok {
-		return fmt.Errorf("watch null for network %q", n.Name())
+	if c.isAgent() {
+		if err = ep.deleteServiceInfoFromCluster(); err != nil {
+			return types.InternalErrorf("Could not delete service state for endpoint %s from cluster on rename: %v", ep.Name(), err)
+		}
+	} else {
+		c.Lock()
+		netWatch, ok = c.nmap[n.ID()]
+		c.Unlock()
+		if !ok {
+			return fmt.Errorf("watch null for network %q", n.Name())
+		}
+		n.updateSvcRecord(ep, c.getLocalEps(netWatch), false)
 	}
-
-	n.updateSvcRecord(ep, n.getController().getLocalEps(netWatch), false)
 
 	oldName := ep.name
 	oldAnonymous := ep.anonymous
 	ep.name = name
 	ep.anonymous = false
 
-	n.updateSvcRecord(ep, n.getController().getLocalEps(netWatch), true)
-	defer func() {
-		if err != nil {
-			n.updateSvcRecord(ep, n.getController().getLocalEps(netWatch), false)
-			ep.name = oldName
-			ep.anonymous = oldAnonymous
-			n.updateSvcRecord(ep, n.getController().getLocalEps(netWatch), true)
+	if c.isAgent() {
+		if err = ep.addServiceInfoToCluster(); err != nil {
+			return types.InternalErrorf("Could not add service state for endpoint %s to cluster on rename: %v", ep.Name(), err)
 		}
-	}()
+		defer func() {
+			if err != nil {
+				ep.deleteServiceInfoFromCluster()
+				ep.name = oldName
+				ep.anonymous = oldAnonymous
+				ep.addServiceInfoToCluster()
+			}
+		}()
+	} else {
+		n.updateSvcRecord(ep, c.getLocalEps(netWatch), true)
+		defer func() {
+			if err != nil {
+				n.updateSvcRecord(ep, c.getLocalEps(netWatch), false)
+				ep.name = oldName
+				ep.anonymous = oldAnonymous
+				n.updateSvcRecord(ep, c.getLocalEps(netWatch), true)
+			}
+		}()
+	}
 
 	// Update the store with the updated name
-	if err = n.getController().updateToStore(ep); err != nil {
+	if err = c.updateToStore(ep); err != nil {
 		return err
 	}
 	// After the name change do a dummy endpoint count update to


### PR DESCRIPTION
- The rename logic has not been updated yet to work in swarm overlay networks.
  This PR takes care of it.

Signed-off-by: Alessandro Boch <aboch@docker.com>