### PR TITLE
Docker removes stale endpoints in nat network only

### DIFF
--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -366,7 +366,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		config.HnsID = hnsresponse.Id
 		genData[HNSID] = config.HnsID
 
-	} else {
+	} else if d.name == "nat" {
 		// Delete any stale HNS endpoints for this network.
 		if endpoints, err := hcsshim.HNSListEndpointRequest(); err == nil {
 			for _, ep := range endpoints {


### PR DESCRIPTION
With RS4 we added support for VMs to use HNS networks. These VMs create persistent  endpoints in HNS network and expect them to be reused across reboot. Because of this change in docker, docker ends up deleting these endpoints aswell.

For now limiting docker to only remove stale endpoints in nat network. We are trying to come up with a better story for endpoint ownership in this or next milestone.