### PR TITLE
filter xtables lock warnings when firewalld is active

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -45,7 +46,7 @@ var (
 	iptablesPath  string
 	supportsXlock = false
 	supportsCOpt  = false
-	xLockWaitMsg  = "Another app is currently holding the xtables lock; waiting"
+	xLockWaitMsg  = "Another app is currently holding the xtables lock"
 	// used to lock iptables commands if xtables lock is not supported
 	bestEffortLock sync.Mutex
 	// ErrIptablesNotFound is returned when the rule is not found.
@@ -423,12 +424,31 @@ func existsRaw(table Table, chain string, rule ...string) bool {
 	return strings.Contains(string(existingRules), ruleString)
 }
 
+// Maximum duration that an iptables operation can take
+// before flagging a warning.
+const opWarnTime = 2 * time.Second
+
+func filterOutput(start time.Time, output []byte, args ...string) []byte {
+	// Flag operations that have taken a long time to complete
+	if time.Since(start) > opWarnTime {
+		logrus.Warnf("xtables contention detected while running [%s]: %q", strings.Join(args, " "), string(output))
+	}
+	// ignore iptables' message about xtables lock:
+	// it is a warning, not an error.
+	if strings.Contains(string(output), xLockWaitMsg) {
+		output = []byte("")
+	}
+	// Put further filters here if desired
+	return output
+}
+
 // Raw calls 'iptables' system command, passing supplied arguments.
 func Raw(args ...string) ([]byte, error) {
 	if firewalldRunning {
+		startTime := time.Now()
 		output, err := Passthrough(Iptables, args...)
 		if err == nil || !strings.Contains(err.Error(), "was not provided by any .service files") {
-			return output, err
+			return filterOutput(startTime, output, args...), err
 		}
 	}
 	return raw(args...)
@@ -447,17 +467,13 @@ func raw(args ...string) ([]byte, error) {
 
 	logrus.Debugf("%s, %v", iptablesPath, args)
 
+	startTime := time.Now()
 	output, err := exec.Command(iptablesPath, args...).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("iptables failed: iptables %v: %s (%s)", strings.Join(args, " "), output, err)
 	}
 
-	// ignore iptables' message about xtables lock
-	if strings.Contains(string(output), xLockWaitMsg) {
-		output = []byte("")
-	}
-
-	return output, err
+	return filterOutput(startTime, output, args...), err
 }
 
 // RawCombinedOutput inernally calls the Raw function and returns a non nil


### PR DESCRIPTION
It turns out that when running under RHEL 7.3 (and possibly other distributions), Linux can be configured with firewalld, but still run into contention on the xtables lock when performing iptables operations even though use of firewalld doesn't specify the `--wait` flag for iptables.  An example of this as seen in e2e tests is as follows:

```
Apr 10 15:24:18 tests-BUILD-28-rhel-7-3-dm-ee-test-rhel-0 dockerd[3453]: time="2018-04-10T15:24:18.405670490-04:00" level=debug msg="Firewalld passthrough: ipv4, [-t nat -I DOCKER-INGRESS -p tcp --dport 30017 -j DNAT --to-destination 172.18.0.2:30017]"
Apr 10 15:24:20 tests-BUILD-28-rhel-7-3-dm-ee-test-rhel-0 dockerd[3453]: time="2018-04-10T15:24:20.413670601-04:00" level=error msg="Failed to add ingress: setting up rule failed, [-t nat -I DOCKER-INGRESS -p tcp --dport 30017 -j DNAT --to-destination 172.18.0.2:30017]: Another app is currently holding the xtables lock; waiting (1s) for it to exit...\n (<nil>)"
```

The first line of the output shows that iptables programming was going through firewalld.  The second line consists of output from the iptables command along with the error which is `(<nil>)`.  Now, the `RawCombinedOutput()` function calls `Raw()` which in turn dispatches between issuing the command either using the `Passthrough()` function for firewalld execution or the `raw()` function for direct fork/exec execution.   `Passthrough()` generates the first (debug) line in the output above. `Raw()` returns both the output from the command and an `error` value which is non-nil presumably if the command exits with a non-zero exit code indicating failure.  The output above therefore indicates that the command exited with a zero-status (successfully) but generated output indicating that it had to wait for 1s to try to acquire the iptables lock.

Now `RawCombinedOutput()` returns only an error code and it returns an error if either `Raw()` returns an error *OR* if the output from iptables is non-empty.  This means that the iptables warning above ends up causing `RawCombinedOutput()` to return an error when in fact none was present.  This is not an unknown situation as the code in `raw()` specifically scans the output that it gets from the iptables operation looking for the xtables lock message.  If it sees it, it returns empty output instead.  This prevents flagging a false-positive error.  However, the firewalld path using the `Passthrough()` does not perform this filtering and so causes this false-positive error.

One might, at this point, ask whether this is just a spurious log problem or a genuine error given that the operation did, in fact, complete successfully.  Unfortunately, the operations that were failing above were due to programming ingress rules using iptables.  There were actually a series of iptables modifications that are all needed for correct ingress redirection.  If one of the early or middle operations is caught as a failure, libnetwork will not try to program the remaining ones.   This leaves the system in an inconsistent state.

This PR consists of two commits.  The first simply replicates the output filter from the `raw()` path on the `Passthrough()` path and should avoid the error.   The second was added based on a suggestion from @fcrisciani and it adds a warning when the xtables lock contention is detected.  This makes the fact that the contention is occurring more visible so as to provide better visibility that there may be other issues in this area.