### PR TITLE
Sandbox.SetKey() should not reset the osl sandbox on failure

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -644,13 +644,6 @@ func (sb *sandbox) SetKey(basePath string) error {
 	sb.Lock()
 	sb.osSbox = osSbox
 	sb.Unlock()
-	defer func() {
-		if err != nil {
-			sb.Lock()
-			sb.osSbox = nil
-			sb.Unlock()
-		}
-	}()
 
 	// If the resolver was setup before stop it and set it up in the
 	// new osl sandbox.


### PR DESCRIPTION
Related to docker/docker/issues/31414

Because the failure would not be on creating the osl sandbox
(which is done by somebody else). It would be on the programming
libnetwork does on the osl sandbox. In case of failure just report
the error. External caller will take care of removing the parent sandbox
via the cleanup on the error handling path. Otherwise the osl sandbox
will never be removed.

Signed-off-by: Alessandro Boch <aboch@docker.com>