### PR TITLE
Makefile: Add shell target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,3 +134,6 @@ circle-ci-build: ${build_image}.created
 	@${cidocker} make build-local
 
 circle-ci: circle-ci-build circle-ci-check circle-ci-cross integration-tests
+
+shell:
+	@${docker} ${SHELL}


### PR DESCRIPTION
This makes it easy to drop into the build container, for instance to
run tests or other Go tools over a subset of the code.

Signed-off-by: Euan Harris <euan.harris@docker.com>