### PR TITLE
Enable Hotadd support for windows

### DIFF
--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -65,6 +65,7 @@ type hnsEndpoint struct {
 	nid            string
 	profileID      string
 	Type           string
+	containerID    string
 	macAddress     net.HardwareAddr
 	epOption       *endpointOption       // User specified parameters
 	epConnectivity *endpointConnectivity // User specified parameters
@@ -726,7 +727,15 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		return err
 	}
 
-	// This is just a stub for now
+	endpoint.containerID = sboxKey
+
+	err = hcsshim.HotAttachEndpoint(endpoint.containerID, endpoint.profileID)
+	if err != nil {
+		// If container doesn't exists in hcs, do not throw error for hot add/remove
+		if err != hcsshim.ErrComputeSystemDoesNotExist {
+			return err
+		}
+	}
 
 	jinfo.DisableGatewayService()
 	return nil
@@ -740,13 +749,18 @@ func (d *driver) Leave(nid, eid string) error {
 	}
 
 	// Ensure that the endpoint exists
-	_, err = network.getEndpoint(eid)
+	endpoint, err := network.getEndpoint(eid)
 	if err != nil {
 		return err
 	}
 
-	// This is just a stub for now
-
+	err = hcsshim.HotDetachEndpoint(endpoint.containerID, endpoint.profileID)
+	if err != nil {
+		// If container doesn't exists in hcs, do not throw error for hot add/remove
+		if err != hcsshim.ErrComputeSystemDoesNotExist {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/osl/namespace_windows.go
+++ b/osl/namespace_windows.go
@@ -5,12 +5,7 @@ import "testing"
 // GenerateKey generates a sandbox key based on the passed
 // container id.
 func GenerateKey(containerID string) string {
-	maxLen := 12
-	if len(containerID) < maxLen {
-		maxLen = len(containerID)
-	}
-
-	return containerID[:maxLen]
+	return containerID
 }
 
 // NewSandbox provides a new sandbox instance created in an os specific way

--- a/sandbox.go
+++ b/sandbox.go
@@ -144,13 +144,6 @@ func (sb *sandbox) ContainerID() string {
 	return sb.containerID
 }
 
-func (sb *sandbox) Key() string {
-	if sb.config.useDefaultSandBox {
-		return osl.GenerateKey("default")
-	}
-	return osl.GenerateKey(sb.id)
-}
-
 func (sb *sandbox) Labels() map[string]interface{} {
 	sb.Lock()
 	defer sb.Unlock()

--- a/sandbox_others.go
+++ b/sandbox_others.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package libnetwork
+
+import "github.com/docker/libnetwork/osl"
+
+func (sb *sandbox) Key() string {
+	if sb.config.useDefaultSandBox {
+		return osl.GenerateKey("default")
+	}
+	return osl.GenerateKey(sb.id)
+}

--- a/sandbox_windows.go
+++ b/sandbox_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package libnetwork
+
+import "github.com/docker/libnetwork/osl"
+
+func (sb *sandbox) Key() string {
+	if sb.config.useDefaultSandBox {
+		return osl.GenerateKey("default")
+	}
+	return osl.GenerateKey(sb.containerID)
+}


### PR DESCRIPTION
Hot add for windows requires containerID to be passed down to hcsshim, which interally finds the right container and connects the nic.