### PR TITLE
Support flush API for IPVS service

### DIFF
--- a/ipvs/ipvs.go
+++ b/ipvs/ipvs.go
@@ -116,6 +116,13 @@ func (i *Handle) DelService(s *Service) error {
 	return i.doCmd(s, nil, ipvsCmdDelService)
 }
 
+// Flush deletes all existing services in the passed
+// handle.
+func (i *Handle) Flush() error {
+	_, err := i.doCmdWithoutAttr(ipvsCmdFlush)
+	return err
+}
+
 // NewDestination creates a new real server in the passed ipvs
 // service which should already be existing in the passed handle.
 func (i *Handle) NewDestination(s *Service, d *Destination) error {

--- a/ipvs/ipvs_test.go
+++ b/ipvs/ipvs_test.go
@@ -178,6 +178,41 @@ func TestService(t *testing.T) {
 		}
 	}
 
+	svcs := []Service{
+		{
+			AddressFamily: nl.FAMILY_V4,
+			SchedName:     RoundRobin,
+			Protocol:      syscall.IPPROTO_TCP,
+			Port:          80,
+			Address:       net.ParseIP("10.20.30.40"),
+			Netmask:       0xFFFFFFFF,
+		},
+		{
+			AddressFamily: nl.FAMILY_V4,
+			SchedName:     LeastConnection,
+			Protocol:      syscall.IPPROTO_UDP,
+			Port:          8080,
+			Address:       net.ParseIP("10.20.30.41"),
+			Netmask:       0xFFFFFFFF,
+		},
+	}
+	// Create services for testing flush
+	for _, svc := range svcs {
+		if !i.IsServicePresent(&svc) {
+			err = i.NewService(&svc)
+			assert.NoError(t, err)
+			checkService(t, i, &svc, true)
+		} else {
+			t.Errorf("svc: %v exists", svc)
+		}
+	}
+	err = i.Flush()
+	assert.NoError(t, err)
+	got, err := i.GetServices()
+	assert.NoError(t, err)
+	if len(got) != 0 {
+		t.Errorf("Unexpected services after flush")
+	}
 }
 
 func createDummyInterface(t *testing.T) {

--- a/ipvs/netlink.go
+++ b/ipvs/netlink.go
@@ -402,6 +402,13 @@ func (i *Handle) doGetServicesCmd(svc *Service) ([]*Service, error) {
 	return res, nil
 }
 
+// doCmdWithoutAttr a simple wrapper of netlink socket execute command
+func (i *Handle) doCmdWithoutAttr(cmd uint8) ([][]byte, error) {
+	req := newIPVSRequest(cmd)
+	req.Seq = atomic.AddUint32(&i.seq, 1)
+	return execute(i.sock, req, 0)
+}
+
 func assembleDestination(attrs []syscall.NetlinkRouteAttr) (*Destination, error) {
 
 	var d Destination


### PR DESCRIPTION
We vendor libnetwork's ipvs library into kubernetes and want a batch API for flushing IPVS services.

Do we have plan to support the flush API for IPVS service?

related issue:
#1930 