### PR TITLE
wait for iptables lock in support script

### DIFF
--- a/support.sh
+++ b/support.sh
@@ -22,8 +22,8 @@ type -P ${BRCTL} > /dev/null || die "This tool requires brctl"
 type -P ${IPTABLES} > /dev/null || die "This tool requires iptables"
 
 echo "iptables configuration"
-${IPTABLES} -n -v -L -t filter
-${IPTABLES} -n -v -L -t nat
+${IPTABLES} -w1 -n -v -L -t filter
+${IPTABLES} -w1 -n -v -L -t nat
 echo ""
 
 echo "Overlay network configuration"


### PR DESCRIPTION
Addresses failure to collect iptables information if lock is held during
data capture. Follows the reccomendation of iptables stderr in this
scenario:

```
Another app is currently holding the xtables lock. Perhaps you want to
use the -w option?
```

Signed-off-by: Trapier Marshall <trapier.marshall@docker.com>