### PR TITLE
Disable hostname lookup on chain exists check

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -456,7 +456,7 @@ func RawCombinedOutputNative(args ...string) error {
 
 // ExistChain checks if a chain exists
 func ExistChain(chain string, table Table) bool {
-	if _, err := Raw("-t", string(table), "-L", chain); err == nil {
+	if _, err := Raw("-t", string(table), "-nL", chain); err == nil {
 		return true
 	}
 	return false


### PR DESCRIPTION
Without `-n`, iptables will attempt to lookup hostnames for IP
addresses, which can slow down the call dramatically.
Since we don't need this, and generally don't even care about the
output, use the `-n` flag to disable this.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>