### PR TITLE
networkdb: Use write lock in handleNodeEvent

### DIFF
--- a/networkdb/delegate.go
+++ b/networkdb/delegate.go
@@ -21,8 +21,8 @@ func (nDB *NetworkDB) handleNodeEvent(nEvent *NodeEvent) bool {
 	// time.
 	nDB.networkClock.Witness(nEvent.LTime)
 
-	nDB.RLock()
-	defer nDB.RUnlock()
+	nDB.Lock()
+	defer nDB.Unlock()
 
 	// check if the node exists
 	n, _, _ := nDB.findNode(nEvent.NodeName)


### PR DESCRIPTION
`handleNodeEvent` is calling `changeNodeState` which writes to various
maps on the ndb object.
Using a write lock prevents a panic on concurrent read/write access on
these maps.

Related to moby/moby#36814