### PR TITLE
Simplifying 'possible transient state' log messages

### DIFF
--- a/service_common.go
+++ b/service_common.go
@@ -280,8 +280,7 @@ func (c *controller) addServiceBinding(svcName, svcID, nID, eID, containerName s
 
 	ok, entries := s.assignIPToEndpoint(ip.String(), eID)
 	if !ok || entries > 1 {
-		setStr, b := s.printIPToEndpoint(ip.String())
-		logrus.Warnf("addServiceBinding %s possible trainsient state ok:%t entries:%d set:%t %s", eID, ok, entries, b, setStr)
+		logrus.Warnf("addServiceBinding %s possible transient state ok:%t entries:%d", eID, ok, entries)
 	}
 
 	// Add loadbalancer service and backend in all sandboxes in
@@ -348,8 +347,7 @@ func (c *controller) rmServiceBinding(svcName, svcID, nID, eID, containerName st
 
 	ok, entries := s.removeIPToEndpoint(ip.String(), eID)
 	if !ok || entries > 0 {
-		setStr, b := s.printIPToEndpoint(ip.String())
-		logrus.Warnf("rmServiceBinding %s possible trainsient state ok:%t entries:%d set:%t %s", eID, ok, entries, b, setStr)
+		logrus.Warnf("rmServiceBinding %s possible transient state ok:%t entries:%d", eID, ok, entries)
 	}
 
 	// Remove loadbalancer service(if needed) and backend in all


### PR DESCRIPTION
Fixes #1983 - see that issue for context.

When the number of entries in the endpoint set is large, the `setStr`
value will cause these log messages to be particularly long. In my
scenario I had ~1500-2000 entries, which were causing 100kB+ messages to
be logged.

This removes `setStr` from the message, as well as `b`, so that I can
also remove the call to `s.printIPToEndpoint`. I'm not sure how valuable
it is to know that the set is present, since we already know (from the
`ok` variable) that the mapping is present.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>