### PR TITLE
Fix sandbox cleanup

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -822,10 +822,6 @@ func (ep *endpoint) Delete(force bool) error {
 		}
 	}
 
-	if err = n.getController().deleteFromStore(ep); err != nil {
-		return err
-	}
-
 	defer func() {
 		if err != nil && !force {
 			ep.dbExists = false
@@ -839,6 +835,11 @@ func (ep *endpoint) Delete(force bool) error {
 	n.getController().unWatchSvcRecord(ep)
 
 	if err = ep.deleteEndpoint(force); err != nil && !force {
+		return err
+	}
+
+	// This has to come after the sandbox and the driver to guarantee that can be the source of truth on restart cases
+	if err = n.getController().deleteFromStore(ep); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Driver and Sanbox have 2 different stores where the endpoints are saved
It is possible that the 2 store go out of sync if the endpoint is added to the driver
but there is a crash before the sandbox join.
On restart now we take the list of endpoints from the network and we assign
them back to the sandbox

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>