### PR TITLE
[WIP] NetworkDB performance improvements

### DIFF
--- a/networkdb/benchmark_test.go
+++ b/networkdb/benchmark_test.go
@@ -1,0 +1,115 @@
+package networkdb
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddNetworkNode(t *testing.T) {
+	n := &NetworkDB{config: &Config{NodeID: "node-0"}, networkNodes: make(map[string]map[string]struct{})}
+	for i := 0; i < 2000; i++ {
+		n.addNetworkNode("network", "node-"+strconv.Itoa(i%1000))
+	}
+	assert.Equal(t, 1000, len(n.networkNodes["network"]))
+	for i := 0; i < 2000; i++ {
+		n.addNetworkNode("network"+strconv.Itoa(i%1000), "node-"+strconv.Itoa(i))
+	}
+	for i := 0; i < 1000; i++ {
+		assert.Equal(t, 2, len(n.networkNodes["network"+strconv.Itoa(i%1000)]))
+	}
+}
+
+func TestDeleteNetworkNode(t *testing.T) {
+	n := &NetworkDB{config: &Config{NodeID: "node-0"}, networkNodes: make(map[string]map[string]struct{})}
+	for i := 0; i < 1000; i++ {
+		n.addNetworkNode("network", "node-"+strconv.Itoa(i%1000))
+	}
+	assert.Equal(t, 1000, len(n.networkNodes["network"]))
+	for i := 0; i < 2000; i++ {
+		n.deleteNetworkNode("network", "node-"+strconv.Itoa(i%1000))
+	}
+	assert.Equal(t, 0, len(n.networkNodes["network"]))
+	for i := 0; i < 2000; i++ {
+		n.addNetworkNode("network"+strconv.Itoa(i%1000), "node-"+strconv.Itoa(i))
+	}
+	for i := 0; i < 1000; i++ {
+		assert.Equal(t, 2, len(n.networkNodes["network"+strconv.Itoa(i%1000)]))
+		n.deleteNetworkNode("network"+strconv.Itoa(i%1000), "node-"+strconv.Itoa(i))
+		assert.Equal(t, 1, len(n.networkNodes["network"+strconv.Itoa(i%1000)]))
+	}
+	for i := 1000; i < 2000; i++ {
+		n.deleteNetworkNode("network"+strconv.Itoa(i%1000), "node-"+strconv.Itoa(i))
+		assert.Equal(t, 0, len(n.networkNodes["network"+strconv.Itoa(i%1000)]))
+	}
+}
+
+func TestRandomNodes(t *testing.T) {
+	n := &NetworkDB{config: &Config{NodeID: "node-0"}}
+	nodes := make(map[string]struct{})
+	for i := 0; i < 1000; i++ {
+		nodes["node-"+strconv.Itoa(i)] = struct{}{}
+	}
+	nodeHit := make(map[string]int)
+	for i := 0; i < 5000; i++ {
+		chosen := n.mRandomNodes(3, nodes)
+		for _, c := range chosen {
+			if c == "node-0" {
+				t.Fatal("should never hit itself")
+			}
+			nodeHit[c]++
+		}
+	}
+
+	// check results
+	var min, max int
+	for node, hit := range nodeHit {
+		if min == 0 {
+			min = hit
+		}
+		if hit == 0 && node != "node-0" {
+			t.Fatal("node never hit")
+		}
+		if hit > max {
+			max = hit
+		}
+		if hit < min {
+			min = hit
+		}
+	}
+	assert.NotEqual(t, 0, min)
+}
+
+func BenchmarkAddNetworkNode(b *testing.B) {
+	n := &NetworkDB{config: &Config{NodeID: "node-0"}, networkNodes: make(map[string]map[string]struct{})}
+	for i := 0; i < b.N; i++ {
+		n.addNetworkNode("network", "node-"+strconv.Itoa(i%1000))
+	}
+}
+
+func BenchmarkDeleteNetworkNode(b *testing.B) {
+	n := &NetworkDB{config: &Config{NodeID: "node-0"}, networkNodes: make(map[string]map[string]struct{})}
+	nodes := make([]string, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		name := "node-" + strconv.Itoa(i)
+		n.addNetworkNode("network", name)
+		nodes = append(nodes, name)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n.deleteNetworkNode("network", nodes[i%1000])
+	}
+}
+
+func BenchmarkRandomNodes(b *testing.B) {
+	n := &NetworkDB{config: &Config{NodeID: "node-0"}}
+	nodes := make(map[string]struct{})
+	for i := 0; i < 1000; i++ {
+		nodes["node-"+strconv.Itoa(i)] = struct{}{}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n.mRandomNodes(3, nodes)
+	}
+}

--- a/networkdb/delegate.go
+++ b/networkdb/delegate.go
@@ -154,18 +154,14 @@ func (nDB *NetworkDB) handleTableEvent(tEvent *TableEvent) bool {
 	// Ignore the table events for networks that are in the process of going away
 	nDB.RLock()
 	networks := nDB.networks[nDB.config.NodeID]
-	network, ok := networks[tEvent.NetworkID]
+	network, okNetwork := networks[tEvent.NetworkID]
 	// Check if the owner of the event is still part of the network
-	nodes := nDB.networkNodes[tEvent.NetworkID]
 	var nodePresent bool
-	for _, node := range nodes {
-		if node == tEvent.NodeName {
-			nodePresent = true
-			break
-		}
+	if nodes, ok := nDB.networkNodes[tEvent.NetworkID]; ok {
+		_, nodePresent = nodes[tEvent.NodeName]
 	}
 	nDB.RUnlock()
-	if !ok || network.leaving || !nodePresent {
+	if !okNetwork || network.leaving || !nodePresent {
 		// I'm out of the network OR the event owner is not anymore part of the network so do not propagate
 		return false
 	}


### PR DESCRIPTION
CPU profile showed how the mRandomNodes was taking ~30% of the CPU time
of the gossip cycle.

Changing the data structure from a []string to a map allowed to improve
the performance of all the functions that were using it.

Following the comparison of the benchmarks before and after the change

Benchmark on:
```
goos: darwin
goarch: amd64
```
AddNodeNetwork (90% faster):
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkAddNetworkNode-4     1859          181           -90.26%

benchmark                     old allocs     new allocs     delta
BenchmarkAddNetworkNode-4     1              1              +0.00%

benchmark                     old bytes     new bytes     delta
BenchmarkAddNetworkNode-4     15            15            +0.00%
```
DelNodeNetwork (8% faster):
```
benchmark                        old ns/op     new ns/op     delta                                                                                                                                                                                                              
BenchmarkDeleteNetworkNode-4     11.0          10.1          -8.18%                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                
benchmark                        old allocs     new allocs     delta                                                                                                                                                                                                            
BenchmarkDeleteNetworkNode-4     0              0              +0.00%                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                
benchmark                        old bytes     new bytes     delta                                                                                                                                                                                                              
BenchmarkDeleteNetworkNode-4     0             0             +0.00%
```
RandomNode (90% faster and 93% less allocations):
```
benchmark                  old ns/op     new ns/op     delta
BenchmarkRandomNodes-4     1830          172           -90.60%

benchmark                  old allocs     new allocs     delta
BenchmarkRandomNodes-4     16             1              -93.75%

benchmark                  old bytes     new bytes     delta
BenchmarkRandomNodes-4     535           48            -91.03%
```
Full profile: 
![image](https://user-images.githubusercontent.com/1823625/34631688-707eb0f4-f226-11e7-8992-186f693a4153.png)
Detail:
![image](https://user-images.githubusercontent.com/1823625/34631861-4ff66eb6-f227-11e7-9278-ecbce890ae0f.png)


Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>
  
  