### PR TITLE
enable unit test in arm64

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.8.4
+FROM golang:1.8.5
 RUN apt-get update && apt-get -y install iptables
 
 RUN go get github.com/tools/godep \


### PR DESCRIPTION
change base image tag from 1.8.4 to 1.8.5  to enable unit test in arm64 as golang:1.8.4 does not support arm64v8 . help me check @calavera @vdemeester @tomdee @erikh 
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>