### PR TITLE
Enabling ILB/ELB on windows using per-node, per-network LB endpoint.

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -75,6 +75,7 @@ type endpoint struct {
 	dbIndex           uint64
 	dbExists          bool
 	serviceEnabled    bool
+	loadBalancer      bool
 	sync.Mutex
 }
 
@@ -101,6 +102,7 @@ func (ep *endpoint) MarshalJSON() ([]byte, error) {
 	epMap["virtualIP"] = ep.virtualIP.String()
 	epMap["ingressPorts"] = ep.ingressPorts
 	epMap["svcAliases"] = ep.svcAliases
+	epMap["loadBalancer"] = ep.loadBalancer
 
 	return json.Marshal(epMap)
 }
@@ -201,6 +203,10 @@ func (ep *endpoint) UnmarshalJSON(b []byte) (err error) {
 		ep.virtualIP = net.ParseIP(vip.(string))
 	}
 
+	if v, ok := epMap["loadBalancer"]; ok {
+		ep.loadBalancer = v.(bool)
+	}
+
 	sal, _ := json.Marshal(epMap["svcAliases"])
 	var svcAliases []string
 	json.Unmarshal(sal, &svcAliases)
@@ -238,6 +244,7 @@ func (ep *endpoint) CopyTo(o datastore.KVObject) error {
 	dstEp.svcName = ep.svcName
 	dstEp.svcID = ep.svcID
 	dstEp.virtualIP = ep.virtualIP
+	dstEp.loadBalancer = ep.loadBalancer
 
 	dstEp.svcAliases = make([]string, len(ep.svcAliases))
 	copy(dstEp.svcAliases, ep.svcAliases)
@@ -1010,6 +1017,13 @@ func CreateOptionService(name, id string, vip net.IP, ingressPorts []*PortConfig
 func CreateOptionMyAlias(alias string) EndpointOption {
 	return func(ep *endpoint) {
 		ep.myAliases = append(ep.myAliases, alias)
+	}
+}
+
+//CreateOptionLoadBalancer function returns an option setter for denoting the endpoint is a load balancer for a network
+func CreateOptionLoadBalancer() EndpointOption {
+	return func(ep *endpoint) {
+		ep.loadBalancer = true
 	}
 }
 

--- a/endpoint.go
+++ b/endpoint.go
@@ -992,7 +992,7 @@ func CreateOptionDisableResolution() EndpointOption {
 	}
 }
 
-//CreateOptionAlias function returns an option setter for setting endpoint alias
+// CreateOptionAlias function returns an option setter for setting endpoint alias
 func CreateOptionAlias(name string, alias string) EndpointOption {
 	return func(ep *endpoint) {
 		if ep.aliases == nil {
@@ -1013,14 +1013,14 @@ func CreateOptionService(name, id string, vip net.IP, ingressPorts []*PortConfig
 	}
 }
 
-//CreateOptionMyAlias function returns an option setter for setting endpoint's self alias
+// CreateOptionMyAlias function returns an option setter for setting endpoint's self alias
 func CreateOptionMyAlias(alias string) EndpointOption {
 	return func(ep *endpoint) {
 		ep.myAliases = append(ep.myAliases, alias)
 	}
 }
 
-//CreateOptionLoadBalancer function returns an option setter for denoting the endpoint is a load balancer for a network
+// CreateOptionLoadBalancer function returns an option setter for denoting the endpoint is a load balancer for a network
 func CreateOptionLoadBalancer() EndpointOption {
 	return func(ep *endpoint) {
 		ep.loadBalancer = true

--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -31,6 +31,9 @@ type EndpointInfo interface {
 
 	// Sandbox returns the attached sandbox if there, nil otherwise.
 	Sandbox() Sandbox
+
+	// LoadBalancer returns whether the endpoint is the load balancer endpoint for the network.
+	LoadBalancer() bool
 }
 
 // InterfaceInfo provides an interface to retrieve interface addresses bound to the endpoint.
@@ -325,6 +328,12 @@ func (ep *endpoint) Sandbox() Sandbox {
 		return nil
 	}
 	return cnt
+}
+
+func (ep *endpoint) LoadBalancer() bool {
+	ep.Lock()
+	defer ep.Unlock()
+	return ep.loadBalancer
 }
 
 func (ep *endpoint) StaticRoutes() []*types.StaticRoute {

--- a/sandbox.go
+++ b/sandbox.go
@@ -918,7 +918,7 @@ func (sb *sandbox) clearNetworkResources(origEp *endpoint) error {
 	}
 
 	if index == -1 {
-		logrus.Errorf("Endpoint %s has already been deleted", ep.Name())
+		logrus.Warnf("Endpoint %s has already been deleted", ep.Name())
 		sb.Unlock()
 		return nil
 	}

--- a/sandbox.go
+++ b/sandbox.go
@@ -916,6 +916,13 @@ func (sb *sandbox) clearNetworkResources(origEp *endpoint) error {
 			break
 		}
 	}
+
+	if index == -1 {
+		logrus.Errorf("Endpoint %s has already been deleted", ep.Name())
+		sb.Unlock()
+		return nil
+	}
+
 	heap.Remove(&sb.endpoints, index)
 	for _, e := range sb.endpoints {
 		if len(e.Gateway()) > 0 {

--- a/service.go
+++ b/service.go
@@ -89,4 +89,5 @@ type loadBalancer struct {
 
 	// Back pointer to service to which the loadbalancer belongs.
 	service *service
+	sync.Mutex
 }

--- a/service_common.go
+++ b/service_common.go
@@ -287,7 +287,7 @@ func (c *controller) addServiceBinding(svcName, svcID, nID, eID, containerName s
 	// Add loadbalancer service and backend in all sandboxes in
 	// the network only if vip is valid.
 	if len(vip) != 0 {
-		n.(*network).addLBBackend(ip, vip, lb.fwMark, ingressPorts)
+		n.(*network).addLBBackend(ip, vip, lb, ingressPorts)
 	}
 
 	// Add the appropriate name resolutions
@@ -355,7 +355,7 @@ func (c *controller) rmServiceBinding(svcName, svcID, nID, eID, containerName st
 	// Remove loadbalancer service(if needed) and backend in all
 	// sandboxes in the network only if the vip is valid.
 	if len(vip) != 0 && entries == 0 {
-		n.(*network).rmLBBackend(ip, vip, lb.fwMark, ingressPorts, rmService)
+		n.(*network).rmLBBackend(ip, vip, lb, ingressPorts, rmService)
 	}
 
 	// Delete the name resolutions

--- a/service_linux.go
+++ b/service_linux.go
@@ -111,7 +111,7 @@ func (sb *sandbox) populateLoadbalancers(ep *endpoint) {
 
 // Add loadbalancer backend to all sandboxes which has a connection to
 // this network. If needed add the service as well.
-func (n *network) addLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*PortConfig) {
+func (n *network) addLBBackend(ip, vip net.IP, lb *loadBalancer, ingressPorts []*PortConfig) {
 	n.WalkEndpoints(func(e Endpoint) bool {
 		ep := e.(*endpoint)
 		if sb, ok := ep.getSandbox(); ok {
@@ -124,7 +124,7 @@ func (n *network) addLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*Po
 				gwIP = ep.Iface().Address().IP
 			}
 
-			sb.addLBBackend(ip, vip, fwMark, ingressPorts, ep.Iface().Address(), gwIP, n.ingress)
+			sb.addLBBackend(ip, vip, lb.fwMark, ingressPorts, ep.Iface().Address(), gwIP, n.ingress)
 		}
 
 		return false
@@ -134,7 +134,7 @@ func (n *network) addLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*Po
 // Remove loadbalancer backend from all sandboxes which has a
 // connection to this network. If needed remove the service entry as
 // well, as specified by the rmService bool.
-func (n *network) rmLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*PortConfig, rmService bool) {
+func (n *network) rmLBBackend(ip, vip net.IP, lb *loadBalancer, ingressPorts []*PortConfig, rmService bool) {
 	n.WalkEndpoints(func(e Endpoint) bool {
 		ep := e.(*endpoint)
 		if sb, ok := ep.getSandbox(); ok {
@@ -147,7 +147,7 @@ func (n *network) rmLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*Por
 				gwIP = ep.Iface().Address().IP
 			}
 
-			sb.rmLBBackend(ip, vip, fwMark, ingressPorts, ep.Iface().Address(), gwIP, rmService, n.ingress)
+			sb.rmLBBackend(ip, vip, lb.fwMark, ingressPorts, ep.Iface().Address(), gwIP, rmService, n.ingress)
 		}
 
 		return false

--- a/service_windows.go
+++ b/service_windows.go
@@ -73,6 +73,7 @@ func (n *network) addLBBackend(ip, vip net.IP, lb *loadBalancer, ingressPorts []
 		if err != nil {
 			logrus.Errorf("Failed to add ILB policy for service %s (%s) with endpoints %v using load balancer IP %s on network %s: %v",
 				lb.service.name, vip.String(), endpoints, sourceVIP, n.Name(), err)
+			return
 		}
 
 		lbPolicylistMap[lb] = &policyLists{

--- a/service_windows.go
+++ b/service_windows.go
@@ -1,11 +1,145 @@
 package libnetwork
 
-import "net"
+import (
+	"net"
 
-func (n *network) addLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*PortConfig) {
+	"github.com/Microsoft/hcsshim"
+	"github.com/docker/docker/pkg/system"
+	"github.com/sirupsen/logrus"
+)
+
+type policyLists struct {
+	ilb *hcsshim.PolicyList
+	elb *hcsshim.PolicyList
 }
 
-func (n *network) rmLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*PortConfig, rmService bool) {
+var lbPolicylistMap map[*loadBalancer]*policyLists
+
+func init() {
+	lbPolicylistMap = make(map[*loadBalancer]*policyLists)
+}
+
+func (n *network) addLBBackend(ip, vip net.IP, lb *loadBalancer, ingressPorts []*PortConfig) {
+
+	if system.GetOSVersion().Build > 16236 {
+		lb.Lock()
+		defer lb.Unlock()
+		//find the load balancer IP for the network.
+		var sourceVIP string
+		for _, e := range n.Endpoints() {
+			epInfo := e.Info()
+			if epInfo == nil {
+				continue
+			}
+			if epInfo.LoadBalancer() {
+				sourceVIP = epInfo.Iface().Address().IP.String()
+				break
+			}
+		}
+
+		if sourceVIP == "" {
+			logrus.Errorf("Failed to find load balancer IP for network %s", n.Name())
+			return
+		}
+
+		var endpoints []hcsshim.HNSEndpoint
+
+		for eid := range lb.backEnds {
+			//Call HNS to get back ID (GUID) corresponding to the endpoint.
+			hnsEndpoint, err := hcsshim.GetHNSEndpointByName(eid)
+			if err != nil {
+				logrus.Errorf("Failed to find HNS ID for endpoint %v: %v", eid, err)
+				return
+			}
+
+			endpoints = append(endpoints, *hnsEndpoint)
+		}
+
+		if policies, ok := lbPolicylistMap[lb]; ok {
+
+			if policies.ilb != nil {
+				policies.ilb.Delete()
+				policies.ilb = nil
+			}
+
+			if policies.elb != nil {
+				policies.elb.Delete()
+				policies.elb = nil
+			}
+			delete(lbPolicylistMap, lb)
+		}
+
+		ilbPolicy, err := hcsshim.AddLoadBalancer(endpoints, true, sourceVIP, vip.String(), 0, 0, 0)
+		if err != nil {
+			logrus.Errorf("Failed to add ILB policy for service %s (%s) with endpoints %v using load balancer IP %s on network %s: %v",
+				lb.service.name, vip.String(), endpoints, sourceVIP, n.Name(), err)
+		}
+
+		lbPolicylistMap[lb] = &policyLists{
+			ilb: ilbPolicy,
+		}
+
+		publishedPorts := make(map[uint32]uint32)
+
+		for i, port := range ingressPorts {
+			protocol := uint16(6)
+
+			// Skip already published port
+			if publishedPorts[port.PublishedPort] == port.TargetPort {
+				continue
+			}
+
+			if port.Protocol == ProtocolUDP {
+				protocol = 17
+			}
+
+			// check if already has udp matching to add wild card publishing
+			for j := i + 1; j < len(ingressPorts); j++ {
+				if ingressPorts[j].TargetPort == port.TargetPort &&
+					ingressPorts[j].PublishedPort == port.PublishedPort {
+					protocol = 0
+				}
+			}
+
+			publishedPorts[port.PublishedPort] = port.TargetPort
+
+			lbPolicylistMap[lb].elb, err = hcsshim.AddLoadBalancer(endpoints, false, sourceVIP, "", protocol, uint16(port.TargetPort), uint16(port.PublishedPort))
+			if err != nil {
+				logrus.Errorf("Failed to add ELB policy for service %s (ip:%s target port:%v published port:%v) with endpoints %v using load balancer IP %s on network %s: %v",
+					lb.service.name, vip.String(), uint16(port.TargetPort), uint16(port.PublishedPort), endpoints, sourceVIP, n.Name(), err)
+				return
+			}
+		}
+	}
+}
+
+func (n *network) rmLBBackend(ip, vip net.IP, lb *loadBalancer, ingressPorts []*PortConfig, rmService bool) {
+	if system.GetOSVersion().Build > 16236 {
+		if len(lb.backEnds) > 0 {
+			//Reprogram HNS (actually VFP) with the existing backends.
+			n.addLBBackend(ip, vip, lb, ingressPorts)
+		} else {
+			lb.Lock()
+			defer lb.Unlock()
+			logrus.Debugf("No more backends for service %s (ip:%s).  Removing all policies", lb.service.name, lb.vip.String())
+
+			if policyLists, ok := lbPolicylistMap[lb]; ok {
+				if policyLists.ilb != nil {
+					policyLists.ilb.Delete()
+					policyLists.ilb = nil
+				}
+
+				if policyLists.elb != nil {
+					policyLists.elb.Delete()
+					policyLists.elb = nil
+				}
+				delete(lbPolicylistMap, lb)
+
+			} else {
+				logrus.Errorf("Failed to find policies for service %s (%s)", lb.service.name, lb.vip.String())
+			}
+		}
+	}
 }
 
 func (sb *sandbox) populateLoadbalancers(ep *endpoint) {

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 github.com/Azure/go-ansiterm 19f72df4d05d31cbe1c56bfc8045c96babff6c7e
 github.com/BurntSushi/toml f706d00e3de6abe700c994cdd545a1a4915af060
 github.com/Microsoft/go-winio ce2922f643c8fd76b46cadc7f404a06282678b34
-github.com/Microsoft/hcsshim v0.6.1
+github.com/Microsoft/hcsshim v0.6.3
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/boltdb/bolt c6ba97b89e0454fec9aa92e1d33a4e2c5fc1f631

--- a/vendor/github.com/Microsoft/hcsshim/hnspolicylist.go
+++ b/vendor/github.com/Microsoft/hcsshim/hnspolicylist.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// RoutePolicy is a structure defining schema for Route based Policy
 type RoutePolicy struct {
 	Policy
 	DestinationPrefix string `json:"DestinationPrefix,omitempty"`
@@ -13,6 +14,7 @@ type RoutePolicy struct {
 	EncapEnabled      bool   `json:"NeedEncap,omitempty"`
 }
 
+// ELBPolicy is a structure defining schema for ELB LoadBalancing based Policy
 type ELBPolicy struct {
 	LBPolicy
 	SourceVIP string   `json:"SourceVIP,omitempty"`
@@ -20,6 +22,7 @@ type ELBPolicy struct {
 	ILB       bool     `json:"ILB,omitempty"`
 }
 
+// LBPolicy is a structure defining schema for LoadBalancing based Policy
 type LBPolicy struct {
 	Policy
 	Protocol     uint16 `json:"Protocol,omitempty"`
@@ -27,10 +30,11 @@ type LBPolicy struct {
 	ExternalPort uint16
 }
 
+// PolicyList is a structure defining schema for Policy list request
 type PolicyList struct {
-	Id                 string   `json:"ID,omitempty"`
-	EndpointReferences []string `json:"References,omitempty"`
-	Policies           []string `json:"Policies,omitempty"`
+	ID                 string            `json:"ID,omitempty"`
+	EndpointReferences []string          `json:"References,omitempty"`
+	Policies           []json.RawMessage `json:"Policies,omitempty"`
 }
 
 // HNSPolicyListRequest makes a call into HNS to update/query a single network
@@ -44,6 +48,7 @@ func HNSPolicyListRequest(method, path, request string) (*PolicyList, error) {
 	return &policy, nil
 }
 
+// HNSListPolicyListRequest gets all the policy list
 func HNSListPolicyListRequest() ([]PolicyList, error) {
 	var plist []PolicyList
 	err := hnsCall("GET", "/policylists/", "", &plist)
@@ -54,7 +59,7 @@ func HNSListPolicyListRequest() ([]PolicyList, error) {
 	return plist, nil
 }
 
-// PolicyListRequest makes a HNS call to modify/query a network endpoint
+// PolicyListRequest makes a HNS call to modify/query a network policy list
 func PolicyListRequest(method, path, request string) (*PolicyList, error) {
 	policylist := &PolicyList{}
 	err := hnsCall(method, "/policylists/"+path, request, &policylist)
@@ -65,11 +70,16 @@ func PolicyListRequest(method, path, request string) (*PolicyList, error) {
 	return policylist, nil
 }
 
+// GetPolicyListByID get the policy list by ID
+func GetPolicyListByID(policyListID string) (*PolicyList, error) {
+	return PolicyListRequest("GET", policyListID, "")
+}
+
 // Create PolicyList by sending PolicyListRequest to HNS.
 func (policylist *PolicyList) Create() (*PolicyList, error) {
 	operation := "Create"
 	title := "HCSShim::PolicyList::" + operation
-	logrus.Debugf(title+" id=%s", policylist.Id)
+	logrus.Debugf(title+" id=%s", policylist.ID)
 	jsonString, err := json.Marshal(policylist)
 	if err != nil {
 		return nil, err
@@ -77,20 +87,20 @@ func (policylist *PolicyList) Create() (*PolicyList, error) {
 	return PolicyListRequest("POST", "", string(jsonString))
 }
 
-// Create PolicyList by sending PolicyListRequest to HNS
+// Delete deletes PolicyList
 func (policylist *PolicyList) Delete() (*PolicyList, error) {
 	operation := "Delete"
 	title := "HCSShim::PolicyList::" + operation
-	logrus.Debugf(title+" id=%s", policylist.Id)
+	logrus.Debugf(title+" id=%s", policylist.ID)
 
-	return PolicyListRequest("DELETE", policylist.Id, "")
+	return PolicyListRequest("DELETE", policylist.ID, "")
 }
 
-// Add an endpoint to a Policy List
+// AddEndpoint add an endpoint to a Policy List
 func (policylist *PolicyList) AddEndpoint(endpoint *HNSEndpoint) (*PolicyList, error) {
 	operation := "AddEndpoint"
 	title := "HCSShim::PolicyList::" + operation
-	logrus.Debugf(title+" id=%s, endpointId:%s", policylist.Id, endpoint.Id)
+	logrus.Debugf(title+" id=%s, endpointId:%s", policylist.ID, endpoint.Id)
 
 	_, err := policylist.Delete()
 	if err != nil {
@@ -103,11 +113,11 @@ func (policylist *PolicyList) AddEndpoint(endpoint *HNSEndpoint) (*PolicyList, e
 	return policylist.Create()
 }
 
-// Remove an endpoint from the Policy List
+// RemoveEndpoint removes an endpoint from the Policy List
 func (policylist *PolicyList) RemoveEndpoint(endpoint *HNSEndpoint) (*PolicyList, error) {
 	operation := "RemoveEndpoint"
 	title := "HCSShim::PolicyList::" + operation
-	logrus.Debugf(title+" id=%s, endpointId:%s", policylist.Id, endpoint.Id)
+	logrus.Debugf(title+" id=%s, endpointId:%s", policylist.ID, endpoint.Id)
 
 	_, err := policylist.Delete()
 	if err != nil {
@@ -129,16 +139,20 @@ func (policylist *PolicyList) RemoveEndpoint(endpoint *HNSEndpoint) (*PolicyList
 }
 
 // AddLoadBalancer policy list for the specified endpoints
-func AddLoadBalancer(endpoints []HNSEndpoint, isILB bool, vip string, protocol uint16, internalPort uint16, externalPort uint16) (*PolicyList, error) {
+func AddLoadBalancer(endpoints []HNSEndpoint, isILB bool, sourceVIP, vip string, protocol uint16, internalPort uint16, externalPort uint16) (*PolicyList, error) {
 	operation := "AddLoadBalancer"
 	title := "HCSShim::PolicyList::" + operation
-	logrus.Debugf(title+" Vip:%s", vip)
+	logrus.Debugf(title+" endpointId=%v, isILB=%v, sourceVIP=%s, vip=%s, protocol=%v, internalPort=%v, externalPort=%v", endpoints, isILB, sourceVIP, vip, protocol, internalPort, externalPort)
 
 	policylist := &PolicyList{}
 
 	elbPolicy := &ELBPolicy{
-		VIPs: []string{vip},
-		ILB:  isILB,
+		SourceVIP: sourceVIP,
+		ILB:       isILB,
+	}
+
+	if len(vip) > 0 {
+		elbPolicy.VIPs = []string{vip}
 	}
 	elbPolicy.Type = ExternalLoadBalancer
 	elbPolicy.Protocol = protocol
@@ -153,12 +167,11 @@ func AddLoadBalancer(endpoints []HNSEndpoint, isILB bool, vip string, protocol u
 	if err != nil {
 		return nil, err
 	}
-
-	policylist.Policies[0] = string(jsonString)
+	policylist.Policies = append(policylist.Policies, jsonString)
 	return policylist.Create()
 }
 
-// AddLoadBalancer policy list for the specified endpoints
+// AddRoute adds route policy list for the specified endpoints
 func AddRoute(endpoints []HNSEndpoint, destinationPrefix string, nextHop string, encapEnabled bool) (*PolicyList, error) {
 	operation := "AddRoute"
 	title := "HCSShim::PolicyList::" + operation
@@ -182,6 +195,6 @@ func AddRoute(endpoints []HNSEndpoint, destinationPrefix string, nextHop string,
 		return nil, err
 	}
 
-	policylist.Policies[0] = string(jsonString)
+	policylist.Policies = append(policylist.Policies, jsonString)
 	return policylist.Create()
 }

--- a/vendor/github.com/Microsoft/hcsshim/interface.go
+++ b/vendor/github.com/Microsoft/hcsshim/interface.go
@@ -48,6 +48,8 @@ type HvRuntime struct {
 	LinuxInitrdFile     string `json:",omitempty"` // File under ImagePath on host containing an initrd image for starting a Linux utility VM
 	LinuxKernelFile     string `json:",omitempty"` // File under ImagePath on host containing a kernel for starting a Linux utility VM
 	LinuxBootParameters string `json:",omitempty"` // Additional boot parameters for starting a Linux Utility VM in initrd mode
+	BootSource          string `json:",omitempty"` // "Vhd" for Linux Utility VM booting from VHD
+	WritableBootSource  bool   `json:",omitempty"` // Linux Utility VM booting from VHD
 }
 
 type MappedVirtualDisk struct {

--- a/vendor/github.com/Microsoft/hcsshim/legacy.go
+++ b/vendor/github.com/Microsoft/hcsshim/legacy.go
@@ -307,6 +307,16 @@ func (r *legacyLayerReader) Read(b []byte) (int, error) {
 	return r.backupReader.Read(b)
 }
 
+func (r *legacyLayerReader) Seek(offset int64, whence int) (int64, error) {
+	if r.backupReader == nil {
+		if r.currentFile == nil {
+			return 0, errors.New("no current file")
+		}
+		return r.currentFile.Seek(offset, whence)
+	}
+	return 0, errors.New("seek not supported on this stream")
+}
+
 func (r *legacyLayerReader) Close() error {
 	r.proceed <- false
 	<-r.result


### PR DESCRIPTION
 This is 1 of 3 PRs (the other 2 are in swarmkit and moby repos).

This change enables ILB/ELB functionality on windows using a per-node, per-network LB endpoint.  The per-node, per-network LB endpoint was discussed with docker 
 as a solution to https://github.com/moby/moby/issues/30820.  Note that only windows is using the LB endpoint.  We have not changed the linux networking code to take advantage of the LB endpoint.

Signed-off-by: Pradip Dhara <pradipd@microsoft.com>