### PR TITLE
check nil pointer or avoid potential panic in bridge network

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -335,11 +335,20 @@ func (c *networkConfiguration) conflictsWithNetworks(id string, others []*bridge
 		if nwID == id {
 			continue
 		}
+
+		if nwConfig == nil {
+			continue
+		}
+
 		// Verify the name (which may have been set by newInterface()) does not conflict with
 		// existing bridge interfaces. Ironically the system chosen name gets stored in the config...
 		// Basically we are checking if the two original configs were both empty.
 		if nwConfig.BridgeName == c.BridgeName {
 			return types.ForbiddenErrorf("conflicts with network %s (%s) by bridge name", nwID, nwConfig.BridgeName)
+		}
+
+		if nwBridge == nil {
+			continue
 		}
 		// If this network config specifies the AddressIPv4, we need
 		// to make sure it does not conflict with any previously allocated


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

This PR tries to fix https://github.com/moby/moby/issues/34515 .

I am not sure why the bridge network has nil field. While I think according to the reported error, this PR's fix may be helpful.

This is a try and if I miss something, please feel free to tell me or close this. Thanks a lot.