### PR TITLE
Fix overlay vxlan races

### DIFF
--- a/drivers/overlay/joinleave.go
+++ b/drivers/overlay/joinleave.go
@@ -47,17 +47,9 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		return fmt.Errorf("couldn't get vxlan id for %q: %v", s.subnetIP.String(), err)
 	}
 
-	if err := n.joinSandbox(false); err != nil {
+	if err := n.joinSandbox(s, false, true); err != nil {
 		return fmt.Errorf("network sandbox join failed: %v", err)
 	}
-
-	if err := n.joinSubnetSandbox(s, false); err != nil {
-		return fmt.Errorf("subnet sandbox join failed for %q: %v", s.subnetIP.String(), err)
-	}
-
-	// joinSubnetSandbox gets called when an endpoint comes up on a new subnet in the
-	// overlay network. Hence the Endpoint count should be updated outside joinSubnetSandbox
-	n.incEndpointCount()
 
 	sbox := n.sandbox()
 

--- a/drivers/overlay/peerdb.go
+++ b/drivers/overlay/peerdb.go
@@ -384,7 +384,7 @@ func (d *driver) peerAddOp(nid, eid string, peerIP net.IP, peerIPMask net.IPMask
 		return fmt.Errorf("couldn't get vxlan id for %q: %v", s.subnetIP.String(), err)
 	}
 
-	if err := n.joinSubnetSandbox(s, false); err != nil {
+	if err := n.joinSandbox(s, false, false); err != nil {
 		return fmt.Errorf("subnet sandbox join failed for %q: %v", s.subnetIP.String(), err)
 	}
 


### PR DESCRIPTION
This function takes the patch offered in https://github.com/docker/libnetwork/pull/1800 and attempts to address the issues found in https://github.com/docker/libnetwork/issues/1765.  It removes a race condition documented in the issue where "re-once"ing the creation of an overlay sandbox can race with incoming join requests to cause a leak/collision with the vxlan interface.  This PR addresses said issue by removing the "re-once" pattern and replacing it with a traditional mutex+boolean initializer pattern.  This also allows removing some restore error handling by having the sandbox join/leave perform proper cleanup on error.  More information is available in the commit logs of the PR.