### PR TITLE
Fix network interface leak issue

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -971,6 +971,22 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	if err != nil {
 		return err
 	}
+	// Update the srcName first to make sure that DeleteEndpoint could be successful.
+	// Set the pointers to empty value here is to make sure we could update db successfully(or will panic)
+	endpoint.srcName = containerIfName
+	endpoint.addr = &net.IPNet{}
+	endpoint.addrv6 = &net.IPNet{}
+
+	if err = d.storeUpdate(endpoint); err != nil {
+		return fmt.Errorf("failed to save bridge endpoint %s to store: %v", endpoint.id[0:7], err)
+	}
+	defer func() {
+		if err != nil {
+			if err = d.storeDelete(endpoint); err != nil {
+				logrus.Warnf("error rolling back bridge endpoint %s from store: %v", endpoint.id[0:7], err)
+			}
+		}
+	}()
 
 	// Generate and add the interface pipe host <-> sandbox
 	veth := &netlink.Veth{
@@ -1029,9 +1045,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 			return err
 		}
 	}
-
 	// Store the sandbox side pipe interface parameters
-	endpoint.srcName = containerIfName
 	endpoint.macAddress = ifInfo.MacAddress()
 	endpoint.addr = ifInfo.Address()
 	endpoint.addrv6 = ifInfo.AddressIPv6()


### PR DESCRIPTION
Fix Issue: https://github.com/docker/libnetwork/issues/1850

Description:
  When the network resource(sandbox or interface) is created and not saved in store,
  And docker got killed or crashed, there will be network resource leak.

Solution:
  Save the resource to datastore first, then create the network resource.

Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>