### PR TITLE
Remove the error message on mac delete failure..

### DIFF
--- a/osl/neigh_linux.go
+++ b/osl/neigh_linux.go
@@ -91,9 +91,7 @@ func (n *networkNamespace) DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr,
 			if nh.linkDst != "" {
 				nlnh.LinkIndex = iface.Attrs().Index
 			}
-			if err := nlh.NeighDel(nlnh); err != nil {
-				logrus.Warnf("Deleting bridge mac mac %s failed, %v", dstMac, err)
-			}
+			nlh.NeighDel(nlnh)
 		}
 	}
 


### PR DESCRIPTION
Deletion of the dynamic mac is expected to work only if there was active
traffic with that endpoint and a dynamic entry exists. It can also age
out. Hence the mac removal failing is not error. Removing it to make the
debugging easier when parsing the logs.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>