### PR TITLE
Code cleanup using context

### DIFF
--- a/network.go
+++ b/network.go
@@ -1,6 +1,7 @@
 package libnetwork
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -1240,30 +1241,33 @@ func (n *network) updateSvcRecord(ep *endpoint, localEps []*endpoint, isAdd bool
 		if serviceID == "" {
 			serviceID = ep.ID()
 		}
+
+		ctx := context.WithValue(context.Background(), callerCtxKey, "updateSvcRecord")
+
 		if isAdd {
 			// If anonymous endpoint has an alias use the first alias
 			// for ip->name mapping. Not having the reverse mapping
 			// breaks some apps
 			if ep.isAnonymous() {
 				if len(myAliases) > 0 {
-					n.addSvcRecords(ep.ID(), myAliases[0], serviceID, iface.Address().IP, ipv6, true, "updateSvcRecord")
+					n.addSvcRecords(ctx, ep.ID(), myAliases[0], serviceID, iface.Address().IP, ipv6, true)
 				}
 			} else {
-				n.addSvcRecords(ep.ID(), epName, serviceID, iface.Address().IP, ipv6, true, "updateSvcRecord")
+				n.addSvcRecords(ctx, ep.ID(), epName, serviceID, iface.Address().IP, ipv6, true)
 			}
 			for _, alias := range myAliases {
-				n.addSvcRecords(ep.ID(), alias, serviceID, iface.Address().IP, ipv6, false, "updateSvcRecord")
+				n.addSvcRecords(ctx, ep.ID(), alias, serviceID, iface.Address().IP, ipv6, false)
 			}
 		} else {
 			if ep.isAnonymous() {
 				if len(myAliases) > 0 {
-					n.deleteSvcRecords(ep.ID(), myAliases[0], serviceID, iface.Address().IP, ipv6, true, "updateSvcRecord")
+					n.deleteSvcRecords(ctx, ep.ID(), myAliases[0], serviceID, iface.Address().IP, ipv6, true)
 				}
 			} else {
-				n.deleteSvcRecords(ep.ID(), epName, serviceID, iface.Address().IP, ipv6, true, "updateSvcRecord")
+				n.deleteSvcRecords(ctx, ep.ID(), epName, serviceID, iface.Address().IP, ipv6, true)
 			}
 			for _, alias := range myAliases {
-				n.deleteSvcRecords(ep.ID(), alias, serviceID, iface.Address().IP, ipv6, false, "updateSvcRecord")
+				n.deleteSvcRecords(ctx, ep.ID(), alias, serviceID, iface.Address().IP, ipv6, false)
 			}
 		}
 	}
@@ -1299,14 +1303,14 @@ func delNameToIP(svcMap common.SetMatrix, name, serviceID string, epIP net.IP) {
 	})
 }
 
-func (n *network) addSvcRecords(eID, name, serviceID string, epIP, epIPv6 net.IP, ipMapUpdate bool, method string) {
+func (n *network) addSvcRecords(ctx context.Context, eID, name, serviceID string, epIP, epIPv6 net.IP, ipMapUpdate bool) {
 	// Do not add service names for ingress network as this is a
 	// routing only network
 	if n.ingress {
 		return
 	}
 
-	logrus.Debugf("%s (%s).addSvcRecords(%s, %s, %s, %t) %s sid:%s", eID, n.ID()[0:7], name, epIP, epIPv6, ipMapUpdate, method, serviceID)
+	logrus.Debugf("%s (%s).addSvcRecords(%s, %s, %s, %t) %s sid:%s", eID, n.ID()[0:7], name, epIP, epIPv6, ipMapUpdate, getCaller(ctx), serviceID)
 
 	c := n.getController()
 	c.Lock()
@@ -1335,14 +1339,14 @@ func (n *network) addSvcRecords(eID, name, serviceID string, epIP, epIPv6 net.IP
 	}
 }
 
-func (n *network) deleteSvcRecords(eID, name, serviceID string, epIP net.IP, epIPv6 net.IP, ipMapUpdate bool, method string) {
+func (n *network) deleteSvcRecords(ctx context.Context, eID, name, serviceID string, epIP net.IP, epIPv6 net.IP, ipMapUpdate bool) {
 	// Do not delete service names from ingress network as this is a
 	// routing only network
 	if n.ingress {
 		return
 	}
 
-	logrus.Debugf("%s (%s).deleteSvcRecords(%s, %s, %s, %t) %s sid:%s ", eID, n.ID()[0:7], name, epIP, epIPv6, ipMapUpdate, method, serviceID)
+	logrus.Debugf("%s (%s).deleteSvcRecords(%s, %s, %s, %t) %s sid:%s ", eID, n.ID()[0:7], name, epIP, epIPv6, ipMapUpdate, getCaller(ctx), serviceID)
 
 	c := n.getController()
 	c.Lock()


### PR DESCRIPTION
The debugs using the caller of method has been extremely useful
in faster debugging and understanding of flow. This commit uses context
to pass in the caller information instead of explicit method names.
The ideal way would have been to use the runtime package Caller function
to get the callers from the function stack instead of passing the method
explicitly. However since the caller tree need not be symmetric it would
make it ugly to retrieve the interested caller. Hencing moving the method
name passing to context which would make it cleaner and more readable.

Signed-off-by: Abhinandan Prativadi <abhi@docker.com>