### PR TITLE
[17.12] Enable IPV6 config on Sandbox creation on live-restore

### DIFF
--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -220,9 +220,11 @@ func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
 	if err != nil {
 		logrus.Warnf("Failed to set the timeout on the sandbox netlink handle sockets: %v", err)
 	}
-
+	// In live-restore mode, IPV6 entries are getting cleaned up due to below code
+	// We should retain IPV6 configrations in live-restore mode when Docker Daemon
+	// comes back. It should work as it is on other cases
 	// As starting point, disable IPv6 on all interfaces
-	if !n.isDefault {
+	if !isRestore && !n.isDefault {
 		err = setIPv6(n.path, "all", false)
 		if err != nil {
 			logrus.Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)


### PR DESCRIPTION
Cherry-pick of https://github.com/docker/libnetwork/pull/2043 for 17.12. I left out some unrelated commits from the PR

cherry picked from commit 76bfcb0eb14686d3c25683df22e14bc1d3b093ef, no conflicts


In sandbox creation we disable IPV6 config. But this causes problem in live-restore case
where all IPV6 configs are wiped out on running container. Hence extra check has been added
take care of this issue.
