### PR TITLE
Revert "[backport 17.03] Fixes bug that mistook gw6 for gw."

### DIFF
--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -415,7 +415,7 @@ func (epj *endpointJoinInfo) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := epMap["gw"]; ok {
-		epj.gw = net.ParseIP(v.(string))
+		epj.gw6 = net.ParseIP(v.(string))
 	}
 	if v, ok := epMap["gw6"]; ok {
 		epj.gw6 = net.ParseIP(v.(string))


### PR DESCRIPTION
Reverts docker/libnetwork#1876

Signed-off-by: Flavio Crisciani flavio.crisciani@docker.com