### PR TITLE
endpoint_cnt store updates should not create an object

### DIFF
--- a/store.go
+++ b/store.go
@@ -256,6 +256,7 @@ retry:
 			if err := cs.GetObject(datastore.Key(kvObject.Key()...), kvObject); err != nil {
 				return fmt.Errorf("could not update the kvobject to latest when trying to delete: %v", err)
 			}
+			logrus.Errorf("Error (%v) deleting object %v, retrying....", err, kvObject.Key())
 			goto retry
 		}
 		return err


### PR DESCRIPTION
endpoint_cnt object is created during network create and destroyed when
network is deleted. But the updateToStore function creates an object
when it is not present in the store. endpoint_cnt is a mutable object
and is updated during endpoint create and delete events. If endpoint
create or delete happens after the network is deleted, it can
incorrectly create an endpoint_cnt object in the store and that can
cause problems when the same network is created again later.

The fix is to not create the endpoint_cnt object when endpoint_cnt is
incremented or decremented

This handles the error seen in https://github.com/moby/moby/issues/35310.
But I think https://github.com/moby/moby/issues/35310 needs a more complete fix which is not handled in this PR

Signed-off-by: Madhu Venugopal <madhu@docker.com>