### PR TITLE
Add service virtual IP to sandbox's loopback address

### DIFF
--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -356,6 +356,22 @@ func (n *networkNamespace) loopbackUp() error {
 	return n.nlHandle.LinkSetUp(iface)
 }
 
+func (n *networkNamespace) AddLoopbackAliasIP(ip *net.IPNet) error {
+	iface, err := n.nlHandle.LinkByName("lo")
+	if err != nil {
+		return err
+	}
+	return n.nlHandle.AddrAdd(iface, &netlink.Addr{IPNet: ip})
+}
+
+func (n *networkNamespace) RemoveLoopbackAliasIP(ip *net.IPNet) error {
+	iface, err := n.nlHandle.LinkByName("lo")
+	if err != nil {
+		return err
+	}
+	return n.nlHandle.AddrDel(iface, &netlink.Addr{IPNet: ip})
+}
+
 func (n *networkNamespace) InvokeFunc(f func()) error {
 	return nsInvoke(n.nsPath(), func(nsFD int) error { return nil }, func(callerFD int) error {
 		f()

--- a/osl/options_linux.go
+++ b/osl/options_linux.go
@@ -66,12 +66,6 @@ func (n *networkNamespace) LinkLocalAddresses(list []*net.IPNet) IfaceOption {
 	}
 }
 
-func (n *networkNamespace) IPAliases(list []*net.IPNet) IfaceOption {
-	return func(i *nwIface) {
-		i.ipAliases = list
-	}
-}
-
 func (n *networkNamespace) Routes(routes []*net.IPNet) IfaceOption {
 	return func(i *nwIface) {
 		i.routes = routes

--- a/osl/sandbox.go
+++ b/osl/sandbox.go
@@ -32,6 +32,12 @@ type Sandbox interface {
 	// Unset the previously set default IPv6 gateway in the sandbox
 	UnsetGatewayIPv6() error
 
+	// AddLoopbackAliasIP adds the passed IP address to the sandbox loopback interface
+	AddLoopbackAliasIP(ip *net.IPNet) error
+
+	// RemoveLoopbackAliasIP removes the passed IP address from the sandbox loopback interface
+	RemoveLoopbackAliasIP(ip *net.IPNet) error
+
 	// Add a static route to the sandbox.
 	AddStaticRoute(*types.StaticRoute) error
 
@@ -91,9 +97,6 @@ type IfaceOptionSetter interface {
 	// LinkLocalAddresses returns an option setter to set the link-local IP addresses.
 	LinkLocalAddresses([]*net.IPNet) IfaceOption
 
-	// IPAliases returns an option setter to set IP address Aliases
-	IPAliases([]*net.IPNet) IfaceOption
-
 	// Master returns an option setter to set the master interface if any for this
 	// interface. The master interface name should refer to the srcname of a
 	// previously added interface of type bridge.
@@ -149,9 +152,6 @@ type Interface interface {
 
 	// LinkLocalAddresses returns the link-local IP addresses assigned to the interface.
 	LinkLocalAddresses() []*net.IPNet
-
-	// IPAliases returns the IP address aliases assigned to the interface.
-	IPAliases() []*net.IPNet
 
 	// IP routes for the interface.
 	Routes() []*net.IPNet


### PR DESCRIPTION
Refreshed the PR: https://github.com/docker/libnetwork/pull/1585
Addressed comments suggesting to remove the IPAlias logic not anymore used

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>