### PR TITLE
Added a new network creation driver option (disable_gatewaydns) for t…

### DIFF
--- a/drivers/windows/labels.go
+++ b/drivers/windows/labels.go
@@ -39,4 +39,7 @@ const (
 
 	// DisableDNS label
 	DisableDNS = "com.docker.network.windowsshim.disable_dns"
+
+	// DisableGatewayDNS label
+	DisableGatewayDNS = "com.docker.network.windowsshim.disable_gatewaydns"
 )

--- a/drivers/windows/windows_store.go
+++ b/drivers/windows/windows_store.go
@@ -64,7 +64,7 @@ func (d *driver) populateNetworks() error {
 		if err = d.createNetwork(ncfg); err != nil {
 			logrus.Warnf("could not create windows network for id %s hnsid %s while booting up from persistent state: %v", ncfg.ID, ncfg.HnsID, err)
 		}
-		logrus.Debugf("Network (%s) restored", ncfg.ID[0:7])
+		logrus.Debugf("Network  %v (%s) restored", d.name, ncfg.ID[0:7])
 	}
 
 	return nil


### PR DESCRIPTION
…he Windows driver

Signed-off-by: Cheng-mean Liu <soccerl@microsoft.com>

This new disable_gatewaydns option provides a way for a client to create a network instance without any gateway IP added into the DNS list for all of its endpoints. 

Usage of disable_gatewaydns:
When set as true, the Windows network driver will skip the addition of the gateway IP into the DNS list.
When not specified, the default setting for disable_gatewaydns is false, that is, it will always add gateway IP into an endpoint's DNS list unless an endpoint was created specifically with an existing epOption.DisableDNS option. 

Example usage:
docker network create -d nat --gateway 172.8.128.1 --subnet 172.8.128.0/20 -o com.docker.network.windowsshim.dnsservers=4.4.4.4,8.8.8.8 -o com.docker.network.windowsshim.disable_gatewaydns=true  mynat
