### PR TITLE
dnet: remove unused method for dnetConnection struct

### DIFF
--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -329,13 +329,6 @@ func (d *dnetConnection) GetRemoteAddressList() []string {
 	return []string{d.Orchestration.Peer}
 }
 
-func (d *dnetConnection) GetNetworkKeys() []*types.EncryptionKey {
-	return nil
-}
-
-func (d *dnetConnection) SetNetworkKeys([]*types.EncryptionKey) {
-}
-
 func (d *dnetConnection) ListenClusterEvents() <-chan cluster.ConfigEventType {
 	return d.configEvent
 }


### PR DESCRIPTION
The cluster provider interface does not need GetNetworkKeys
and SetNetworkKeys

Signed-off-by: Hui Kang <kangh@us.ibm.com>