### PR TITLE
Removing the override for ipamdriver for local scope networks in

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -738,7 +738,6 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 	if network.configOnly {
 		network.scope = datastore.LocalScope
 		network.networkType = "null"
-		network.ipamType = ""
 		goto addToStore
 	}
 

--- a/network.go
+++ b/network.go
@@ -412,6 +412,9 @@ func (n *network) applyConfigurationTo(to *network) error {
 			}
 		}
 	}
+	if len(n.ipamType) != 0 {
+		to.ipamType = n.ipamType
+	}
 	if len(n.ipamOptions) > 0 {
 		to.ipamOptions = make(map[string]string, len(n.ipamOptions))
 		for k, v := range n.ipamOptions {


### PR DESCRIPTION
The commit contains fix for the issue reported in https://github.com/moby/moby/issues/33415 and
https://github.com/docker/libnetwork/issues/1772. With the feature introduced to support local scope networks in swarm mode (moby/moby#32981) the network configuration to include ipam driver was over-riden in libnetwork. This has been removed with this fix which will allow ipam-driver option to be used for task allocation. 
Verified with the steps posted in the issue docker/libnetwork#1772 as well.

Signed-off-by: Abhinandan Prativadi <abhi@docker.com>