### PR TITLE
Remove extra unused fields

### DIFF
--- a/drivers/overlay/joinleave.go
+++ b/drivers/overlay/joinleave.go
@@ -38,7 +38,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		return fmt.Errorf("cannot join secure network: required modules to install IPSEC rules are missing on host")
 	}
 
-	s := n.getSubnetforIP(ep.addr)
+	s := n.getSubnetforIP(ep.addr.IP)
 	if s == nil {
 		return fmt.Errorf("could not find subnet for endpoint %s", eid)
 	}
@@ -120,7 +120,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		}
 	}
 
-	d.peerAdd(nid, eid, ep.addr.IP, ep.addr.Mask, ep.mac, net.ParseIP(d.advertiseAddress), false, false, true)
+	d.peerAdd(nid, eid, ep.addr.IP, ep.mac, net.ParseIP(d.advertiseAddress), false, false, true)
 
 	if err = d.checkEncryption(nid, nil, n.vxlanID(s), true, true); err != nil {
 		logrus.Warn(err)
@@ -200,11 +200,11 @@ func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key stri
 	}
 
 	if etype == driverapi.Delete {
-		d.peerDelete(nid, eid, addr.IP, addr.Mask, mac, vtep, false)
+		d.peerDelete(nid, eid, addr.IP, mac, vtep, false)
 		return
 	}
 
-	d.peerAdd(nid, eid, addr.IP, addr.Mask, mac, vtep, false, false, false)
+	d.peerAdd(nid, eid, addr.IP, mac, vtep, false, false, false)
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.
@@ -232,7 +232,7 @@ func (d *driver) Leave(nid, eid string) error {
 		}
 	}
 
-	d.peerDelete(nid, eid, ep.addr.IP, ep.addr.Mask, ep.mac, net.ParseIP(d.advertiseAddress), true)
+	d.peerDelete(nid, eid, ep.addr.IP, ep.mac, net.ParseIP(d.advertiseAddress), true)
 
 	n.leaveSandbox()
 

--- a/drivers/overlay/ov_endpoint.go
+++ b/drivers/overlay/ov_endpoint.go
@@ -76,7 +76,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 		return fmt.Errorf("create endpoint was not passed interface IP address")
 	}
 
-	if s := n.getSubnetforIP(ep.addr); s == nil {
+	if s := n.getSubnetforIP(ep.addr.IP); s == nil {
 		return fmt.Errorf("no matching subnet for IP %q in network %q", ep.addr, nid)
 	}
 

--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -763,13 +763,13 @@ func (n *network) watchMiss(nlSock *nl.NetlinkSocket) {
 
 			if n.driver.isSerfAlive() {
 				logrus.Debugf("miss notification: dest IP %v, dest MAC %v", ip, mac)
-				mac, IPmask, vtep, err := n.driver.resolvePeer(n.id, ip)
+				mac, _, vtep, err := n.driver.resolvePeer(n.id, ip)
 				if err != nil {
 					logrus.Errorf("could not resolve peer %q: %v", ip, err)
 					continue
 				}
-				n.driver.peerAdd(n.id, "dummy", ip, IPmask, mac, vtep, l2Miss, l3Miss, false)
-			} else if l3Miss && time.Since(t) > time.Second {
+				n.driver.peerAdd(n.id, "dummy", ip, mac, vtep, l2Miss, l3Miss, false)
+			} else if l3Miss && time.Since(t) >= time.Second {
 				// All the local peers will trigger a miss notification but this one is expected and the local container will reply
 				// autonomously to the ARP request
 				// In case the gc_thresh3 values is low kernel might reject new entries during peerAdd. This will trigger the following
@@ -1068,15 +1068,9 @@ func (n *network) contains(ip net.IP) bool {
 }
 
 // getSubnetforIP returns the subnet to which the given IP belongs
-func (n *network) getSubnetforIP(ip *net.IPNet) *subnet {
+func (n *network) getSubnetforIP(ip net.IP) *subnet {
 	for _, s := range n.subnets {
-		// first check if the mask lengths are the same
-		i, _ := s.subnetIP.Mask.Size()
-		j, _ := ip.Mask.Size()
-		if i != j {
-			continue
-		}
-		if s.subnetIP.Contains(ip.IP) {
+		if s.subnetIP.Contains(ip) {
 			return s
 		}
 	}

--- a/drivers/overlay/ov_serf.go
+++ b/drivers/overlay/ov_serf.go
@@ -120,9 +120,9 @@ func (d *driver) processEvent(u serf.UserEvent) {
 
 	switch action {
 	case "join":
-		d.peerAdd(nid, eid, net.ParseIP(ipStr), net.IPMask(net.ParseIP(maskStr).To4()), mac, net.ParseIP(vtepStr), false, false, false)
+		d.peerAdd(nid, eid, net.ParseIP(ipStr), mac, net.ParseIP(vtepStr), false, false, false)
 	case "leave":
-		d.peerDelete(nid, eid, net.ParseIP(ipStr), net.IPMask(net.ParseIP(maskStr).To4()), mac, net.ParseIP(vtepStr), false)
+		d.peerDelete(nid, eid, net.ParseIP(ipStr), mac, net.ParseIP(vtepStr), false)
 	}
 }
 
@@ -140,8 +140,8 @@ func (d *driver) processQuery(q *serf.Query) {
 		return
 	}
 
-	logrus.Debugf("Sending peer query resp mac %v, mask %s, vtep %s", pKey.peerMac, net.IP(pEntry.peerIPMask).String(), pEntry.vtep)
-	q.Respond([]byte(fmt.Sprintf("%s %s %s", pKey.peerMac.String(), net.IP(pEntry.peerIPMask).String(), pEntry.vtep.String())))
+	logrus.Debugf("Sending peer query resp mac %v, vtep %s", pKey.peerMac, pEntry.vtep)
+	q.Respond([]byte(fmt.Sprintf("%s %s", pKey.peerMac.String(), pEntry.vtep.String())))
 }
 
 func (d *driver) resolvePeer(nid string, peerIP net.IP) (net.HardwareAddr, net.IPMask, net.IP, error) {

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -146,7 +146,7 @@ func (d *driver) restoreEndpoints() error {
 		}
 		n.addEndpoint(ep)
 
-		s := n.getSubnetforIP(ep.addr)
+		s := n.getSubnetforIP(ep.addr.IP)
 		if s == nil {
 			return fmt.Errorf("could not find subnet for endpoint %s", ep.id)
 		}
@@ -170,7 +170,7 @@ func (d *driver) restoreEndpoints() error {
 		}
 
 		n.incEndpointCount()
-		d.peerAdd(ep.nid, ep.id, ep.addr.IP, ep.addr.Mask, ep.mac, net.ParseIP(d.advertiseAddress), false, false, true)
+		d.peerAdd(ep.nid, ep.id, ep.addr.IP, ep.mac, net.ParseIP(d.advertiseAddress), false, false, true)
 	}
 	return nil
 }

--- a/drivers/overlay/peerdb_test.go
+++ b/drivers/overlay/peerdb_test.go
@@ -10,9 +10,8 @@ import (
 func TestPeerMarshal(t *testing.T) {
 	_, ipNet, _ := net.ParseCIDR("192.168.0.1/24")
 	p := &peerEntry{eid: "eid",
-		isLocal:    true,
-		peerIPMask: ipNet.Mask,
-		vtep:       ipNet.IP}
+		isLocal: true,
+		vtep:    ipNet.IP}
 	entryDB := p.MarshalDB()
 	x := entryDB.UnMarshalDB()
 	if x.eid != p.eid {
@@ -20,9 +19,6 @@ func TestPeerMarshal(t *testing.T) {
 	}
 	if x.isLocal != p.isLocal {
 		t.Fatalf("Incorrect Unmarshalling for isLocal: %v != %v", x.isLocal, p.isLocal)
-	}
-	if x.peerIPMask.String() != p.peerIPMask.String() {
-		t.Fatalf("Incorrect Unmarshalling for eid: %v != %v", x.peerIPMask, p.peerIPMask)
 	}
 	if x.vtep.String() != p.vtep.String() {
 		t.Fatalf("Incorrect Unmarshalling for eid: %v != %v", x.vtep, p.vtep)

--- a/osl/sandbox.go
+++ b/osl/sandbox.go
@@ -48,7 +48,7 @@ type Sandbox interface {
 	AddNeighbor(dstIP net.IP, dstMac net.HardwareAddr, force bool, option ...NeighOption) error
 
 	// DeleteNeighbor deletes neighbor entry from the sandbox.
-	DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr, osDelete bool) error
+	DeleteNeighbor(dstIP net.IP, dstMac net.HardwareAddr) error
 
 	// Returns an interface with methods to set neighbor options.
 	NeighborOptions() NeighborOptionSetter


### PR DESCRIPTION
DeleteNeighbor does not need the extra boolean for the cleanup of the OS

The mask of the peer was not really used, also the assumption is that networks
are never overlapping

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>