### PR TITLE
Fix to use ContainerID for windows instead of SandboxID

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -48,6 +48,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -1042,10 +1043,15 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 	}
 	c.Unlock()
 
+	sandboxID := stringid.GenerateRandomID()
+	if runtime.GOOS == "windows" {
+		sandboxID = containerID
+	}
+
 	// Create sandbox and process options first. Key generation depends on an option
 	if sb == nil {
 		sb = &sandbox{
-			id:                 stringid.GenerateRandomID(),
+			id:                 sandboxID,
 			containerID:        containerID,
 			endpoints:          epHeap{},
 			epPriority:         map[string]int{},


### PR DESCRIPTION
Use containerID for windows platform, since sandbox concept is not yet available in platform.
Once the support comes in future, we can revert this change.