### PR TITLE
Do not invalidate table event messages

### DIFF
--- a/networkdb/broadcast.go
+++ b/networkdb/broadcast.go
@@ -105,8 +105,7 @@ type tableEventMessage struct {
 }
 
 func (m *tableEventMessage) Invalidates(other memberlist.Broadcast) bool {
-	otherm := other.(*tableEventMessage)
-	return m.id == otherm.id && m.tname == otherm.tname && m.key == otherm.key
+	return false
 }
 
 func (m *tableEventMessage) Message() []byte {


### PR DESCRIPTION
- When network DB enqueues a message into the memberlist broadcast queue,
  memberlist checks whether the message can suppress past messages  present
  in the queue by running a invalidation check. The check is implemented by the 
  owner of the message, in this case network DB,  by implementing the Invalidates() method. 
  With the only in clear information available in the message (table id, nw id and key),
  network DB marks any two updates for the same key on the same network as redundant.

-  This means that if N endpoint updates happen in tens of millisecond window, network DB
will suppress the first N-1 updates and only propagate the last one in the cluster.

- For example this is breaking the endpoint rename use-case.
The service record delete event (associated to the old container name) is never 
propagated to the cluster, because always suppressed in favor of the service
record add event (which carries the new container name), because the two events
are generated in close succession. This cause service record for the old container
name to not be removed by the other node in the cluster.


- IMO, we should not run the risk of suppressing meaningful messages  for the rest of the cluster, 
as a many services depend on it, like the service records and the distributed load balancers.

Signed-off-by: Alessandro Boch <aboch@docker.com>