### PR TITLE
Revert disabling IPv6 in containers conencted to IPv4 only networks

### DIFF
--- a/cmd/proxy/network_proxy_test.go
+++ b/cmd/proxy/network_proxy_test.go
@@ -164,7 +164,6 @@ func TestTCP4ProxyHalfClose(t *testing.T) {
 }
 
 func TestTCP6Proxy(t *testing.T) {
-	t.Skip("Need to start CI docker with --ipv6")
 	backend := NewEchoServer(t, "tcp", "[::1]:0", EchoServerOptions{})
 	defer backend.Close()
 	backend.Run()
@@ -208,7 +207,6 @@ func TestUDP4Proxy(t *testing.T) {
 }
 
 func TestUDP6Proxy(t *testing.T) {
-	t.Skip("Need to start CI docker with --ipv6")
 	backend := NewEchoServer(t, "udp", "[::1]:0", EchoServerOptions{})
 	defer backend.Close()
 	backend.Run()

--- a/networkdb/networkdb_test.go
+++ b/networkdb/networkdb_test.go
@@ -3,7 +3,6 @@ package networkdb
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync/atomic"
@@ -22,7 +21,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	ioutil.WriteFile("/proc/sys/net/ipv6/conf/lo/disable_ipv6", []byte{'0', '\n'}, 0644)
 	logrus.SetLevel(logrus.ErrorLevel)
 	os.Exit(m.Run())
 }

--- a/osl/interface_linux.go
+++ b/osl/interface_linux.go
@@ -179,8 +179,6 @@ func (i *nwIface) Remove() error {
 	}
 	n.Unlock()
 
-	n.checkLoV6()
-
 	return nil
 }
 
@@ -320,8 +318,6 @@ func (n *networkNamespace) AddInterface(srcName, dstPrefix string, options ...If
 	n.iFaces = append(n.iFaces, i)
 	n.Unlock()
 
-	n.checkLoV6()
-
 	return nil
 }
 
@@ -381,9 +377,6 @@ func setInterfaceIPv6(nlh *netlink.Handle, iface netlink.Link, i *nwIface) error
 	}
 	if err := checkRouteConflict(nlh, i.AddressIPv6(), netlink.FAMILY_V6); err != nil {
 		return err
-	}
-	if err := setIPv6(i.ns.path, i.DstName(), true); err != nil {
-		return fmt.Errorf("failed to enable ipv6: %v", err)
 	}
 	ipAddr := &netlink.Addr{IPNet: i.AddressIPv6(), Label: "", Flags: syscall.IFA_F_NODAD}
 	return nlh.AddrAdd(iface, ipAddr)

--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -24,10 +24,6 @@ import (
 
 const defaultPrefix = "/var/run/docker"
 
-func init() {
-	reexec.Register("set-ipv6", reexecSetIPv6)
-}
-
 var (
 	once             sync.Once
 	garbagePathMap   = make(map[string]bool)
@@ -51,7 +47,6 @@ type networkNamespace struct {
 	nextIfIndex  map[string]int
 	isDefault    bool
 	nlHandle     *netlink.Handle
-	loV6Enabled  bool
 	sync.Mutex
 }
 
@@ -221,12 +216,6 @@ func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
 		logrus.Warnf("Failed to set the timeout on the sandbox netlink handle sockets: %v", err)
 	}
 
-	// As starting point, disable IPv6 on all interfaces
-	err = setIPv6(n.path, "all", false)
-	if err != nil {
-		logrus.Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)
-	}
-
 	if err = n.loopbackUp(); err != nil {
 		n.nlHandle.Delete()
 		return nil, err
@@ -272,12 +261,6 @@ func GetSandboxForExternalKey(basePath string, key string) (Sandbox, error) {
 	err = n.nlHandle.SetSocketTimeout(ns.NetlinkSocketsTimeout)
 	if err != nil {
 		logrus.Warnf("Failed to set the timeout on the sandbox netlink handle sockets: %v", err)
-	}
-
-	// As starting point, disable IPv6 on all interfaces
-	err = setIPv6(n.path, "all", false)
-	if err != nil {
-		logrus.Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)
 	}
 
 	if err = n.loopbackUp(); err != nil {
@@ -523,86 +506,5 @@ func (n *networkNamespace) Restore(ifsopt map[string][]IfaceOption, routes []*ty
 		n.Unlock()
 	}
 
-	return nil
-}
-
-// Checks whether IPv6 needs to be enabled/disabled on the loopback interface
-func (n *networkNamespace) checkLoV6() {
-	var (
-		enable = false
-		action = "disable"
-	)
-
-	n.Lock()
-	for _, iface := range n.iFaces {
-		if iface.AddressIPv6() != nil {
-			enable = true
-			action = "enable"
-			break
-		}
-	}
-	n.Unlock()
-
-	if n.loV6Enabled == enable {
-		return
-	}
-
-	if err := setIPv6(n.path, "lo", enable); err != nil {
-		logrus.Warnf("Failed to %s IPv6 on loopback interface on network namespace %q: %v", action, n.path, err)
-	}
-
-	n.loV6Enabled = enable
-}
-
-func reexecSetIPv6() {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	if len(os.Args) < 3 {
-		logrus.Errorf("invalid number of arguments for %s", os.Args[0])
-		os.Exit(1)
-	}
-
-	ns, err := netns.GetFromPath(os.Args[1])
-	if err != nil {
-		logrus.Errorf("failed get network namespace %q: %v", os.Args[1], err)
-		os.Exit(2)
-	}
-	defer ns.Close()
-
-	if err = netns.Set(ns); err != nil {
-		logrus.Errorf("setting into container netns %q failed: %v", os.Args[1], err)
-		os.Exit(3)
-	}
-
-	var (
-		action = "disable"
-		value  = byte('1')
-		path   = fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/disable_ipv6", os.Args[2])
-	)
-
-	if os.Args[3] == "true" {
-		action = "enable"
-		value = byte('0')
-	}
-
-	if err = ioutil.WriteFile(path, []byte{value, '\n'}, 0644); err != nil {
-		logrus.Errorf("failed to %s IPv6 forwarding for container's interface %s: %v", action, os.Args[2], err)
-		os.Exit(4)
-	}
-
-	os.Exit(0)
-}
-
-func setIPv6(path, iface string, enable bool) error {
-	cmd := &exec.Cmd{
-		Path:   reexec.Self(),
-		Args:   append([]string{"set-ipv6"}, path, iface, strconv.FormatBool(enable)),
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-	}
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("reexec to set IPv6 failed: %v", err)
-	}
 	return nil
 }

--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -222,11 +222,9 @@ func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
 	}
 
 	// As starting point, disable IPv6 on all interfaces
-	if !n.isDefault {
-		err = setIPv6(n.path, "all", false)
-		if err != nil {
-			logrus.Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)
-		}
+	err = setIPv6(n.path, "all", false)
+	if err != nil {
+		logrus.Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)
 	}
 
 	if err = n.loopbackUp(); err != nil {

--- a/osl/sandbox_linux_test.go
+++ b/osl/sandbox_linux_test.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -191,32 +190,17 @@ func TestDisableIPv6DAD(t *testing.T) {
 
 	defer testutils.SetupTestOSContext(t)()
 
-	key, err := newKey(t)
-	if err != nil {
-		t.Fatalf("Failed to obtain a key: %v", err)
-	}
-
-	s, err := NewSandbox(key, true, false)
-	if err != nil {
-		t.Fatalf("Failed to create a new sandbox: %v", err)
-	}
-	runtime.LockOSThread()
-	defer s.Destroy()
-
-	n, ok := s.(*networkNamespace)
-	if !ok {
-		t.Fatal(ok)
-	}
-	nlh := n.nlHandle
-
 	ipv6, _ := types.ParseCIDR("2001:db8::44/64")
-	iface := &nwIface{addressIPv6: ipv6, ns: n, dstName: "sideA"}
+	iface := &nwIface{addressIPv6: ipv6}
 
 	veth := &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{Name: "sideA"},
 		PeerName:  "sideB",
 	}
-
+	nlh, err := netlink.NewHandle(syscall.NETLINK_ROUTE)
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = nlh.LinkAdd(veth)
 	if err != nil {
 		t.Fatal(err)
@@ -245,27 +229,14 @@ func TestDisableIPv6DAD(t *testing.T) {
 func TestSetInterfaceIP(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
-	key, err := newKey(t)
-	if err != nil {
-		t.Fatalf("Failed to obtain a key: %v", err)
-	}
-
-	s, err := NewSandbox(key, true, false)
-	if err != nil {
-		t.Fatalf("Failed to create a new sandbox: %v", err)
-	}
-	runtime.LockOSThread()
-	defer s.Destroy()
-
-	n, ok := s.(*networkNamespace)
-	if !ok {
-		t.Fatal(ok)
-	}
-	nlh := n.nlHandle
-
 	ipv4, _ := types.ParseCIDR("172.30.0.33/24")
 	ipv6, _ := types.ParseCIDR("2001:db8::44/64")
-	iface := &nwIface{address: ipv4, addressIPv6: ipv6, ns: n, dstName: "sideA"}
+	iface := &nwIface{address: ipv4, addressIPv6: ipv6}
+
+	nlh, err := netlink.NewHandle(syscall.NETLINK_ROUTE)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if err := nlh.LinkAdd(&netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{Name: "sideA"},


### PR DESCRIPTION
Unless we find a solution to moby/moby/issues/33099 in the following days, I'd keep this one ready to fix the backward compatibility breakage before 17.06 is released.