### PR TITLE
Add a minimum value for the CP MTU

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	warningThNetworkControlPlaneMTU = 1500
+	minimumNetworkControlPlaneMTU   = 500
+)
+
 // Config encapsulates configurations of various Libnetwork components
 type Config struct {
 	Daemon          DaemonCfg
@@ -226,9 +231,12 @@ func OptionExperimental(exp bool) Option {
 func OptionNetworkControlPlaneMTU(exp int) Option {
 	return func(c *Config) {
 		logrus.Debugf("Network Control Plane MTU: %d", exp)
-		if exp < 1500 {
-			// if exp == 0 the value won't be used
-			logrus.Warnf("Received a MTU of %d, this value is very low, the network control plane can misbehave", exp)
+		if exp < warningThNetworkControlPlaneMTU {
+			logrus.Warnf("Received a MTU of %d, this value is very low, the network control plane can misbehave,"+
+				" defaulting to minimum value (%d)", exp, minimumNetworkControlPlaneMTU)
+			if exp < minimumNetworkControlPlaneMTU {
+				exp = minimumNetworkControlPlaneMTU
+			}
 		}
 		c.Daemon.NetworkControlPlaneMTU = exp
 	}


### PR DESCRIPTION
Avoid negative numbers and also set a lower bondary.
500 will mean 400 bytes minimum payload that will allow
at least a couple of gossip message to fit.
There is not theoretical limit becasue the message is made of
strings so there is still the possibility to have cases where
the 400 bytes are not enough to fit a single message, but
in that case we should start thinking why do I need a node
name that is long as an enciclopedia

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>