### PR TITLE
Flavio as Libnetwork maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -17,6 +17,7 @@
 			"mavenugo",
 			"sanimej",
 			"chenchun",
+                        "fcrisciani",
 		]
 
 [people]
@@ -41,6 +42,11 @@
 	Name = "Chun Chen"
 	Email = "ramichen@tencent.com"
 	GitHub = "chenchun"
+
+	[people.fcrisciani]
+	Name = "Flavio Crisciani"
+	Email = "flavio.crisciani@docker.com"
+	GitHub = "fcrisciani"
 
 	[people.icecrime]
 	Name = "Arnaud Porterie"


### PR DESCRIPTION
Flavio has been contributing various useful features in Docker 17.05
and 17.06 releases and also an active maintainer who helps with various
bug fixes and PR reviews

Signed-off-by: Madhu Venugopal <madhu@docker.com>