### PR TITLE
Enable Linux bridge ProxyArpWifi

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -60,6 +60,7 @@ type networkConfiguration struct {
 	EnableIPv6           bool
 	EnableIPMasquerade   bool
 	EnableICC            bool
+	EnableBrProxyArp     bool
 	Mtu                  int
 	DefaultBindingIP     net.IP
 	DefaultBridge        bool
@@ -239,6 +240,10 @@ func (c *networkConfiguration) fromLabels(labels map[string]string) error {
 		case DefaultBindingIP:
 			if c.DefaultBindingIP = net.ParseIP(value); c.DefaultBindingIP == nil {
 				return parseErr(label, value, "nil ip")
+			}
+		case EnableBrProxyArp:
+			if c.EnableBrProxyArp, err = strconv.ParseBool(value); err != nil {
+				return parseErr(label, value, err.Error())
 			}
 		case netlabel.ContainerIfacePrefix:
 			c.ContainerIfacePrefix = value
@@ -449,6 +454,7 @@ func parseNetworkGenericOptions(data interface{}) (*networkConfiguration, error)
 		config = &networkConfiguration{
 			EnableICC:          true,
 			EnableIPMasquerade: true,
+			EnableBrProxyArp:   false,
 		}
 		err = config.fromLabels(opt)
 	case options.Generic:
@@ -1041,6 +1047,54 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 		if err = ifInfo.SetMacAddress(endpoint.macAddress); err != nil {
 			return err
 		}
+	}
+
+	// The bridge proxy arp feature requires three things to happen:
+	// 1) Set the proxyarpwifi flag on the container side bridge port to disable ARP packet flooding.
+	// 2) Generate an arp entry in the host's ARP table mapping the containers IP address to its MAC.
+	// 3) Generate a static FDB entry for the containers MAC address.
+
+	if config.EnableBrProxyArp {
+
+		BridgeIF, err := d.nlh.LinkByName(config.BridgeName)
+		if err != nil {
+			return fmt.Errorf("could not find interface with destination name %s: %v", config.BridgeName, err)
+		}
+
+		HostIF, err := d.nlh.LinkByName(hostIfName)
+		if err != nil {
+			return fmt.Errorf("could not find interface with destination name %s: %v", hostIfName, err)
+		}
+
+		err = d.nlh.LinkSetBrProxyArpWiFi(host, true)
+		if err != nil {
+			return fmt.Errorf("unable to set BridgeProxyArp mode on %s: %v", hostIfName, err)
+		}
+
+		nlnh := &netlink.Neigh{
+			IP:           endpoint.addr.IP,
+			HardwareAddr: endpoint.macAddress,
+		}
+
+		// Generate the permanent arp entry.
+		nlnh.State = netlink.NUD_PERMANENT
+		nlnh.LinkIndex = BridgeIF.Attrs().Index
+
+		if err := d.nlh.NeighSet(nlnh); err != nil {
+			return fmt.Errorf("Failed to add neighbor entry: %v", err)
+		}
+		logrus.Debugf("An arp entry has been created: Interface=%s Ip=%s MAC=%s", config.BridgeName, nlnh.IP, nlnh.HardwareAddr)
+
+		// Generate the static fdb entry.
+		nlnh.State = netlink.NUD_NOARP
+		nlnh.Flags = netlink.NTF_MASTER
+		nlnh.Family = syscall.AF_BRIDGE
+		nlnh.LinkIndex = HostIF.Attrs().Index
+
+		if err := d.nlh.NeighSet(nlnh); err != nil {
+			return fmt.Errorf("Failed to add fdb entry: %v", err)
+		}
+		logrus.Debugf("An fdb entry has been created: Interface=%s  MAC=%s", hostIfName, nlnh.HardwareAddr)
 	}
 
 	// Up the host interface after finishing all netlink configuration

--- a/drivers/bridge/bridge_store.go
+++ b/drivers/bridge/bridge_store.go
@@ -137,6 +137,7 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap["EnableIPv6"] = ncfg.EnableIPv6
 	nMap["EnableIPMasquerade"] = ncfg.EnableIPMasquerade
 	nMap["EnableICC"] = ncfg.EnableICC
+	nMap["EnableBrProxyArp"] = ncfg.EnableBrProxyArp
 	nMap["Mtu"] = ncfg.Mtu
 	nMap["Internal"] = ncfg.Internal
 	nMap["DefaultBridge"] = ncfg.DefaultBridge
@@ -199,6 +200,10 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 
 	if v, ok := nMap["BridgeIfaceCreator"]; ok {
 		ncfg.BridgeIfaceCreator = ifaceCreator(v.(float64))
+	}
+
+	if v, ok := nMap["EnableBrProxyArp"]; ok {
+		ncfg.EnableBrProxyArp = v.(bool)
 	}
 
 	return nil

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -276,6 +276,7 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 		DefaultBridge:      "true",
 		EnableICC:          "true",
 		EnableIPMasquerade: "true",
+		EnableBrProxyArp:   "true",
 		DefaultBindingIP:   bndIPs,
 	}
 
@@ -317,6 +318,10 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 
 	if !nw.config.EnableIPMasquerade {
 		t.Fatal("incongruent EnableIPMasquerade in bridge network")
+	}
+
+	if !nw.config.EnableBrProxyArp {
+		t.Fatal("incongruent EnableBrProxyArp in bridge network")
 	}
 
 	bndIP := net.ParseIP(bndIPs)
@@ -1069,5 +1074,56 @@ func TestCreateWithExistingBridge(t *testing.T) {
 
 	if _, err := netlink.LinkByName(brName); err != nil {
 		t.Fatal("Deleting bridge network that using existing bridge interface unexpectedly deleted the bridge interface")
+	}
+}
+
+func TestProxyArp(t *testing.T) {
+	if !testutils.IsRunningInContainer() {
+		defer testutils.SetupTestOSContext(t)()
+	}
+	d := newDriver()
+
+	err := d.configure(nil)
+	if err != nil {
+		t.Fatalf("Failed to setup driver config: %v", err)
+	}
+
+	netconfig := &networkConfiguration{BridgeName: DefaultBridgeName, EnableBrProxyArp: true, DefaultBridge: true}
+	genericOption := make(map[string]interface{})
+	genericOption[netlabel.GenericData] = netconfig
+
+	ipdList := getIPv4Data(t, "")
+
+	err = d.CreateNetwork("ProxyArpTest", genericOption, nil, ipdList, nil)
+	if err != nil {
+		t.Fatalf("Bridge creation failed: %v", err)
+	}
+
+	te := newTestEndpoint(ipdList[0].Pool, 10)
+	err = d.CreateEndpoint("ProxyArpTest", "ep", te.Interface(), nil)
+	if err != nil {
+		t.Fatalf("Failed to create endpoint: %v", err)
+	}
+
+	BridgeIF, err := netlink.LinkByName(DefaultBridgeName)
+	if err != nil {
+		t.Fatalf("Failed to lookup bridge interface: %v", err)
+	}
+
+	dump, err := netlink.NeighList(BridgeIF.Attrs().Index, 0)
+	if err != nil {
+		t.Errorf("Failed to NeighList: %v", err)
+	}
+
+	FoundNeigh := 0
+	for _, v := range dump {
+		if v.State&netlink.NUD_PERMANENT != 0 &&
+			bytes.Equal(te.iface.mac, v.HardwareAddr) &&
+			te.iface.addr.IP.Equal(v.IP) {
+			FoundNeigh++
+		}
+	}
+	if FoundNeigh != 1 {
+		t.Errorf("Expected a single match in the neighbor table got %d matches", FoundNeigh)
 	}
 }

--- a/drivers/bridge/labels.go
+++ b/drivers/bridge/labels.go
@@ -15,4 +15,7 @@ const (
 
 	// DefaultBridge label
 	DefaultBridge = "com.docker.network.bridge.default_bridge"
+
+	// EnableBrProxyArp label
+	EnableBrProxyArp = "com.docker.network.bridge.proxyarp"
 )

--- a/vendor.conf
+++ b/vendor.conf
@@ -35,7 +35,7 @@ github.com/seccomp/libseccomp-golang 1b506fc7c24eec5a3693cdcbed40d9c226cfc6a1
 github.com/stretchr/testify dab07ac62d4905d3e48d17dc549c684ac3b7c15a
 github.com/syndtr/gocapability/capability 2c00daeb6c3b45114c80ac44119e7b8801fdd852
 github.com/ugorji/go f1f1a805ed361a0e078bb537e4ea78cd37dcf065
-github.com/vishvananda/netlink 1e86b2bee5b6a7d377e4c02bb7f98209d6a7297c
+github.com/vishvananda/netlink b144143ea1df18e21a08e2ec101ada9a94a9cc85
 github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
 golang.org/x/net c427ad74c6d7a814201695e9ffde0c5d400a7674
 golang.org/x/sys 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9


### PR DESCRIPTION
This change enables the Linux bridge's ProxyArpWiFi feature eliminating
the need to flood ARP packets. When an endpoint is created the bridge
driver already has the data needed to complete arp and fdb table
entries. Rather than let the kernel discover this information on its own
we populate the arp and fdb tables when the endpoint is configured.  All
other broadcast traffic will pass normal allowing the administrator to
manage it using ebtables.

Linux bridge ProxyArpWifi is enabled with:
--opt com.docker.network.bridge.proxyarp=1

Dependencies:
linux kernel v4.1-rc1 or later(commit 842a9ae08a25671db3d4f689eed68b4d64be15b5)
vishvananda/netlink commit b144143ea1df18e21a08e2ec101ada9a94a9cc85

Signed-off-by: David Wilder <wilder@us.ibm.com>