### PR TITLE
Fix debug statement in startResolver

### DIFF
--- a/network_windows.go
+++ b/network_windows.go
@@ -29,7 +29,7 @@ func executeInCompartment(compartmentID uint32, x func()) {
 
 func (n *network) startResolver() {
 	n.resolverOnce.Do(func() {
-		logrus.Debugf("Launching DNS server for network", n.Name())
+		logrus.Debugf("Launching DNS server for network %q", n.Name())
 		options := n.Info().DriverOptions()
 		hnsid := options[windows.HNSID]
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Very simple fix. Been annoying for way too long running the Windows daemon in debug mode and seeing 

```
level=debug msg="Launching DNS server for network%!(EXTRA string=none)"
```

@msabansal @mavenugo