### PR TITLE
On clusterLeave, notify only if there are peers

### DIFF
--- a/networkdb/broadcast.go
+++ b/networkdb/broadcast.go
@@ -86,6 +86,15 @@ func (nDB *NetworkDB) sendNodeEvent(event NodeEvent_Type) error {
 		notify: notifyCh,
 	})
 
+	nDB.RLock()
+	noPeers := len(nDB.nodes) <= 1
+	nDB.RUnlock()
+
+	// Message enqueued, do not wait for a send if no peer is present
+	if noPeers {
+		return nil
+	}
+
 	// Wait for the broadcast
 	select {
 	case <-notifyCh:


### PR DESCRIPTION
- Otherwise operation will unnecessarely block
  for five seconds.
- This is particularly noticeable on graceful
  shutdown of daemon in one node cluster.

Related to docker/docker/issues/32446
