### PR TITLE
[nit] overlay: "Host IP" -> "HostIP" for consistency

### DIFF
--- a/drivers/overlay/joinleave.go
+++ b/drivers/overlay/joinleave.go
@@ -158,7 +158,7 @@ func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (s
 	}
 
 	return key, map[string]string{
-		"Host IP": peer.TunnelEndpointIP,
+		"HostIP": peer.TunnelEndpointIP,
 	}
 }
 


### PR DESCRIPTION
https://github.com/docker/libnetwork/pull/1674 ( https://github.com/docker/docker/pull/31710 ) introduced `Info` structure e.g.
```json
{
  "Name": "s1.2.q4hcq2aiiml25ubtrtg4q1txt",
  "EndpointID": "040879b027e55fb658e8b60ae3b87c6cdac7d291e86a190a3b5ac6567b26511a",
  "EndpointIP": "10.0.0.5",
  "Info": {
  "Host IP": "192.168.33.11"
}
```

Given that other JSON key does not contain any whitespace, I suggest changing `Host IP` to `HostIP`.

Please close if it was intentional 😃 @sanimej @mavenugo 

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>