### PR TITLE
Reference: Allow docker service's task to see remote client source IP

### DIFF
--- a/osl/sandbox.go
+++ b/osl/sandbox.go
@@ -32,6 +32,9 @@ type Sandbox interface {
 	// Unset the previously set default IPv6 gateway in the sandbox
 	UnsetGatewayIPv6() error
 
+	// Add a policy routing rule to the sandbox
+	AddPolicyRoutingRule(table int, src, dst *net.IPNet) error
+
 	// Add a static route to the sandbox.
 	AddStaticRoute(*types.StaticRoute) error
 

--- a/types/types.go
+++ b/types/types.go
@@ -422,10 +422,9 @@ const (
 
 // StaticRoute is a statically-provisioned IP route.
 type StaticRoute struct {
+	Table       int
 	Destination *net.IPNet
-
-	RouteType int // NEXT_HOP or CONNECTED
-
+	RouteType   int // NEXT_HOP or CONNECTED
 	// NextHop will be resolved by the kernel (i.e. as a loose hop).
 	NextHop net.IP
 }
@@ -434,9 +433,11 @@ type StaticRoute struct {
 func (r *StaticRoute) GetCopy() *StaticRoute {
 	d := GetIPNetCopy(r.Destination)
 	nh := GetIPCopy(r.NextHop)
-	return &StaticRoute{Destination: d,
-		RouteType: r.RouteType,
-		NextHop:   nh,
+	return &StaticRoute{
+		Table:       r.Table,
+		Destination: d,
+		RouteType:   r.RouteType,
+		NextHop:     nh,
 	}
 }
 


### PR DESCRIPTION
I am publishing this change for reference only.

In case in future we plan to support a new service publishing mode which restricts the ingress load balancing to the tasks local to this node only, then integrated with this changes it will allow for the service's tasks to receive the requests directly from the remote client source IP.