### PR TITLE
[17.09] Disable hostname lookup on chain exists check

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -456,7 +456,7 @@ func RawCombinedOutputNative(args ...string) error {
 
 // ExistChain checks if a chain exists
 func ExistChain(chain string, table Table) bool {
-	if _, err := Raw("-t", string(table), "-L", chain); err == nil {
+	if _, err := Raw("-t", string(table), "-nL", chain); err == nil {
 		return true
 	}
 	return false


### PR DESCRIPTION
cherry-pick of https://github.com/docker/libnetwork/pull/1974 for 17.09

```
git checkout -b 17.09-backport-iptables_no_dns_lookup upstream/bump_17.09
git cherry-pick -s -S -x 8dce207dddc3f805b852088a60cc27bfe54b065e
```

Without `-n`, iptables will attempt to lookup hostnames for IP
addresses, which can slow down the call dramatically.
Since we don't need this, and generally don't even care about the
output, use the `-n` flag to disable this.

(cherry picked from commit 8dce207dddc3f805b852088a60cc27bfe54b065e)
