### PR TITLE
Make node join event logging less noisy

### DIFF
--- a/networkdb/delegate.go
+++ b/networkdb/delegate.go
@@ -111,9 +111,12 @@ func (nDB *NetworkDB) handleNodeEvent(nEvent *NodeEvent) bool {
 	switch nEvent.Type {
 	case NodeEventTypeJoin:
 		nDB.Lock()
+		_, found := nDB.nodes[n.Name]
 		nDB.nodes[n.Name] = n
 		nDB.Unlock()
-		logrus.Infof("Node join event for %s/%s", n.Name, n.Addr)
+		if !found {
+			logrus.Infof("Node join event for %s/%s", n.Name, n.Addr)
+		}
 		return true
 	case NodeEventTypeLeave:
 		nDB.Lock()


### PR DESCRIPTION
Commit 90103909401ecbe2b39216bb44dc79b89eee2b7e added a number of debugging messages for node join/leave events.

This patch checks if a node already was listed, and otherwise skips the logging to make the logs a bit less noisy.

relates to https://github.com/docker/libnetwork/pull/1775
addresses https://github.com/moby/moby/issues/33962

ping @sanimej PTAL - we may want to have this in a 17.06.x patch release