### PR TITLE
Revert "use builtin package context rather than vendored one"

### DIFF
--- a/cluster/provider.go
+++ b/cluster/provider.go
@@ -1,9 +1,8 @@
 package cluster
 
 import (
-	"context"
-
 	"github.com/docker/docker/api/types/network"
+	"golang.org/x/net/context"
 )
 
 const (

--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,6 +36,7 @@ import (
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/types"
 	"github.com/gorilla/mux"
+	"golang.org/x/net/context"
 )
 
 const (


### PR DESCRIPTION
Reverts docker/libnetwork#1841

This breaks the integration with Moby:
```
---> Making bundle: binary (in bundles/17.06.0-dev/binary)                                                                                                                                                                     
Building: bundles/17.06.0-dev/binary-daemon/dockerd-17.06.0-dev                                                                                                                                                                                                             
# github.com/docker/docker/daemon/cluster                                     
daemon/cluster/cluster.go:238: cannot use c (type *Cluster) as type cluster.Provider in argument to c.config.Backend.DaemonJoinsCluster:
        *Cluster does not implement cluster.Provider (wrong type for WaitForDetachment method)
                have WaitForDetachment("github.com/docker/docker/vendor/golang.org/x/net/context".Context, string, string, string, string) error                                               
                want WaitForDetachment("context".Context, string, string, string, string) error     
make: *** [binary] Error 1  
```