### PR TITLE
Fix README flag and expose orphan network peers

### DIFF
--- a/cmd/diagnostic/README.md
+++ b/cmd/diagnostic/README.md
@@ -252,11 +252,11 @@ Remember to use the full network ID, you can easily find that with `docker netwo
 **Service discovery and load balancer:**
 
 ```bash
-$ diagnostiClient -c sd -v -net n8a8ie6tb3wr2e260vxj8ncy4 -a
+$ diagnostiClient -t sd -v -net n8a8ie6tb3wr2e260vxj8ncy4 -a
 ```
 
 **Overlay network:**
 
 ```bash
-$ diagnostiClient -port 2001 -c overlay -v -net n8a8ie6tb3wr2e260vxj8ncy4 -a
+$ diagnostiClient -port 2001 -t overlay -v -net n8a8ie6tb3wr2e260vxj8ncy4 -a
 ```

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -313,7 +313,7 @@ func (nDB *NetworkDB) Peers(nid string) []PeerInfo {
 		} else {
 			// Added for testing purposes, this condition should never happen else mean that the network list
 			// is out of sync with the node list
-			peers = append(peers, PeerInfo{})
+			peers = append(peers, PeerInfo{Name: nodeName, IP: "unknown"})
 		}
 	}
 	return peers

--- a/networkdb/networkdbdiagnostic.go
+++ b/networkdb/networkdbdiagnostic.go
@@ -84,7 +84,11 @@ func dbPeers(ctx interface{}, w http.ResponseWriter, r *http.Request) {
 		peers := nDB.Peers(r.Form["nid"][0])
 		rsp := &diagnostic.TableObj{Length: len(peers)}
 		for i, peerInfo := range peers {
-			rsp.Elements = append(rsp.Elements, &diagnostic.PeerEntryObj{Index: i, Name: peerInfo.Name, IP: peerInfo.IP})
+			if peerInfo.IP == "unknown" {
+				rsp.Elements = append(rsp.Elements, &diagnostic.PeerEntryObj{Index: i, Name: "orphan-" + peerInfo.Name, IP: peerInfo.IP})
+			} else {
+				rsp.Elements = append(rsp.Elements, &diagnostic.PeerEntryObj{Index: i, Name: peerInfo.Name, IP: peerInfo.IP})
+			}
 		}
 		log.WithField("response", fmt.Sprintf("%+v", rsp)).Info("network peers done")
 		diagnostic.HTTPReply(w, diagnostic.CommandSucceed(rsp), json)


### PR DESCRIPTION
- Readme example was using wrong flag
- Network peers were not exposed properly

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>