### PR TITLE
Ignore failure to save hns endpoint to store

### DIFF
--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -639,7 +639,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	}
 
 	if err = d.storeUpdate(endpoint); err != nil {
-		return fmt.Errorf("failed to save endpoint %s to store: %v", endpoint.id[0:7], err)
+		logrus.Errorf("Failed to save endpoint %s to store: %v", endpoint.id[0:7], err)
 	}
 
 	return nil


### PR DESCRIPTION
Workaround for https://github.com/docker/libnetwork/issues/1950 to treat failure to save endpoint to store as non fatal. These endpoints are just required for cleanup in case of docker service crash and saving them is not really required and should not be considered fatal.