### PR TITLE
[bug]Fix race between sandbox.delete() and SetKey()

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -626,6 +626,10 @@ func (sb *sandbox) SetKey(basePath string) error {
 	}
 
 	sb.Lock()
+	if sb.inDelete {
+		sb.Unlock()
+		return types.ForbiddenErrorf("failed to SetKey: sandbox %q delete in progress", sb.id)
+	}
 	oldosSbox := sb.osSbox
 	sb.Unlock()
 


### PR DESCRIPTION
When sandbox is deleting, another SetKey routine could be also in
progress as there's no lock to protect it, when this happens, there
could be a scene that one sandbox is removed, but it's osSbox file
"/var/run/docker/netns/xxxx" left on system and will never be cleaned.

So add a inDelete check for SetKey() to eliminate the race.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>