### PR TITLE
Lock goroutine to OS thread while changing NS

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -81,6 +82,10 @@ func setDefaultVlan() {
 		logrus.Error("insufficient number of arguments")
 		os.Exit(1)
 	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	nsPath := os.Args[1]
 	ns, err := netns.GetFromPath(nsPath)
 	if err != nil {


### PR DESCRIPTION
Prevents an issue where the goroutine may jump to a new OS thread during
execution putting it into a mount/network NS that is unexpected.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
(cherry picked from commit 65bb58fad9f75b4302a972663a238e3f1a7ba3bb)
Signed-off-by: Brian Goff <cpuguy83@gmail.com>