### PR TITLE
Clean up kernel entries properly on task reschedules.

### DIFF
--- a/drivers/overlay/peerdb.go
+++ b/drivers/overlay/peerdb.go
@@ -260,6 +260,13 @@ func (d *driver) peerAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask,
 		return err
 	}
 
+	// This peer add could be for an IP which was assigned to a remote task
+	// that just went down and we haaven't received the gossip delete event
+	// yet. Hence check the current peerDb and clean up the kernel state.
+	// The case where the network sandbox is not avialble is when the node
+	// doesn't have this network instantiated yet. In that there is nothing
+	// to clean up.
+	oldMac, _, oldVtep, existsErr := d.peerDbSearch(nid, peerIP)
 	if updateDb {
 		d.peerDbAdd(nid, eid, peerIP, peerIPMask, peerMac, vtep, false)
 	}
@@ -299,6 +306,14 @@ func (d *driver) peerAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask,
 	// Add neighbor entry for the peer IP
 	if err := sbox.AddNeighbor(peerIP, peerMac, l3Miss, sbox.NeighborOptions().LinkName(s.vxlanName)); err != nil {
 		return fmt.Errorf("could not add neighbor entry into the sandbox: %v", err)
+	}
+
+	if existsErr == nil && vtep.String() != oldVtep.String() &&
+		oldVtep.String() != d.advertiseAddress {
+		if err := sbox.DeleteNeighbor(oldVtep, oldMac, true); err != nil {
+			logrus.Errorf(`peerAdd for %s with vtep %s, old vtep %s 
+			cleanup failed: %v`, peerIP, vtep, oldVtep, err)
+		}
 	}
 
 	// Add fdb entry to the bridge for the peer mac


### PR DESCRIPTION
related to [moby #33789](https://github.com/moby/moby/issues/33789)

When a task gets scheduled on a node, its IP could have been used by a task on a remote node 
that just went down. The add event could be received before the delete the older task that went 
down. In this case the kernel entry cleanup should be done before we update our state based on
the new add event. Otherwise the cleanup won't happen correctly when the old delete event does arrive.

This PR has the required changes in the libnetwork. But at least with Ubuntu 4.4.0 kernel running in AWS, I see that sometimes the fdb entry still remains even through the netlink call to delete the
entry succeeds. This needs to be looked into. But in cases where the fdb entry does get deleted
correctly this will avoid the overlay connectivity issue.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>