### PR TITLE
Change GetRemoteAddr to return all managers

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -207,13 +207,18 @@ func (c *controller) agentSetup() error {
 	bindAddr := clusterProvider.GetLocalAddress()
 	advAddr := clusterProvider.GetAdvertiseAddress()
 	dataAddr := clusterProvider.GetDataPathAddress()
-	remote := clusterProvider.GetRemoteAddress()
-	remoteAddr, _, _ := net.SplitHostPort(remote)
+	remoteList := clusterProvider.GetRemoteAddressList()
+	remoteAddrList := make([]string, len(remoteList))
+	for _, remote := range remoteList {
+		addr, _, _ := net.SplitHostPort(remote)
+		remoteAddrList = append(remoteAddrList, addr)
+	}
+
 	listen := clusterProvider.GetListenAddress()
 	listenAddr, _, _ := net.SplitHostPort(listen)
 
-	logrus.Infof("Initializing Libnetwork Agent Listen-Addr=%s Local-addr=%s Adv-addr=%s Data-addr=%s Remote-addr=%s",
-		listenAddr, bindAddr, advAddr, dataAddr, remoteAddr)
+	logrus.Infof("Initializing Libnetwork Agent Listen-Addr=%s Local-addr=%s Adv-addr=%s Data-addr=%s Remote-addr-list=%v",
+		listenAddr, bindAddr, advAddr, dataAddr, remoteAddrList)
 	if advAddr != "" && agent == nil {
 		if err := c.agentInit(listenAddr, bindAddr, advAddr, dataAddr); err != nil {
 			logrus.Errorf("Error in agentInit : %v", err)
@@ -227,8 +232,8 @@ func (c *controller) agentSetup() error {
 		}
 	}
 
-	if remoteAddr != "" {
-		if err := c.agentJoin(remoteAddr); err != nil {
+	if len(remoteAddrList) > 0 {
+		if err := c.agentJoin(remoteAddrList); err != nil {
 			logrus.Errorf("Error in joining gossip cluster : %v(join will be retried in background)", err)
 		}
 	}
@@ -342,12 +347,12 @@ func (c *controller) agentInit(listenAddr, bindAddrOrInterface, advertiseAddr, d
 	return nil
 }
 
-func (c *controller) agentJoin(remote string) error {
+func (c *controller) agentJoin(remoteAddrList []string) error {
 	agent := c.getAgent()
 	if agent == nil {
 		return nil
 	}
-	return agent.networkDB.Join([]string{remote})
+	return agent.networkDB.Join(remoteAddrList)
 }
 
 func (c *controller) agentDriverNotify(d driverapi.Driver) {

--- a/cluster/provider.go
+++ b/cluster/provider.go
@@ -13,7 +13,7 @@ type Provider interface {
 	GetListenAddress() string
 	GetAdvertiseAddress() string
 	GetDataPathAddress() string
-	GetRemoteAddress() string
+	GetRemoteAddressList() []string
 	ListenClusterEvents() <-chan struct{}
 	AttachNetwork(string, string, []string) (*network.NetworkingConfig, error)
 	DetachNetwork(string, string) error

--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -324,8 +324,8 @@ func (d *dnetConnection) GetListenAddress() string {
 	return d.Orchestration.Bind
 }
 
-func (d *dnetConnection) GetRemoteAddress() string {
-	return d.Orchestration.Peer
+func (d *dnetConnection) GetRemoteAddressList() []string {
+	return []string{d.Orchestration.Peer}
 }
 
 func (d *dnetConnection) GetNetworkKeys() []*types.EncryptionKey {


### PR DESCRIPTION
Change in the provider interface to let the provider
return the whole list of managers.
This will allow the netwrok db to have multiple choice
to establish the first adjacencies

Relates to https://github.com/docker/libnetwork/issues/1734

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>