### PR TITLE
Fix panic in networkdb test code

### DIFF
--- a/networkdb/networkdb_test.go
+++ b/networkdb/networkdb_test.go
@@ -55,7 +55,9 @@ func closeNetworkDBInstances(dbs []*NetworkDB) {
 
 func (db *NetworkDB) verifyNodeExistence(t *testing.T, node string, present bool) {
 	for i := 0; i < 80; i++ {
+		db.RLock()
 		_, ok := db.nodes[node]
+		db.RUnlock()
 		if present && ok {
 			return
 		}
@@ -72,7 +74,10 @@ func (db *NetworkDB) verifyNodeExistence(t *testing.T, node string, present bool
 
 func (db *NetworkDB) verifyNetworkExistence(t *testing.T, node string, id string, present bool) {
 	for i := 0; i < 80; i++ {
-		if nn, nnok := db.networks[node]; nnok {
+		db.RLock()
+		nn, nnok := db.networks[node]
+		db.RUnlock()
+		if nnok {
 			n, ok := nn[id]
 			if present && ok {
 				return


### PR DESCRIPTION
```
fatal error: concurrent map read and map write

goroutine 264 [running]:
runtime.throw(0x90043c, 0x21)
	/usr/local/go/src/runtime/panic.go:566 +0x95 fp=0xc4203d1d68 sp=0xc4203d1d48
runtime.mapaccess2_faststr(0x86df20, 0xc4203f5470, 0xc42044afc0, 0x5, 0xc4203d1e40, 0x4ed6b8)
	/usr/local/go/src/runtime/hashmap_fast.go:306 +0x52b fp=0xc4203d1dc8 sp=0xc4203d1d68
github.com/docker/libnetwork/networkdb.(*NetworkDB).verifyNodeExistence(0xc42007e160, 0xc42008a240, 0xc42044afc0, 0x5, 0x1)
	/go/src/github.com/docker/libnetwork/networkdb/networkdb_test.go:58 +0x6c fp=0xc4203d1e50 sp=0xc4203d1dc8
github.com/docker/libnetwork/networkdb.TestNetworkDBCRUDMediumCluster(0xc42008a240)
	/go/src/github.com/docker/libnetwork/networkdb/networkdb_test.go:395 +0x991 fp=0xc4203d1f68 sp=0xc4203d1e50
testing.tRunner(0xc42008a240, 0x932168)
	/usr/local/go/src/testing/testing.go:610 +0x81 fp=0xc4203d1f90 sp=0xc4203d1f68
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:2086 +0x1 fp=0xc4203d1f98 sp=0xc4203d1f90
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:646 +0x2ec
```

Signed-off-by: Alessandro Boch <aboch@docker.com>