### PR TITLE
Fix test using com.docker.network.mtu

### DIFF
--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -417,7 +417,7 @@ func TestNetworkConfig(t *testing.T) {
 		libnetwork.NetworkOptionIpam("", "", ipamV4ConfList, nil, nil),
 		libnetwork.NetworkOptionIpam("", "", nil, ipamV6ConfList, nil),
 		libnetwork.NetworkOptionLabels(map[string]string{"number": "two"}),
-		libnetwork.NetworkOptionDriverOpts(map[string]string{"com.docker.network.mtu": "1600"}),
+		libnetwork.NetworkOptionDriverOpts(map[string]string{"com.docker.network.driver.mtu": "1600"}),
 	} {
 		_, err = controller.NewNetwork(bridgeNetType, "testBR", "",
 			libnetwork.NetworkOptionConfigFrom("config_network0"), opt)


### PR DESCRIPTION
This should be `com.docker.network.driver.mtu`

fixes https://github.com/docker/libnetwork/issues/1906

ping @abhinandanpb PTAL