### PR TITLE
Change wording for Endpoint description

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -30,7 +30,7 @@ A Sandbox may contain *many* endpoints from *multiple* networks.
 
 An Endpoint joins a Sandbox to a Network.
 An implementation of an Endpoint could be a `veth` pair, an Open vSwitch internal port or similar.
-An Endpoint can belong to *only one* network but may only belong to *one* Sandbox.
+An Endpoint can belong to *only one* network and *one* Sandbox.
 
 **Network**
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -30,7 +30,7 @@ A Sandbox may contain *many* endpoints from *multiple* networks.
 
 An Endpoint joins a Sandbox to a Network.
 An implementation of an Endpoint could be a `veth` pair, an Open vSwitch internal port or similar.
-An Endpoint can belong to *only one* network and *one* Sandbox.
+An Endpoint can belong to only one network and it can belong to only one Sandbox, if connected.
 
 **Network**
 


### PR DESCRIPTION
I was reading over the description of the Endpoint and it struck me as a bit odd: 
`An Endpoint can belong to *only one* network but may only belong to *one* Sandbox.`
I just wanted to rephrase it so that it's clear that an Endpoint has a one to one relationship with the Sandbox and a Network. If that is not the case, then I'm sorry for proposing the change. I'm only just starting to take a deeper dive into Docker networking.