### PR TITLE
RFC: Add support for optional runtime hint using network options

### DIFF
--- a/drivers/macvlan/macvlan.go
+++ b/drivers/macvlan/macvlan.go
@@ -46,6 +46,7 @@ type endpoint struct {
 	srcName  string
 	dbIndex  uint64
 	dbExists bool
+	runtime  string
 }
 
 type network struct {

--- a/drivers/macvlan/macvlan_endpoint.go
+++ b/drivers/macvlan/macvlan_endpoint.go
@@ -40,6 +40,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 			return err
 		}
 	}
+
 	// disallow portmapping -p
 	if opt, ok := epOptions[netlabel.PortMap]; ok {
 		if _, ok := opt.([]types.PortBinding); ok {
@@ -53,6 +54,18 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 		if _, ok := opt.([]types.TransportPort); ok {
 			if len(opt.([]types.TransportPort)) > 0 {
 				logrus.Warnf("%s driver does not support port exposures", macvlanType)
+			}
+		}
+	}
+
+	// Setup the runtime to default to namespace, override if specified
+	ep.runtime = "namespace"
+	if opt, ok := epOptions["runtime"]; ok {
+		if runtime, ok := opt.(string); ok {
+			if runtime != "namespace" && runtime != "vm" {
+				logrus.Warnf("driver does not support [%s] runtime", runtime)
+			} else {
+				ep.runtime = runtime
 			}
 		}
 	}

--- a/drivers/macvlan/macvlan_joinleave.go
+++ b/drivers/macvlan/macvlan_joinleave.go
@@ -28,7 +28,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		return fmt.Errorf("error generating an interface name: %s", err)
 	}
 	// create the netlink macvlan interface
-	vethName, err := createMacVlan(containerIfName, n.config.Parent, n.config.MacvlanMode)
+	vethName, err := createMacVlan(containerIfName, n.config.Parent, n.config.MacvlanMode, endpoint.runtime)
 	if err != nil {
 		return err
 	}

--- a/drivers/macvlan/macvlan_store.go
+++ b/drivers/macvlan/macvlan_store.go
@@ -255,6 +255,7 @@ func (ep *endpoint) MarshalJSON() ([]byte, error) {
 	epMap["id"] = ep.id
 	epMap["nid"] = ep.nid
 	epMap["SrcName"] = ep.srcName
+	epMap["runtime"] = ep.runtime
 	if len(ep.mac) != 0 {
 		epMap["MacAddress"] = ep.mac.String()
 	}
@@ -295,6 +296,7 @@ func (ep *endpoint) UnmarshalJSON(b []byte) error {
 	ep.id = epMap["id"].(string)
 	ep.nid = epMap["nid"].(string)
 	ep.srcName = epMap["SrcName"].(string)
+	ep.runtime = epMap["runtime"].(string)
 
 	return nil
 }


### PR DESCRIPTION
docker supports alternate OCI runtimes including virtual machine based runtimes. In certian cases network plugins can optionally choose to support creation of  virtual machine friendly interfaces using optional network options.

This is illustrated here with the hint being used by the macvlan driver to create a macvtap interface vs a macvlan interface when the runtime is known to be a VM based runtime.

docker run --runtime=cor -it --net=pub_net --network "name=pub_net,runtime=namespace" alpine sh

This is currently based off of
https://github.com/docker/docker/pull/27638

However this will be implemented as per the proposal
https://github.com/docker/docker/issues/31964

The drawback of this approach is that the runtime and the endpoint runtime type have to be specified twice. However this approach may work better with containerd, where I assume the namespace and interfaces will be created prior to the launch of the container, and there is no prehook involved.

Ideally this could be done by extending the OCI specification pre-hook definition and sending that information to the network plugin.

```
// HookState is the payload provided to a hook on execution.
type HookState struct {
	Version string `json:"version"`
	ID      string `json:"id"`
	Pid     int    `json:"pid"`
	Root    string `json:"root"`
        Runtime string `json:"runtime"`
}
```

However that will not work consistently as the pre-hook is invoked after the EndpointCreate has occurred. 
Some plugins create the interface at the time of Join and some at the time of Create. 


Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>