### PR TITLE
Do not reset network scope during store read

### DIFF
--- a/store.go
+++ b/store.go
@@ -98,7 +98,9 @@ func (c *controller) getNetworkFromStore(nid string) (*network, error) {
 		}
 
 		n.epCnt = ec
-		n.scope = store.Scope()
+		if n.scope == "" {
+			n.scope = store.Scope()
+		}
 		return n, nil
 	}
 
@@ -132,7 +134,9 @@ func (c *controller) getNetworksForScope(scope string) ([]*network, error) {
 		}
 
 		n.epCnt = ec
-		n.scope = scope
+		if n.scope == "" {
+			n.scope = scope
+		}
 		nl = append(nl, n)
 	}
 
@@ -171,7 +175,9 @@ func (c *controller) getNetworksFromStore() ([]*network, error) {
 				ec.n = n
 				n.epCnt = ec
 			}
-			n.scope = store.Scope()
+			if n.scope == "" {
+				n.scope = store.Scope()
+			}
 			n.Unlock()
 			nl = append(nl, n)
 		}


### PR DESCRIPTION
- Unless it is needed

After #1742, the `scope` field of the `network` structure is no longer tied to the network's datascope. The datastore APIs do in fact deduct the store scope for the network object from the DataScope() API.
That API itself has been changed to return the proper datastore scope in case of regular or swarm network.

The network read from store function are resetting the `network.scope` to the network's datascope. This was a long because of a long ago change to make sure a network could be removed in case the driver (remote) is no longer there, or in case a network was added with a older docker version where the scope field was not being saved to store.

Changed the code to perform the above logic only in case the `network.scope` is missing.
