### PR TITLE
Fix container access issue when it moves across hosts

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -439,7 +439,7 @@ func (n *network) restoreSubnetSandbox(s *subnet, brName, vxlanName string) erro
 
 	Ifaces = make(map[string][]osl.IfaceOption)
 	vxlanIfaceOption := make([]osl.IfaceOption, 1)
-	vxlanIfaceOption = append(vxlanIfaceOption, sbox.InterfaceOptions().Master(brName))
+	vxlanIfaceOption = append(vxlanIfaceOption, sbox.InterfaceOptions().Master(brName), sbox.InterfaceOptions().DisableLearning())
 	Ifaces[fmt.Sprintf("%s+%s", vxlanName, "vxlan")] = vxlanIfaceOption
 	err = sbox.Restore(Ifaces, nil, nil, nil)
 	if err != nil {

--- a/osl/options_linux.go
+++ b/osl/options_linux.go
@@ -77,3 +77,9 @@ func (n *networkNamespace) Routes(routes []*net.IPNet) IfaceOption {
 		i.routes = routes
 	}
 }
+
+func (n *networkNamespace) DisableLearning() IfaceOption {
+	return func(i *nwIface) {
+		i.disableLearning = true
+	}
+}

--- a/osl/sandbox.go
+++ b/osl/sandbox.go
@@ -101,6 +101,10 @@ type IfaceOptionSetter interface {
 
 	// Address returns an option setter to set interface routes.
 	Routes([]*net.IPNet) IfaceOption
+
+	// DisableLearning returns an option setter to disable mac learning on a bridge
+	// interface
+	DisableLearning() IfaceOption
 }
 
 // Info represents all possible information that


### PR DESCRIPTION
Fixes #1768 

Noticed this issue when debugging few test case failures in e2e test suite. This is likely to be the root cause for [docker #33076](https://github.com/moby/moby/issues/33076) and the service access issue during container bring up reported in [docker #30321](https://github.com/moby/moby/issues/30321)

libnetwork IPAM recycles the IP address when a  task goes down on a node and brought up in another node. For remote tasks overlay network namespace has one static fdb entry programmed by the driver and one dynamic entry learned by the bridge from the data path when a packet is received from the remote container. The dynamic entry ages out after 300 seconds. If a task on a remote node goes down and gets scheduled on a node the dynamic fdb entry still remains. Unless the container generates some data traffic it won't be updated. This can lead to unpredictability in accessing the container; sometimes it will work pretty quickly if there is some traffic from the container and the mac entry gets updated. If the container is completely `silent` it can lead to upto 300 seconds of traffic loss.

Change in this PR is to disable the mac learning in the bridge. This is done only for the vxlan interface. For local veth interfaces we rely on mac learning for container to container communication.

There is one caveat with this approach: When there are many local containers traffic to a remote task would get replicated to all those local endpoints. This can potentially be a performance issue. An alternative approach is to delete the dynamic mac entry in the bridge. But in some older kernels deleting the dynamic entry doesn't work because of the default vlan issue. It might still be possible to handle that case by setting the default bridge vlan. If that is feasible this fix can be changed to use that approach.


Signed-off-by: Santhosh Manohar <santhosh@docker.com>