### PR TITLE
Restore isAgent || n.dynamic check

### DIFF
--- a/network.go
+++ b/network.go
@@ -911,8 +911,8 @@ func (n *network) driver(load bool) (driverapi.Driver, error) {
 	if n.scope == "" && cap != nil {
 		n.scope = cap.DataScope
 	}
-	if isAgent && n.dynamic {
-		// If we are running in agent mode and the network
+	if isAgent || n.dynamic {
+		// If we are running in agent mode or the network
 		// is dynamic, then the networks are swarm scoped
 		// regardless of the backing driver.
 		n.scope = datastore.SwarmScope


### PR DESCRIPTION
- This got mistakenly chaged by 596122e05edd3
- Current PR restores behavior added in 2736974436513da1919746e184e6fa708bf1aeba

Issue:
On daemon reload with with swarm configuration, it is possible for the following failure in creating the ingress network:

```
INFO[0002] Gossip cluster hostname aboch-XPS-01bd4c59753f 
 INFO[0002] Docker daemon                                 commit=ca4b3c6 graphdriver=aufs version=17.06.0-dev
ERRO[0002] Failed creating ingress network: This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again. 
```

debugging revealed the issue is because of the change, where is Agent would return false because the cluster provider is not yet set.

Note: On defer path, ingress network removal with driver won't take place for same reason. 
On failure in creating the ingress network, the daemon won't create and attach the ingress sandbox.
As a result a `docker network prune` will remove the (anyway bad) ingress network during the execution of `localNetworksPrune` given the network has no active endpoints.

Signed-off-by: Alessandro Boch <aboch@docker.com>