### PR TITLE
Explicitly pass the sha to codecov

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,4 +13,4 @@ test:
   override:
     - make circle-ci
   post:
-    - bash <(curl -s https://codecov.io/bash)
+    - bash <(curl -s https://codecov.io/bash) -C "$(git log --format="%H" -n 1)"


### PR DESCRIPTION
In case of merge commit, the sha passed to the codecov tool
is the one of the merged commit intstead of the merge commit
this creates error because the base commit is always different.
Passing it explicitely should fix it

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>