### PR TITLE
Allow containers access published ports when userland-proxy has been disabled

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -258,7 +258,6 @@ func (c *ChainInfo) Forward(action Action, ip net.IP, port int, proto, destAddr 
 	}
 
 	args = []string{
-		"!", "-i", bridgeName,
 		"-o", bridgeName,
 		"-p", proto,
 		"-d", destAddr,

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -67,7 +67,6 @@ func TestForward(t *testing.T) {
 	}
 
 	filterRule := []string{
-		"!", "-i", bridgeName,
 		"-o", bridgeName,
 		"-d", dstAddr,
 		"-p", proto,


### PR DESCRIPTION
# Containers Should Be Able To Access Published Ports When `userland-proxy` Has Been Disabled

## Background

I'm trying to setup a Portus service for docker images, and I found to setup notifications of webhook events of Docker Registry (Distribution) or crono task for Portus requires containers have ability to access published ports, say, access `https://docker-registry.vizv.com/`.

And currently containers scheduled from `docker stack deploy` cannot access those published ports. So I managed to fix this issue by myself.

I'm not an expert of iptables, and I learned it from almost the beginning in order to fix this issue, so please feel free to correct me if I was wrong.

## Environment

Output of `docker version`:

```
Client:
 Version:      17.09.0-ce
 API version:  1.32
 Go version:   go1.8.3
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:41:23 2017
 OS/Arch:      linux/amd64

Server:
 Version:      17.09.0-ce
 API version:  1.32 (minimum version 1.12)
 Go version:   go1.8.3
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:42:49 2017
 OS/Arch:      linux/amd64
 Experimental: false
```

Output of `docker info`:

```
Containers: 6
 Running: 3
 Paused: 0
 Stopped: 3
Images: 4
Server Version: 17.09.0-ce
Storage Driver: devicemapper
 Pool Name: docker-thinpool
 Pool Blocksize: 524.3kB
 Base Device Size: 10.74GB
 Backing Filesystem: xfs
 Data file:
 Metadata file:
 Data Space Used: 300.9MB
 Data Space Total: 13.25GB
 Data Space Available: 12.95GB
 Metadata Space Used: 159.7kB
 Metadata Space Total: 138.4MB
 Metadata Space Available: 138.3MB
 Thin Pool Minimum Free Space: 1.325GB
 Udev Sync Supported: true
 Deferred Removal Enabled: true
 Deferred Deletion Enabled: true
 Deferred Deleted Device Count: 0
 Library Version: 1.02.140-RHEL7 (2017-05-03)
Logging Driver: json-file
Cgroup Driver: cgroupfs
Plugins:
 Volume: local
 Network: bridge host macvlan null overlay
 Log: awslogs fluentd gcplogs gelf journald json-file logentries splunk syslog
Swarm: active
 NodeID: g5wgui6caq9kve1vlnxumxyt0
 Is Manager: false
 Node Address: 198.98.62.145
 Manager Addresses:
  209.141.62.180:2377
Runtimes: runc
Default Runtime: runc
Init Binary: docker-init
containerd version: 06b9cb35161009dcb7123345749fef02f7cea8e0
runc version: 3f2f8b84a77f73d38244dd690525642a72156c64
init version: 949e6fa
Security Options:
 seccomp
  Profile: default
 selinux
Kernel Version: 3.10.0-693.2.2.el7.x86_64
Operating System: CentOS Linux 7 (Core)
OSType: linux
Architecture: x86_64
CPUs: 1
Total Memory: 992.4MiB
Name: beloved-rose.vizv.com
ID: 7RBS:EVHW:CNPA:NVIV:4M6Y:DIER:YU3N:CKTX:Q35L:XMVA:V66Y:4IOG
Docker Root Dir: /var/lib/docker
Debug Mode (client): false
Debug Mode (server): false
Registry: https://index.docker.io/v1/
Experimental: false
Insecure Registries:
 127.0.0.0/8
Live Restore Enabled: false
```

## The Issue

The main idea is **containers should be able to access published ports as if they are other hosts on the Internet**.

Many people found they are unable to access published ports from containers, such as moby/moby#24370, moby/moby#29330, moby/moby#30750, moby/moby#32138. And some service stacks such as Portus, GitLab Runner, Email infrastructure, and Docker Registry requires to access published ports of other containers.

However some issues are not able to reproduce anymore (I assume this is because `--link` is going to be deprecated, and containers in the same subnet are able to directly talk to each other with rule
`-A FORWARD -i docker0 -o docker0 -j ACCEPT` in the `filter:FORWARD` chain).

For example, run `docker run --rm -it -p 8080:80 nginx:stable-alpine` and `docker run --rm -it alpine wget -O- br.vizv.com:8080` will work.

However, after I setup a trace in iptables, I found the second container can access first container not because port 8080 is published, but because they are both connected to docker0.

Here is the trace (firewalld stuff, `DOCKER-USER`, and `DOCKER-ISOLATION` are skipped since they have no match / effect; but `DOCKER` was shown).

```
...

# In nat:PREROUTING
# Apply rule -A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
Oct  2 17:45:21 beloved-rose kernel: TRACE: nat:PREROUTING:rule:4 IN=docker0 OUT= PHYSIN=veth255345e MAC=02:42:97:6a:ee:48:02:42:ac:11:00:03:08:00 SRC=172.17.0.3 DST=198.98.62.145 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=7958 DF PROTO=TCP SPT=36578 DPT=8080 SEQ=1797023696 ACK=0 WINDOW=29200 RES=0x00 SYN URGP=0 OPT (020405B40402080A186178C60000000001030307)
# Jump to nat:DOCKER

# In nat:DOCKER
# Apply rule -A DOCKER -p tcp -m tcp --dport 8080 -j DNAT --to-destination 172.17.0.2:80
Oct  2 17:45:21 beloved-rose kernel: TRACE: nat:DOCKER:rule:5 IN=docker0 OUT= PHYSIN=veth255345e MAC=02:42:97:6a:ee:48:02:42:ac:11:00:03:08:00 SRC=172.17.0.3 DST=198.98.62.145 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=7958 DF PROTO=TCP SPT=36578 DPT=8080 SEQ=1797023696 ACK=0 WINDOW=29200 RES=0x00 SYN URGP=0 OPT (020405B40402080A186178C60000000001030307)
# Alter destination to 172.17.0.2:80

# Routeing decision: destination is not local (172.17.0.2), use FORWARD chains

...

# In filter:FORWARD
# Apply rule -A FORWARD -o docker0 -j DOCKER
Oct  2 17:45:21 beloved-rose kernel: TRACE: filter:FORWARD:rule:3 IN=docker0 OUT=docker0 PHYSIN=veth255345e PHYSOUT=vetha7b0a6a MAC=02:42:ac:11:00:02:02:42:ac:11:00:03:08:00 SRC=172.17.0.3 DST=172.17.0.2 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=7958 DF PROTO=TCP SPT=36578 DPT=80 SEQ=1797023696 ACK=0 WINDOW=29200 RES=0x00 SYN URGP=0 OPT (020405B40402080A186178C60000000001030307)
# Jump to filter:DOCKER

# In filter:DOCKER
Oct  2 17:45:21 beloved-rose kernel: TRACE: filter:DOCKER:return:6 IN=docker0 OUT=docker0 PHYSIN=veth255345e PHYSOUT=vetha7b0a6a MAC=02:42:ac:11:00:02:02:42:ac:11:00:03:08:00 SRC=172.17.0.3 DST=172.17.0.2 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=7958 DF PROTO=TCP SPT=36578 DPT=80 SEQ=1797023696 ACK=0 WINDOW=29200 RES=0x00 SYN URGP=0 OPT (020405B40402080A186178C60000000001030307)
# No match, return to filter:FORWARD

# Apply rule -A FORWARD -i docker0 -o docker0 -j ACCEPT
Oct  2 17:45:21 beloved-rose kernel: TRACE: filter:FORWARD:rule:5 IN=docker0 OUT=docker0 PHYSIN=veth255345e PHYSOUT=vetha7b0a6a MAC=02:42:ac:11:00:02:02:42:ac:11:00:03:08:00 SRC=172.17.0.3 DST=172.17.0.2 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=7958 DF PROTO=TCP SPT=36578 DPT=80 SEQ=1797023696 ACK=0 WINDOW=29200 RES=0x00 SYN URGP=0 OPT (020405B40402080A186178C60000000001030307)
# Accepted

...
```

Moreover, current implementation won't work with docker swarm mode with `docker stack deploy`.
To reproduce this, **disable `userland-proxy` first**, then use the following compose file.

```
version: '3.3'

services:
  nginx:
    image: nginx:stable-alpine
    ports:
      - target:     80
        published:  8080
        protocol:   tcp
        mode:       host
```

When you curl `br.vizv.com:8080` from outside of containers, you are able to get the content. However you are not able to curl from the container itself.

So I deploy this service stack file with command: `docker stack deploy -c nginx.yml test_nginx`, and exec wget inside the newly created container with `docker exec 81bfbf703afb wget -O- br.vizv.com:8080`, and I got:

```
Connecting to br.vizv.com:8080 (198.98.62.145:8080)
wget: can't connect to remote host (198.98.62.145): Host is unreachable
```

Similarly, I did the trace on iptables:

```
...
# In nat:PREROUTING
# Apply rule -A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
Oct  2 20:30:37 beloved-rose kernel: TRACE: nat:PREROUTING:rule:4 IN=docker_gwbridge OUT= PHYSIN=vethdb359d0 MAC=02:42:bf:d0:d9:23:02:42:ac:12:00:05:08:00 SRC=172.18.0.5 DST=198.98.62.145 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=9477 DF PROTO=TCP SPT=34512 DPT=8080 SEQ=862052502 ACK=0 WINDOW=29200 RES=0x00 SYN URGP=0 OPT (020405B40402080A18F8C5930000000001030307)
# Jump to nat:DOCKER

# In nat:DOCKER
# Apply rule -A DOCKER -p tcp -m tcp --dport 8080 -j DNAT --to-destination 172.18.0.5:80
Oct  2 20:30:37 beloved-rose kernel: TRACE: nat:DOCKER:rule:5 IN=docker_gwbridge OUT= PHYSIN=vethdb359d0 MAC=02:42:bf:d0:d9:23:02:42:ac:12:00:05:08:00 SRC=172.18.0.5 DST=198.98.62.145 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=9477 DF PROTO=TCP SPT=34512 DPT=8080 SEQ=862052502 ACK=0 WINDOW=29200 RES=0x00 SYN URGP=0 OPT (020405B40402080A18F8C5930000000001030307)
# Alter destination to 172.17.0.2:80

# Routeing decision: destination is not local (172.17.0.2), use FORWARD chains

...

# In filter:FORWARD
# Apply rule -A FORWARD -o docker_gwbridge -j DOCKER
Oct  2 20:30:37 beloved-rose kernel: TRACE: filter:FORWARD:rule:8 IN=docker_gwbridge OUT=docker_gwbridge PHYSIN=vethdb359d0 PHYSOUT=vethdb359d0 MAC=02:42:ac:12:00:05:02:42:ac:12:00:05:08:00 SRC=172.18.0.5 DST=172.18.0.5 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=9477 DF PROTO=TCP SPT=34512 DPT=80 SEQ=862052502 ACK=0 WINDOW=29200 RES=0x00 SYN URGP=0 OPT (020405B40402080A18F8C5930000000001030307)
# Jump to filter:DOCKER

# In filter:DOCKER
Oct  2 20:30:37 beloved-rose kernel: TRACE: filter:DOCKER:return:6 IN=docker_gwbridge OUT=docker_gwbridge PHYSIN=vethdb359d0 PHYSOUT=vethdb359d0 MAC=02:42:ac:12:00:05:02:42:ac:12:00:05:08:00 SRC=172.18.0.5 DST=172.18.0.5 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=9477 DF PROTO=TCP SPT=34512 DPT=80 SEQ=862052502 ACK=0 WINDOW=29200 RES=0x00 SYN URGP=0 OPT (020405B40402080A18F8C5930000000001030307)
# No match, return to filter:FORWARD

# Apply rule -A FORWARD -j REJECT --reject-with icmp-host-prohibited
Oct  2 20:30:37 beloved-rose kernel: TRACE: filter:FORWARD:rule:18 IN=docker_gwbridge OUT=docker_gwbridge PHYSIN=vethdb359d0 PHYSOUT=vethdb359d0 MAC=02:42:ac:12:00:05:02:42:ac:12:00:05:08:00 SRC=172.18.0.5 DST=172.18.0.5 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=9477 DF PROTO=TCP SPT=34512 DPT=80 SEQ=862052502 ACK=0 WINDOW=29200 RES=0x00 SYN URGP=0 OPT (020405B40402080A18F8C5930000000001030307)
# Rejected

...
```

As you can see, neither of those two cases uses the following rules in the `filter:DOCKER` chains:

```
-A DOCKER -d 172.17.0.2/32 ! -i docker0 -o docker0 -p tcp -m tcp --dport 80 -j ACCEPT
and
-A DOCKER -d 172.18.0.5/32 ! -i docker_gwbridge -o docker_gwbridge -p tcp -m tcp --dport 80 -j ACCEPT
```

This is because after DNAT, `--in-interface` and `--out-interface` are the same and these packets do not match those rules.

I assume this is some implementation of isolation (?) or just a mistake?
Because I see no reason publish those ports to public and prevent containers from accessing those ports.

And I track down to the source code here: 

https://github.com/docker/libnetwork/blob/9e5748ad7dc65318889693365a53492be94b1521/iptables/iptables.go#L260-L267

This was introduced [two years ago](https://github.com/docker/libnetwork/commit/44c96449c2aafbb22487086ad94ff865f9ee855a#diff-ba8c3ab87579147ddeff26dd29c70f44R163).

## Fix Proposal

So I propose to fix it with my PR by remove `! -i <the interface>` so that anyone can access these public published ports. I have tested this fix by creating a RPM package and running on another host, and the problems are gone.

Signed-off-by: Wenxuan Zhao <viz@linux.com>