### PR TITLE
 Repair (*Broadcaster).run goroutine leak 

### DIFF
--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -261,6 +261,9 @@ func (nDB *NetworkDB) Close() {
 	if err := nDB.clusterLeave(); err != nil {
 		logrus.Errorf("Could not close DB %s: %v", nDB.config.NodeName, err)
 	}
+
+	//Avoid (*Broadcaster).run goroutine leak
+	nDB.broadcaster.Close()
 }
 
 // ClusterPeers returns all the gossip cluster peers.


### PR DESCRIPTION
 Repair (*Broadcaster).run goroutine leak 

When execute 'docker swarm init' and 'docker swarm leave -f' on a node
 repeatedly, the (*Broadcaster).run goroutine leak.

•What I did
 Execute 'docker swarm init' and 'docker swarm leave -f' on a node
 repeatedly

•How I did it
 while true; do docker swarm init ; sleep 3 ; docker swarm leave -f ; done &

•How to verify it
 'free -m', watch the 'available' item . constant loss explans the goroutine leak.

