### PR TITLE
Repair watchMiss goroutine leak

### DIFF
--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -261,6 +261,8 @@ func (nDB *NetworkDB) Close() {
 	if err := nDB.clusterLeave(); err != nil {
 		logrus.Errorf("Could not close DB %s: %v", nDB.config.NodeName, err)
 	}
+
+	nDB.broadcaster.Close()
 }
 
 // ClusterPeers returns all the gossip cluster peers.


### PR DESCRIPTION
Signed-off-by: yangchenliang <yangchenliang@huawei.com>

Repair watchMiss goroutine leak.

When execute 'docker swarm init' and 'docker swarm leave -f' on a node
repeatedly, the watchMiss goroutine leak.

- What I did
Execute 'docker swarm init' and 'docker swarm leave -f' on a node
repeatedly

- How I did it
while true; do docker swarm init ; sleep 3 ; docker swarm leave -f ; done &

- How to verify it
'free -m', watch the 'available' item .  constant loss explans  the goroutine leak.

when 'docker swarm leave -f ', 'n.nlSocket.Close()'  be called in  func 'destroySandbox';
but in goroutine 'watchMiss', the func 'nlSock.Receive()' would not return, so goroutine leak;

- Description for the changelog

- A picture of a cute animal (not mandatory but encouraged)

