### PR TITLE
Bump vishvananda/netns to be1fbeda19366dea804f00efff2dd73a1642fdcc

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -46,7 +46,7 @@ github.com/stretchr/testify dab07ac62d4905d3e48d17dc549c684ac3b7c15a
 github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
 github.com/ugorji/go f1f1a805ed361a0e078bb537e4ea78cd37dcf065
 github.com/vishvananda/netlink b2de5d10e38ecce8607e6b438b6d174f389a004e
-github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
+github.com/vishvananda/netns be1fbeda19366dea804f00efff2dd73a1642fdcc
 golang.org/x/crypto 558b6879de74bc843225cde5686419267ff707ca
 golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
 golang.org/x/sys 07c182904dbd53199946ba614a412c61d3c548f5

--- a/vendor/github.com/vishvananda/netns/README.md
+++ b/vendor/github.com/vishvananda/netns/README.md
@@ -20,9 +20,10 @@ Testing (requires root):
 package main
 
 import (
+    "fmt"
     "net"
     "runtime"
-    "github.com/vishvananada/netns"
+    "github.com/vishvananda/netns"
 )
 
 func main() {
@@ -36,9 +37,10 @@ func main() {
 
     // Create a new network namespace
     newns, _ := netns.New()
+    netns.Set(newns)
     defer newns.Close()
 
-    // Do something with tne network namespace
+    // Do something with the network namespace
     ifaces, _ := net.Interfaces()
     fmt.Printf("Interfaces: %v\n", ifaces)
 

--- a/vendor/github.com/vishvananda/netns/netns.go
+++ b/vendor/github.com/vishvananda/netns/netns.go
@@ -19,7 +19,7 @@ type NsHandle int
 
 // Equal determines if two network handles refer to the same network
 // namespace. This is done by comparing the device and inode that the
-// file descripors point to.
+// file descriptors point to.
 func (ns NsHandle) Equal(other NsHandle) bool {
 	if ns == other {
 		return true
@@ -46,6 +46,19 @@ func (ns NsHandle) String() string {
 	return fmt.Sprintf("NS(%d: %d, %d)", ns, s.Dev, s.Ino)
 }
 
+// UniqueId returns a string which uniquely identifies the namespace
+// associated with the network handle.
+func (ns NsHandle) UniqueId() string {
+	var s syscall.Stat_t
+	if ns == -1 {
+		return "NS(none)"
+	}
+	if err := syscall.Fstat(int(ns), &s); err != nil {
+		return "NS(unknown)"
+	}
+	return fmt.Sprintf("NS(%d:%d)", s.Dev, s.Ino)
+}
+
 // IsOpen returns true if Close() has not been called.
 func (ns NsHandle) IsOpen() bool {
 	return ns != -1
@@ -61,7 +74,7 @@ func (ns *NsHandle) Close() error {
 	return nil
 }
 
-// Get an empty (closed) NsHandle
+// None gets an empty (closed) NsHandle.
 func None() NsHandle {
 	return NsHandle(-1)
 }

--- a/vendor/github.com/vishvananda/netns/netns_linux.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux.go
@@ -7,14 +7,27 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
 )
 
+// SYS_SETNS syscall allows changing the namespace of the current process.
+var SYS_SETNS = map[string]uintptr{
+	"386":     346,
+	"amd64":   308,
+	"arm64":   268,
+	"arm":     375,
+	"mips":    4344,
+	"mipsle":  4344,
+	"ppc64":   350,
+	"ppc64le": 350,
+	"s390x":   339,
+}[runtime.GOARCH]
+
+// Deprecated: use syscall pkg instead (go >= 1.5 needed).
 const (
-	// These constants belong in the syscall library but have not been
-	// added yet.
 	CLONE_NEWUTS  = 0x04000000 /* New utsname group? */
 	CLONE_NEWIPC  = 0x08000000 /* New ipcs */
 	CLONE_NEWUSER = 0x10000000 /* New user namespace */
@@ -125,7 +138,9 @@ func getThisCgroup(cgroupType string) (string, error) {
 		return "", fmt.Errorf("docker pid not found in /var/run/docker.pid")
 	}
 	pid, err := strconv.Atoi(result[0])
-
+	if err != nil {
+		return "", err
+	}
 	output, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
 		return "", err
@@ -167,8 +182,14 @@ func getPidForContainer(id string) (int, error) {
 		filepath.Join(cgroupRoot, cgroupThis, id, "tasks"),
 		// With more recent lxc versions use, cgroup will be in lxc/
 		filepath.Join(cgroupRoot, cgroupThis, "lxc", id, "tasks"),
-		// With more recent dockee, cgroup will be in docker/
+		// With more recent docker, cgroup will be in docker/
 		filepath.Join(cgroupRoot, cgroupThis, "docker", id, "tasks"),
+		// Even more recent docker versions under systemd use docker-<id>.scope/
+		filepath.Join(cgroupRoot, "system.slice", "docker-"+id+".scope", "tasks"),
+		// Even more recent docker versions under cgroup/systemd/docker/<id>/
+		filepath.Join(cgroupRoot, "..", "systemd", "docker", id, "tasks"),
+		// Kubernetes with docker and CNI is even more different
+		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "*", "pod*", id, "tasks"),
 	}
 
 	var filename string

--- a/vendor/github.com/vishvananda/netns/netns_linux_386.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux_386.go
@@ -1,7 +1,0 @@
-// +build linux,386
-
-package netns
-
-const (
-	SYS_SETNS = 346
-)

--- a/vendor/github.com/vishvananda/netns/netns_linux_amd64.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux_amd64.go
@@ -1,7 +1,0 @@
-// +build linux,amd64
-
-package netns
-
-const (
-	SYS_SETNS = 308
-)

--- a/vendor/github.com/vishvananda/netns/netns_linux_arm.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux_arm.go
@@ -1,7 +1,0 @@
-// +build linux,arm
-
-package netns
-
-const (
-	SYS_SETNS = 375
-)

--- a/vendor/github.com/vishvananda/netns/netns_linux_arm64.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux_arm64.go
@@ -1,7 +1,0 @@
-// +build linux,arm64
-
-package netns
-
-const (
-	SYS_SETNS = 268
-)

--- a/vendor/github.com/vishvananda/netns/netns_linux_ppc64le.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux_ppc64le.go
@@ -1,7 +1,0 @@
-// +build linux,ppc64le
-
-package netns
-
-const (
-	SYS_SETNS = 350
-)

--- a/vendor/github.com/vishvananda/netns/netns_linux_s390x.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux_s390x.go
@@ -1,7 +1,0 @@
-// +build linux,s390x
-
-package netns
-
-const (
-	SYS_SETNS = 339
-)

--- a/vendor/github.com/vishvananda/netns/netns_unspecified.go
+++ b/vendor/github.com/vishvananda/netns/netns_unspecified.go
@@ -22,11 +22,19 @@ func Get() (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
+func GetFromPath(path string) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
 func GetFromName(name string) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
 func GetFromPid(pid int) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromThread(pid, tid int) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 


### PR DESCRIPTION
Full diff: https://github.com/vishvananda/netns/compare/604eaf189ee867d8c147fafc28def2394e878d25...be1fbeda19366dea804f00efff2dd73a1642fdcc


Changes included:

- https://github.com/vishvananda/netns/pull/10 Container cgroup location under systemd
- https://github.com/vishvananda/netns/pull/11 refactor netns
- https://github.com/vishvananda/netns/pull/13 netns add ppc64 same as ppc64le
- https://github.com/vishvananda/netns/pull/14 Added function UniqueId which returns a string that uniquely identifies namespace
- https://github.com/vishvananda/netns/pull/15 Fixed the docker netns detection err on xenial
- https://github.com/vishvananda/netns/pull/18 Add missing stub functions to netns_unspecified.go
- https://github.com/vishvananda/netns/pull/21 Add mips, mipsle to the SYS_SETNS map
- https://github.com/vishvananda/netns/pull/22 fix swallowed err variable
- https://github.com/vishvananda/netns/pull/24 Search kubepods for Docker containers

ping @aboch @fcrisciani PTAL