### PR TITLE
[17.06] Disable hostname lookup on chain exists check

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -456,7 +456,7 @@ func RawCombinedOutputNative(args ...string) error {
 
 // ExistChain checks if a chain exists
 func ExistChain(chain string, table Table) bool {
-	if _, err := Raw("-t", string(table), "-L", chain); err == nil {
+	if _, err := Raw("-t", string(table), "-nL", chain); err == nil {
 		return true
 	}
 	return false


### PR DESCRIPTION
Backport of fix:
* https://github.com/docker/libnetwork/pull/1974 Disable hostname lookup on chain exists check

With cherry-pick of commit 8dce207:
```
$ git cherry-pick -s -x 8dce207
```

No conflicts.