### PR TITLE
Revert "Remove dynamic mac entry from fdb on endpoint deletion"

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -3,10 +3,8 @@ package overlay
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -15,7 +13,6 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netlabel"
@@ -70,54 +67,6 @@ type network struct {
 	secure    bool
 	mtu       int
 	sync.Mutex
-}
-
-func init() {
-	reexec.Register("set-default-vlan", setDefaultVlan)
-}
-
-func setDefaultVlan() {
-	if len(os.Args) < 3 {
-		logrus.Error("insufficient number of arguments")
-		os.Exit(1)
-	}
-	nsPath := os.Args[1]
-	ns, err := netns.GetFromPath(nsPath)
-	if err != nil {
-		logrus.Errorf("overlay namespace get failed, %v", err)
-		os.Exit(1)
-	}
-	if err = netns.Set(ns); err != nil {
-		logrus.Errorf("setting into overlay namespace failed, %v", err)
-		os.Exit(1)
-	}
-
-	// make sure the sysfs mount doesn't propagate back
-	if err = syscall.Unshare(syscall.CLONE_NEWNS); err != nil {
-		logrus.Errorf("unshare failed, %v", err)
-		os.Exit(1)
-	}
-
-	flag := syscall.MS_PRIVATE | syscall.MS_REC
-	if err = syscall.Mount("", "/", "", uintptr(flag), ""); err != nil {
-		logrus.Errorf("root mount failed, %v", err)
-		os.Exit(1)
-	}
-
-	if err = syscall.Mount("sysfs", "/sys", "sysfs", 0, ""); err != nil {
-		logrus.Errorf("mounting sysfs failed, %v", err)
-		os.Exit(1)
-	}
-
-	brName := os.Args[2]
-	path := filepath.Join("/sys/class/net", brName, "bridge/default_pvid")
-	data := []byte{'0', '\n'}
-
-	if err = ioutil.WriteFile(path, data, 0644); err != nil {
-		logrus.Errorf("endbling default vlan on bridge %s failed %v", brName, err)
-		os.Exit(1)
-	}
-	os.Exit(0)
 }
 
 func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {
@@ -562,25 +511,6 @@ func (n *network) setupSubnetSandbox(s *subnet, brName, vxlanName string) error 
 	if err := sbox.AddInterface(vxlanName, "vxlan",
 		sbox.InterfaceOptions().Master(brName)); err != nil {
 		return fmt.Errorf("vxlan interface creation failed for subnet %q: %v", s.subnetIP.String(), err)
-	}
-
-	if !hostMode {
-		var name string
-		for _, i := range sbox.Info().Interfaces() {
-			if i.Bridge() {
-				name = i.DstName()
-			}
-		}
-		cmd := &exec.Cmd{
-			Path:   reexec.Self(),
-			Args:   []string{"set-default-vlan", sbox.Key(), name},
-			Stdout: os.Stdout,
-			Stderr: os.Stderr,
-		}
-		if err := cmd.Run(); err != nil {
-			// not a fatal error
-			logrus.Errorf("reexec to set bridge default vlan failed %v", err)
-		}
 	}
 
 	if hostMode {

--- a/osl/neigh_linux.go
+++ b/osl/neigh_linux.go
@@ -78,23 +78,6 @@ func (n *networkNamespace) DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr,
 		if err := nlh.NeighDel(nlnh); err != nil {
 			logrus.Warnf("Deleting neighbor IP %s, mac %s failed, %v", dstIP, dstMac, err)
 		}
-
-		// Delete the dynamic entry in the bridge
-		if nlnh.Family > 0 {
-			nlnh := &netlink.Neigh{
-				IP:     dstIP,
-				Family: nh.family,
-			}
-
-			nlnh.HardwareAddr = dstMac
-			nlnh.Flags = netlink.NTF_MASTER
-			if nh.linkDst != "" {
-				nlnh.LinkIndex = iface.Attrs().Index
-			}
-			if err := nlh.NeighDel(nlnh); err != nil {
-				logrus.Warnf("Deleting bridge mac mac %s failed, %v", dstMac, err)
-			}
-		}
 	}
 
 	n.Lock()


### PR DESCRIPTION
The mount propagation is causing wierd issues in specific scenarios.
Reverting the patch temporarily until the root-cause is identified.

This reverts commit ae6824ea646a89853afa145a90f56e449f4d3a4f.

Signed-off-by: Madhu Venugopal <madhu@docker.com>