### PR TITLE
[release/v0.9] Disable hostname lookup on chain exists check

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -423,7 +423,7 @@ func RawCombinedOutputNative(args ...string) error {
 
 // ExistChain checks if a chain exists
 func ExistChain(chain string, table Table) bool {
-	if _, err := Raw("-t", string(table), "-L", chain); err == nil {
+	if _, err := Raw("-t", string(table), "-nL", chain); err == nil {
 		return true
 	}
 	return false


### PR DESCRIPTION
backport fix:
* #1974 Disable hostname lookup on chain exists check

with cherry-pick git commit 8dce207
```
$ git cherry-pick -s -x 8dce207
```

cherry-pick when it clean