### PR TITLE
Cleanup interfaces properly when vxlan plumbing fails

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -560,6 +560,23 @@ func (n *network) setupSubnetSandbox(s *subnet, brName, vxlanName string) error 
 
 	if err := sbox.AddInterface(vxlanName, "vxlan",
 		sbox.InterfaceOptions().Master(brName)); err != nil {
+		// If adding vxlan device to the overlay namespace fails, remove the bridge interface we
+		// already added to the namespace. This allows the caller to try the setup again.
+		for _, iface := range sbox.Info().Interfaces() {
+			if iface.SrcName() == brName {
+				if ierr := iface.Remove(); ierr != nil {
+					logrus.Errorf("removing bridge failed from ov ns %v failed, %v", n.sbox.Key(), ierr)
+				}
+			}
+		}
+
+		// Also, delete the vxlan interface. Since a global vni id is associated
+		// with the vxlan interface, an orphaned vxlan interface will result in
+		// failure of vxlan device creation if the vni is assigned to some other
+		// network.
+		if deleteErr := deleteInterface(vxlanName); deleteErr != nil {
+			logrus.Warnf("could not delete vxlan interface, %s, error %v, after config error, %v\n", vxlanName, deleteErr, err)
+		}
 		return fmt.Errorf("vxlan interface creation failed for subnet %q: %v", s.subnetIP.String(), err)
 	}
 
@@ -601,6 +618,9 @@ func (n *network) initSubnetSandbox(s *subnet, restore bool) error {
 		}
 	} else {
 		if err := n.setupSubnetSandbox(s, brName, vxlanName); err != nil {
+			// The error in setupSubnetSandbox could be a temporary glitch. reset the
+			// subnet once object to allow the setup to be retried on another endpoint join.
+			s.once = &sync.Once{}
 			return err
 		}
 	}

--- a/osl/interface_linux.go
+++ b/osl/interface_linux.go
@@ -297,6 +297,16 @@ func (n *networkNamespace) AddInterface(srcName, dstPrefix string, options ...If
 
 	// Configure the interface now this is moved in the proper namespace.
 	if err := configureInterface(nlh, iface, i); err != nil {
+		// If configuring the device fails move it back to the host namespace
+		// and change the name back to the source name. This allows the caller
+		// to properly cleanup the interface. Its important especially for
+		// interfaces with global attributes, ex: vni id for vxlan interfaces.
+		if nerr := nlh.LinkSetName(iface, i.SrcName()); nerr != nil {
+			logrus.Errorf("renaming interface (%s->%s) failed, %v after config error %v\n", i.DstName(), i.SrcName(), nerr, err)
+		}
+		if nerr := nlh.LinkSetNsFd(iface, ns.ParseHandlerInt()); nerr != nil {
+			logrus.Errorf("moving inteface %s to host ns failed, %v, after config error %v\n", i.SrcName(), nerr, err)
+		}
 		return err
 	}
 


### PR DESCRIPTION
Related to #1765 

There have been many reports of container creation failing with "Error creating vxlan: file exists" error. This happens very randomly (but typically after lot of stack deploy/rm) without a specific sequence to recreate the issue.

I haven't been able to recreate it either. But with a forced error I can hit this issue. When setting up the overlay network we create a separate namespace for the overlay network, create a vxlan device and move it into the overlay namespace and configure it (interface name for ex). If something goes wrong here vxlan interface wasn't getting cleaned up properly. If that network is delated, another network could get its vni id. Since an orphaned interface exists with that vni id, new vxlan device can't be created.

Changes in this PR does proper cleanup of the vxlan interface and the overlay namespace on any failure so that subsequent attempts or another network which gets the same vxlan id can succeed.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>