### PR TITLE
Bump Go to 1.8.4

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.8.3
+FROM golang:1.8.4
 RUN apt-get update && apt-get -y install iptables
 
 RUN go get github.com/tools/godep \


### PR DESCRIPTION
Bumps the Go version used to 1.8.4, which contains security fixes;
https://groups.google.com/forum/#!topic/golang-announce/1hZYiemnkdE

Build of the Dockerfile was currently failing for me because https://honnef.co/ is currently down (https://github.com/dominikh/go-tools/issues/197)