### PR TITLE
Remove firewalld running log

### DIFF
--- a/iptables/firewalld.go
+++ b/iptables/firewalld.go
@@ -151,7 +151,6 @@ func checkRunning() bool {
 
 	if connection != nil {
 		err = connection.sysobj.Call(dbusInterface+".getDefaultZone", 0).Store(&zone)
-		logrus.Infof("Firewalld running: %t", err == nil)
 		return err == nil
 	}
 	return false


### PR DESCRIPTION
Related to https://github.com/docker/docker/issues/31473

- The info it provides can be found elsewhere
  The logs gets printed too often becasue of
  the programming being done in the tasks
