### PR TITLE
Modify awk to use cut in check_ip_overlap

### DIFF
--- a/support.sh
+++ b/support.sh
@@ -26,7 +26,7 @@ function echo_and_run {
 
 function check_ip_overlap {
   inspect=$1
-  overlap=$(echo "$inspect_output" | grep "EndpointIP\|VIP" | awk -F ':' '{print $2}' | sort | uniq -c | grep -v "1 ")
+  overlap=$(echo "$inspect_output" | grep "EndpointIP\|VIP" | cut -d':' -f2 | sort | uniq -c | grep -v "1 ")
   if [ ! -z "$overlap" ]; then
     echo -e "\n\n*** OVERLAP on Network ${networkID} ***";
     echo -e "${overlap} \n\n"


### PR DESCRIPTION
This patch replaces awk with cut to workaround issues present with
running this script within ucp-dsinfo.

Signed-off-by: Kyle Squizzato <kyle.squizzato@docker.com>