### PR TITLE
Add AgentStopWait method

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -218,6 +218,7 @@ func (c *controller) agentSetup() error {
 	if c.agent != nil && c.agentInitDone != nil {
 		close(c.agentInitDone)
 		c.agentInitDone = nil
+		c.agentStopDone = make(chan struct{})
 	}
 	c.Unlock()
 


### PR DESCRIPTION
- to signal when the networking cluster agent is stopped

This is needed by the daemon when it cleans up the cluster network resources on swarm leave or on graceful shutdown.  See [comment](https://github.com/docker/docker/pull/32283/files/43a938ef33640edf2d1b28a27120e65290f66284#r109971301).
 
Signed-off-by: Alessandro Boch <aboch@docker.com>