### PR TITLE
fix for #1333, calling LinkDel to delete link device when the err is NULL

### DIFF
--- a/drivers/overlay/ov_network.go
+++ b/drivers/overlay/ov_network.go
@@ -242,7 +242,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 
 	for _, ep := range n.endpoints {
 		if ep.ifName != "" {
-			if link, err := ns.NlHandle().LinkByName(ep.ifName); err != nil {
+			if link, err := ns.NlHandle().LinkByName(ep.ifName); err == nil {
 				ns.NlHandle().LinkDel(link)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: ZhiPeng Lu <lu.zhipeng@zte.com.cn>

I think it should be calling LinkDel to delete link device when the error of LinkByName is NULL.
ping @coolljt0725  @aboch 