### PR TITLE
Fix user specified ndots option

### DIFF
--- a/service_common_test.go
+++ b/service_common_test.go
@@ -55,15 +55,30 @@ func TestDNSOptions(t *testing.T) {
 	defer sb.Delete()
 	sb.(*sandbox).startResolver(false)
 
-	sb.(*sandbox).config.dnsOptionsList = []string{"ndots:5"}
 	err = sb.(*sandbox).setupDNS()
 	require.NoError(t, err)
 	err = sb.(*sandbox).rebuildDNS()
 	require.NoError(t, err)
-
 	currRC, err := resolvconf.GetSpecific(sb.(*sandbox).config.resolvConfPath)
 	require.NoError(t, err)
 	dnsOptionsList := resolvconf.GetOptions(currRC.Content)
 	assert.Equal(t, 1, len(dnsOptionsList), "There should be only 1 option instead:", dnsOptionsList)
 	assert.Equal(t, "ndots:0", dnsOptionsList[0], "The option must be ndots:0 instead:", dnsOptionsList[0])
+
+	sb.(*sandbox).config.dnsOptionsList = []string{"ndots:5"}
+	err = sb.(*sandbox).setupDNS()
+	require.NoError(t, err)
+	currRC, err = resolvconf.GetSpecific(sb.(*sandbox).config.resolvConfPath)
+	require.NoError(t, err)
+	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
+	assert.Equal(t, 1, len(dnsOptionsList), "There should be only 1 option instead:", dnsOptionsList)
+	assert.Equal(t, "ndots:5", dnsOptionsList[0], "The option must be ndots:5 instead:", dnsOptionsList[0])
+
+	err = sb.(*sandbox).rebuildDNS()
+	require.NoError(t, err)
+	currRC, err = resolvconf.GetSpecific(sb.(*sandbox).config.resolvConfPath)
+	require.NoError(t, err)
+	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
+	assert.Equal(t, 1, len(dnsOptionsList), "There should be only 1 option instead:", dnsOptionsList)
+	assert.Equal(t, "ndots:5", dnsOptionsList[0], "The option must be ndots:5 instead:", dnsOptionsList[0])
 }


### PR DESCRIPTION
Setting ndots to 0 does not allow to resolve search domains
The default will remain ndots:0 that will directly resolve
services, but if the user specify a different ndots value
just propagate it into the container

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>