### PR TITLE
Add .travis.yml to enable travis ci for libnetwork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+go:
+  - 1.8.x
+
+go_import_path: github.com/docker/libnetwork
+
+# `make ci` uses Docker
+sudo: required
+services:
+  - docker
+
+before_install:
+  - sudo modprobe ip_vs
+
+script:
+  - make build
+  - make check


### PR DESCRIPTION
Author: Jianyong Wu <jianyong.wu@arm.com>
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>
since now libnetwork has now travis ci, I add .travis.yml to libnetwork to enable travis ci.
help me check it @calavera @vdemeester @tomdee  