### PR TITLE
Fixes docker daemon not starting after endpoint leak 

### DIFF
--- a/drivers/windows/windows_store.go
+++ b/drivers/windows/windows_store.go
@@ -232,9 +232,12 @@ func (ep *hnsEndpoint) MarshalJSON() ([]byte, error) {
 	epMap["Type"] = ep.Type
 	epMap["profileID"] = ep.profileID
 	epMap["MacAddress"] = ep.macAddress.String()
-	epMap["Addr"] = ep.addr.String()
-	epMap["gateway"] = ep.gateway.String()
-
+	if ep.addr.IP != nil {
+		epMap["Addr"] = ep.addr.String()
+	}
+	if ep.gateway != nil {
+		epMap["gateway"] = ep.gateway.String()
+	}
 	epMap["epOption"] = ep.epOption
 	epMap["epConnectivity"] = ep.epConnectivity
 	epMap["PortMapping"] = ep.portMapping
@@ -251,7 +254,6 @@ func (ep *hnsEndpoint) UnmarshalJSON(b []byte) error {
 	if err = json.Unmarshal(b, &epMap); err != nil {
 		return fmt.Errorf("Failed to unmarshal to endpoint: %v", err)
 	}
-
 	if v, ok := epMap["MacAddress"]; ok {
 		if ep.macAddress, err = net.ParseMAC(v.(string)); err != nil {
 			return types.InternalErrorf("failed to decode endpoint MAC address (%s) after json unmarshal: %v", v.(string), err)
@@ -262,7 +264,9 @@ func (ep *hnsEndpoint) UnmarshalJSON(b []byte) error {
 			return types.InternalErrorf("failed to decode endpoint IPv4 address (%s) after json unmarshal: %v", v.(string), err)
 		}
 	}
-
+	if v, ok := epMap["gateway"]; ok {
+		ep.gateway = net.ParseIP(v.(string))
+	}
 	ep.id = epMap["id"].(string)
 	ep.Type = epMap["Type"].(string)
 	ep.nid = epMap["nid"].(string)


### PR DESCRIPTION
The docker daemon doesn't start on windows after an endpoint leaks. It fails with error Error starting daemon: Error initializing network controller: error obtaining controller instance: failed to get endpoints from store: failed to decode endpoint IPv4 address (<nil>) after json unmarshal: invalid CIDR address: <nil>

This is because there is no ip for an endpoint in transparent network. We need to handle that during marshal and unmarshal.
