### PR TITLE
Do not accept swarm scope network creation if swarm is off

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -765,6 +765,10 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 		return nil, types.ForbiddenErrorf("Cannot create a multi-host network from a worker node. Please create the network from a manager node.")
 	}
 
+	if network.scope == datastore.SwarmScope && c.isDistributedControl() {
+		return nil, types.ForbiddenErrorf("cannot create a swarm scoped network when swarm is not active")
+	}
+
 	// Make sure we have a driver available for this network type
 	// before we allocate anything.
 	if _, err := network.driver(true); err != nil {


### PR DESCRIPTION

Issue was reported by @thaJeztah in https://github.com/moby/moby/pull/32981#issuecomment-301956637

```
$ docker node ls
Error response from daemon: This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again.
$ ./docker network create --scope swarm bb
Error response from daemon: cannot create a swarm scoped network when swarm is not active

```
