### PR TITLE
Added OutboundNAT policy support for Windows

### DIFF
--- a/drivers/windows/labels.go
+++ b/drivers/windows/labels.go
@@ -42,4 +42,10 @@ const (
 
 	// DisableGatewayDNS label
 	DisableGatewayDNS = "com.docker.network.windowsshim.disable_gatewaydns"
+
+	// EnableOutboundNat label
+	EnableOutboundNat = "com.docker.network.windowsshim.enable_outboundnat"
+
+	// OutboundNatExceptions label
+	OutboundNatExceptions = "com.docker.network.windowsshim.outboundnat_exceptions"
 )


### PR DESCRIPTION
This change adds support for OutboundNAT policy to the Windows driver passed via a generic option.