### PR TITLE
Remove explicit set of memberlist protocol

### DIFF
--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -107,7 +107,7 @@ func (nDB *NetworkDB) clusterInit() error {
 		config.BindPort = nDB.config.BindPort
 	}
 
-	config.ProtocolVersion = memberlist.ProtocolVersionMax
+	config.ProtocolVersion = memberlist.ProtocolVersion2Compatible
 	config.Delegate = &delegate{nDB: nDB}
 	config.Events = &eventDelegate{nDB: nDB}
 	// custom logger that does not add time or date, so they are not


### PR DESCRIPTION
Memberlist does a full validation of the protocol version (min, current, max)
amoung all the ndoes of the cluster.
The previous code was setting the protocol version to max version.
This makes the upgrade incompatible.

Relates to: moby/moby/issues/33091

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>