### PR TITLE
Fix for Duplicate IP issues

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -402,15 +402,15 @@ func (a *Allocator) getPredefinedPool(as string, ipV6 bool) (*net.IPNet, error) 
 			continue
 		}
 		aSpace.Lock()
-		_, ok := aSpace.subnets[SubnetKey{AddressSpace: as, Subnet: nw.String()}]
-		aSpace.Unlock()
-		if ok {
+		if _, ok := aSpace.subnets[SubnetKey{AddressSpace: as, Subnet: nw.String()}]; ok {
+			aSpace.Unlock()
 			continue
 		}
-
 		if !aSpace.contains(as, nw) {
+			aSpace.Unlock()
 			return nw, nil
 		}
+		aSpace.Unlock()
 	}
 
 	return nil, types.NotFoundErrorf("could not find an available, non-overlapping IPv%d address pool among the defaults to assign to the network", v)


### PR DESCRIPTION
While investigating duplicate IP issue in IPAM library the following bugs were found:
1) Race condition: IPAM library seems to assume the present of datastore to achieve atomicity. However IPAM library can be used without datastore , for eg swarmkit can use the ipam by setting the datastore to nil.  The race condition causes corruption of the bitsequence which might lead to duplicate IPs by releasing non deallocated IP bits and also cause IP leaks due to certain bit being set even though it was not supposed to be allocated.
2) Free bit logic: The logic in getAvailableBit checks for the presence of a free bit from a start bit in a block. However if the start bit is right after the last available bit, it will return the last bit in the block as the next available bit even though it is not free.
For eg:
Consider the block if ```curr:16``` and ```sequence:0xfffeffff, count:10, next:{sequence:0x0fffffff, count:6}``` then the ```getAvailableBit(16)``` would return 31 as the next available bit and we will end up with duplicate IPs/vxlanids etc.
3) Byte Offset Calculations
4) Another Byte Offset Calculations (Regression): Similar to the same example in 2) we were moving on to the next block altogether instead of looking at the next instance in the same block if it is available. 
5) Concurrent Map Access


Tests are added to verify the above scenrios

Signed-off-by: Abhinandan Prativadi <abhi@docker.com>