### PR TITLE
Prevent ingress deletion when endpoint count == 1

### DIFF
--- a/network.go
+++ b/network.go
@@ -959,7 +959,7 @@ func (n *network) delete(force bool) error {
 
 	if len(n.loadBalancerIP) != 0 {
 		endpoints := n.Endpoints()
-		if force || len(endpoints) == 1 {
+		if force || (len(endpoints) == 1 && !n.ingress) {
 			n.deleteLoadBalancerSandbox()
 		}
 		//Reload the network from the store to update the epcnt.


### PR DESCRIPTION
Libnetwork should not delete an ingress network just because its endpoint count
drops to 1 (the IP address of the sandbox).  This addresses a regression
where the ingress sandbox could be deleted on workers when the last
container leave said sandbox.

Adding this fix will ultimately require and accompanying moby/moby fix in order to 
preserve the ability to remove the ingress network manually.  As it turns out, moby
already has the code required to remove the load balancing endpoint in the
daemon.deleteLoadBalancerSandbox() method.  Since removing the ingress network
in moby invokes the daemon.releaseIngress() function to help it, the only change 
required to reinstate ingress network removal along with this fix is to invoke 
deleteLoadBalancerSandbox() within releaseIngress().  This will obviously be in a
moby PR that also adjusts for the libnetwork vendoring (once this fix is in).

Signed-off-by: Chris Telfer <ctelfer@docker.com>