### PR TITLE
Adding a recovery mechanism for a split gossip cluster

### DIFF
--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -3,6 +3,7 @@ package networkdb
 //go:generate protoc -I.:../vendor/github.com/gogo/protobuf --gogo_out=import_path=github.com/docker/libnetwork/networkdb,Mgogoproto/gogo.proto=github.com/gogo/protobuf/gogoproto:. networkdb.proto
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -77,9 +78,10 @@ type NetworkDB struct {
 	// Broadcast queue for node event gossip.
 	nodeBroadcasts *memberlist.TransmitLimitedQueue
 
-	// A central stop channel to stop all go routines running on
+	// A central context to stop all go routines running on
 	// behalf of the NetworkDB instance.
-	stopCh chan struct{}
+	ctx       context.Context
+	cancelCtx context.CancelFunc
 
 	// A central broadcaster for all local watchers watching table
 	// events.


### PR DESCRIPTION

Steps To Reproduce:
- 3 managers 3 workers cluster
- Stop all managers in the cluster (leave the workers running)
- Wait a minute and start all managers

Expected Results:
- All nodes converge into a single gossip cluster

Actual Results:
- The workers and the managers ended up on 2 different gossip clusters. This causes `overlay` and unpredicted networking issues between containers on the 2 different clusters.

Workaround:
- Restart "All" the workers to force re-joining the manager cluster 
or
- To avoid a restart, use the [diagnostic tool ](https://github.com/docker/libnetwork/blob/master/cmd/diagnostic/README.md)with the `/join` endpoint 

PR fix:
This PR adds a go routine that runs every minute and checks that **at least** one node from the `bootStrap` list (ie: managers nodes) is  part of the cluster, if we couldn't find any, then we attempt a `/join` for 10 seconds .

Note:
While testing, I ran into an issue, that I couldn't reliably reproduce; 
a `leave` event was followed by a false positive `join` event was received by a `worker` when the `manager` node was down, this caused an inconsistency in the `nDB.nodes` which caused the logic in this PR to fail.

@fcrisciani recommended the below change and he'll be looking into the problem in more details.

```

	// If the node is not known from memberlist we cannot process save any state of it else if it actually
	// dies we won't receive any notification and we will remain stuck with it
	if _, ok := nDB.nodes[nEvent.NodeName]; !ok {
		logrus.Error("node: %s is unknown to memberlist", nEvent.NodeName)
		return false
	}
``` 
 
Signed-off-by: Dani Louca <dani.louca@docker.com>