### PR TITLE
Fix for docker intercepting DNS requests on ICS network

### DIFF
--- a/network_windows.go
+++ b/network_windows.go
@@ -28,6 +28,9 @@ func executeInCompartment(compartmentID uint32, x func()) {
 }
 
 func (n *network) startResolver() {
+	if n.networkType == "ics" {
+		return
+	}
 	n.resolverOnce.Do(func() {
 		logrus.Debugf("Launching DNS server for network %q", n.Name())
 		options := n.Info().DriverOptions()


### PR DESCRIPTION
New versions of Windows now ship with a default network which is of type ICS. This network supports its own DNS server. We found an issue where docker was intercepting requests on these networks.