### PR TITLE
Preserve link-local IPv6 on container's lo & allow link-local only IPv6 networks

### DIFF
--- a/ipamapi/contract.go
+++ b/ipamapi/contract.go
@@ -54,6 +54,7 @@ var (
 	ErrIPOutOfRange        = types.BadRequestErrorf("Requested address is out of range")
 	ErrPoolOverlap         = types.ForbiddenErrorf("Pool overlaps with other one on this address space")
 	ErrBadPool             = types.BadRequestErrorf("Address space does not contain specified address pool")
+	ErrNotSupported        = types.BadRequestErrorf("Do not support requested operation")
 )
 
 /*******************************

--- a/network.go
+++ b/network.go
@@ -1342,6 +1342,14 @@ func (n *network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {
 		d.AddressSpace = n.addrSpace
 		d.PoolID, d.Pool, d.Meta, err = n.requestPoolHelper(ipam, n.addrSpace, cfg.PreferredPool, cfg.SubPool, n.ipamOptions, ipVer == 6)
 		if err != nil {
+			// If the IPAM driver does not support autoallocation for this ipv6 family, skip it
+			// and adjust the network ipam datastructures. IPv4 support is still mandatory.
+			if err == ipamapi.ErrNotSupported && cfg.PreferredPool == "" && ipVer == 6 {
+				*cfgList = nil
+				*infoList = nil
+				logrus.Infof("IPAM driver does not support autoallocation for IPv%d", ipVer)
+				return nil
+			}
 			return err
 		}
 

--- a/osl/interface_linux.go
+++ b/osl/interface_linux.go
@@ -179,8 +179,6 @@ func (i *nwIface) Remove() error {
 	}
 	n.Unlock()
 
-	n.checkLoV6()
-
 	return nil
 }
 
@@ -319,8 +317,6 @@ func (n *networkNamespace) AddInterface(srcName, dstPrefix string, options ...If
 	n.Lock()
 	n.iFaces = append(n.iFaces, i)
 	n.Unlock()
-
-	n.checkLoV6()
 
 	return nil
 }

--- a/osl/interface_linux.go
+++ b/osl/interface_linux.go
@@ -30,6 +30,7 @@ type nwIface struct {
 	llAddrs     []*net.IPNet
 	routes      []*net.IPNet
 	bridge      bool
+	v6Enabled   bool
 	ns          *networkNamespace
 	sync.Mutex
 }
@@ -373,6 +374,12 @@ func setInterfaceIP(nlh *netlink.Handle, iface netlink.Link, i *nwIface) error {
 
 func setInterfaceIPv6(nlh *netlink.Handle, iface netlink.Link, i *nwIface) error {
 	if i.AddressIPv6() == nil {
+		if i.v6Enabled {
+			// This is the case of a link-local only IPv6 address interface
+			if err := setIPv6(i.ns.path, i.DstName(), true); err != nil {
+				return fmt.Errorf("failed to enable ipv6: %v", err)
+			}
+		}
 		return nil
 	}
 	if err := checkRouteConflict(nlh, i.AddressIPv6(), netlink.FAMILY_V6); err != nil {

--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -221,11 +221,17 @@ func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
 		logrus.Warnf("Failed to set the timeout on the sandbox netlink handle sockets: %v", err)
 	}
 
-	// As starting point, disable IPv6 on all interfaces
 	if !n.isDefault {
+		// As starting point, disable IPv6 on all interfaces, besides the loopback.
+		// Preserve it on the loopback for backward compatibility because some
+		// applications expect this behavior.
 		err = setIPv6(n.path, "all", false)
 		if err != nil {
 			logrus.Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)
+		}
+		err = setIPv6(n.path, "lo", true)
+		if err != nil {
+			logrus.Warnf("Failed to enable IPv6 on `lo` interface on network namespace %q: %v", n.path, err)
 		}
 	}
 
@@ -276,10 +282,16 @@ func GetSandboxForExternalKey(basePath string, key string) (Sandbox, error) {
 		logrus.Warnf("Failed to set the timeout on the sandbox netlink handle sockets: %v", err)
 	}
 
-	// As starting point, disable IPv6 on all interfaces
+	// As starting point, disable IPv6 on all interfaces, besides the loopback.
+	// Preserve it on the loopback for backward compatibility because some
+	// applications expect this behavior.
 	err = setIPv6(n.path, "all", false)
 	if err != nil {
 		logrus.Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)
+	}
+	err = setIPv6(n.path, "lo", true)
+	if err != nil {
+		logrus.Warnf("Failed to enable IPv6 on `lo` interface on network namespace %q: %v", n.path, err)
 	}
 
 	if err = n.loopbackUp(); err != nil {

--- a/osl/options_linux.go
+++ b/osl/options_linux.go
@@ -60,6 +60,12 @@ func (n *networkNamespace) AddressIPv6(addr *net.IPNet) IfaceOption {
 	}
 }
 
+func (n *networkNamespace) EnableIPv6(val bool) IfaceOption {
+	return func(i *nwIface) {
+		i.v6Enabled = val
+	}
+}
+
 func (n *networkNamespace) LinkLocalAddresses(list []*net.IPNet) IfaceOption {
 	return func(i *nwIface) {
 		i.llAddrs = list

--- a/osl/sandbox.go
+++ b/osl/sandbox.go
@@ -88,6 +88,9 @@ type IfaceOptionSetter interface {
 	// Address returns an option setter to set IPv6 address.
 	AddressIPv6(*net.IPNet) IfaceOption
 
+	// EnableIPv6 returns an option setter to enable/disable IPv6 (may not have an IPv6 routable address)
+	EnableIPv6(bool) IfaceOption
+
 	// LinkLocalAddresses returns an option setter to set the link-local IP addresses.
 	LinkLocalAddresses([]*net.IPNet) IfaceOption
 

--- a/sandbox.go
+++ b/sandbox.go
@@ -829,6 +829,7 @@ func (sb *sandbox) populateNetworkResources(ep *endpoint) error {
 		if err := sb.osSbox.AddInterface(i.srcName, i.dstPrefix, ifaceOptions...); err != nil {
 			return fmt.Errorf("failed to add interface %s to sandbox: %v", i.srcName, err)
 		}
+		ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().EnableIPv6(ep.getNetwork().enableIPv6))
 	}
 
 	if joinInfo != nil {


### PR DESCRIPTION
Related to moby/moby/issues/33099
Overrides #1751 

As explained in https://github.com/moby/moby/issues/33099#issuecomment-300072083, it is better to keep IPv6 enabled on the container's loopback interface, for backward compatibility with applications which expect that. (We could do this only if enabled on the host, but doing it regardless seems more robust and should not cause any ipv6 advertise packet be sent out the container.)

Also, restore support for creating an `--ipv6` network with no routable subnet. Libnetwork core will be ok if the IPAM driver cannot auto allocate a subnet for the network.