### PR TITLE
Fixing ipam concurrent allocation

### DIFF
--- a/bitseq/store.go
+++ b/bitseq/store.go
@@ -117,9 +117,9 @@ func (h *Handle) fromDsValue(value []byte) error {
 }
 
 func (h *Handle) writeToStore() error {
-	h.Lock()
+	h.RLock()
 	store := h.store
-	h.Unlock()
+	h.RUnlock()
 	if store == nil {
 		return nil
 	}
@@ -131,9 +131,9 @@ func (h *Handle) writeToStore() error {
 }
 
 func (h *Handle) deleteFromStore() error {
-	h.Lock()
+	h.RLock()
 	store := h.store
-	h.Unlock()
+	h.RUnlock()
 	if store == nil {
 		return nil
 	}


### PR DESCRIPTION
Adding locks to ensure concurrent bitseq allocation doesnt corrupt the RLE encode bitseq.
It was seen with a small test that concurrent use of ipam address request was allocating duplicate IP
addresses

Signed-off-by: Abhinandan Prativadi <abhi@docker.com>