### PR TITLE
agentSetup to first check if clusterProvider is nil

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -187,6 +187,13 @@ func (c *controller) agentSetup() error {
 	clusterProvider := c.cfg.Daemon.ClusterProvider
 	agent := c.agent
 	c.Unlock()
+
+	if clusterProvider == nil {
+		msg := "Aborting initialization of Libnetwork Agent because cluster provider is now unset"
+		logrus.Errorf(msg)
+		return fmt.Errorf(msg)
+	}
+
 	bindAddr := clusterProvider.GetLocalAddress()
 	advAddr := clusterProvider.GetAdvertiseAddress()
 	remote := clusterProvider.GetRemoteAddress()


### PR DESCRIPTION
- concurrent swarm join and daemon stop seen in
  integration tests may cause agentSetup to access
  a nil clusterProvider, resulting in a panic

Reported in moby/moby/issues/32673
