### PR TITLE
use builtin package context rather than vendored one

### DIFF
--- a/cluster/provider.go
+++ b/cluster/provider.go
@@ -1,8 +1,9 @@
 package cluster
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types/network"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,7 +37,6 @@ import (
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/types"
 	"github.com/gorilla/mux"
-	"golang.org/x/net/context"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

use builtin package context rather than vendored one

Since go 1.7, package context has been one builtin package in golang. So I think it is useful to use that directly. I searched globally in libnetwork except the vendored package and changed the two places.