### PR TITLE
Support override of binary name

### DIFF
--- a/portmapper/proxy.go
+++ b/portmapper/proxy.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const userlandProxyCommandName = "docker-proxy"
+var userlandProxyCommandName = "docker-proxy"
 
 type userlandProxy interface {
 	Start() error


### PR DESCRIPTION
This is necessary to support moby/moby#34226. The binary name `docker-proxy` is currently hardcoded in libnetwork. This is the smallest possible change to allow us to configure the binary name, by setting the following arg on `go build` of the engine binary:

```
--ldflags "-X github.com/docker/docker/vendor/github.com/docker/libnetwork/portmapper.userlandProxyCommandName=$PROXY_BINARY_NAME"
```