### PR TITLE
Set kernel specific config on linux

### DIFF
--- a/drivers/overlay/ostweaks_linux.go
+++ b/drivers/overlay/ostweaks_linux.go
@@ -1,0 +1,30 @@
+package overlay
+
+import (
+	"io/ioutil"
+	"path"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+)
+
+var sysctlConf = map[string]string{
+	"net.ipv4.neigh.default.gc_thresh1": "8192",
+	"net.ipv4.neigh.default.gc_thresh2": "49152",
+	"net.ipv4.neigh.default.gc_thresh3": "65536",
+}
+
+// writeSystemProperty writes the value to a path under /proc/sys as determined from the key.
+// For e.g. net.ipv4.ip_forward translated to /proc/sys/net/ipv4/ip_forward.
+func writeSystemProperty(key, value string) error {
+	keyPath := strings.Replace(key, ".", "/", -1)
+	return ioutil.WriteFile(path.Join("/proc/sys", keyPath), []byte(value), 0644)
+}
+
+func applyOStweaks() {
+	for k, v := range sysctlConf {
+		if err := writeSystemProperty(k, v); err != nil {
+			logrus.Errorf("error setting the kernel parameter %s = %s, err: %s", k, v, err)
+		}
+	}
+}

--- a/drivers/overlay/ostweaks_unsupported.go
+++ b/drivers/overlay/ostweaks_unsupported.go
@@ -1,0 +1,5 @@
+// +build !linux
+
+package overlay
+
+func applyOStweaks() {}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -46,7 +46,7 @@ type driver struct {
 	store            datastore.DataStore
 	localStore       datastore.DataStore
 	vxlanIdm         *idm.Idm
-	once             sync.Once
+	initOS           sync.Once
 	joinOnce         sync.Once
 	localJoinOnce    sync.Once
 	keys             []*key
@@ -187,6 +187,9 @@ func (d *driver) configure() error {
 	if d.vxlanIdm == nil {
 		return d.initializeVxlanIdm()
 	}
+
+	// Apply OS specific kernel configs if needed
+	d.initOS.Do(applyOStweaks)
 
 	return nil
 }


### PR DESCRIPTION
On linux systems bump up gc_thresholds so to lower the
probability of running with neighbor table overflow issues

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>