### PR TITLE
Retry other external DNS servers on ServFail

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -452,7 +452,6 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 				logrus.Warnf("[resolver] connect failed: %s", err)
 				continue
 			}
-
 			queryType := dns.TypeToString[query.Question[0].Qtype]
 			logrus.Debugf("[resolver] query %s (%s) from %s, forwarding to %s:%s", name, queryType,
 				extConn.LocalAddr().String(), proto, extDNS.IPStr)
@@ -492,6 +491,11 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			}
 			r.forwardQueryEnd()
 			if resp != nil {
+				if resp.Rcode == dns.RcodeServerFailure {
+					// for Server Failure response, continue to the next external DNS server
+					logrus.Debugf("[resolver] external DNS %s:%s responded with ServFail for %q", proto, extDNS.IPStr, name)
+					continue
+				}
 				answers := 0
 				for _, rr := range resp.Answer {
 					h := rr.Header()
@@ -511,10 +515,10 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 				if resp.Answer == nil || answers == 0 {
 					logrus.Debugf("[resolver] external DNS %s:%s did not return any %s records for %q", proto, extDNS.IPStr, queryType, name)
 				}
+				resp.Compress = true
 			} else {
 				logrus.Debugf("[resolver] external DNS %s:%s returned empty response for %q", proto, extDNS.IPStr, name)
 			}
-			resp.Compress = true
 			break
 		}
 		if resp == nil {


### PR DESCRIPTION
This PR covers the following:
1. Implements fix for https://github.com/docker/libnetwork/issues/1664
2. Fixes a reference to members of `resp` outside null check that may lead to a null exception.
3. Unit tests involving a local DNS server that can be expanded and programmed to cover external DNS tests.