### PR TITLE
Remove gw endpoint on gw nw join failure

### DIFF
--- a/default_gateway.go
+++ b/default_gateway.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/types"
 )
@@ -72,9 +73,19 @@ func (sb *sandbox) setupDefaultGW() error {
 	if err != nil {
 		return fmt.Errorf("container %s: endpoint create on GW Network failed: %v", sb.containerID, err)
 	}
+
+	defer func() {
+		if err != nil {
+			if err2 := newEp.Delete(true); err2 != nil {
+				logrus.Warnf("Failed to remove gw endpoint for container %s after failing to join the gateway network: %v",
+					sb.containerID, err2)
+			}
+		}
+	}()
+
 	epLocal := newEp.(*endpoint)
 
-	if err := epLocal.sbJoin(sb); err != nil {
+	if err = epLocal.sbJoin(sb); err != nil {
 		return fmt.Errorf("container %s: endpoint join on GW Network failed: %v", sb.containerID, err)
 	}
 

--- a/endpoint.go
+++ b/endpoint.go
@@ -528,7 +528,8 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 	}()
 
 	if sb.needDefaultGW() && sb.getEndpointInGWNetwork() == nil {
-		return sb.setupDefaultGW()
+		err = sb.setupDefaultGW()
+		return err
 	}
 
 	moveExtConn := sb.getGatewayEndpoint() != extEp


### PR DESCRIPTION
- Currently if the join fails, the gw endpoint becomes
  stale and stays connected to the gw network.
- Also fix sbJoin to do the cleanup in case
  setupDefaultGW() fails

Signed-off-by: Alessandro Boch <aboch@docker.com>