### PR TITLE
[17.06] Backport missing `MacPool` and `DisableGatewayDNS` options

### DIFF
--- a/drivers/windows/labels.go
+++ b/drivers/windows/labels.go
@@ -28,6 +28,9 @@ const (
 	// DNSServers of the network
 	DNSServers = "com.docker.network.windowsshim.dnsservers"
 
+	// MacPool of the network
+	MacPool = "com.docker.network.windowsshim.macpool"
+
 	// SourceMac of the network
 	SourceMac = "com.docker.network.windowsshim.sourcemac"
 

--- a/drivers/windows/labels.go
+++ b/drivers/windows/labels.go
@@ -39,4 +39,7 @@ const (
 
 	// DisableDNS label
 	DisableDNS = "com.docker.network.windowsshim.disable_dns"
+
+	// DisableGatewayDNS label
+	DisableGatewayDNS = "com.docker.network.windowsshim.disable_gatewaydns"
 )

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -44,6 +44,7 @@ type networkConfiguration struct {
 	NetworkAdapterName string
 	dbIndex            uint64
 	dbExists           bool
+	DisableGatewayDNS  bool
 }
 
 // endpointConfiguration represents the user specified configuration for the sandbox endpoint
@@ -169,6 +170,12 @@ func (d *driver) parseNetworkOptions(id string, genericOptions map[string]string
 			config.DNSSuffix = value
 		case DNSServers:
 			config.DNSServers = value
+		case DisableGatewayDNS:
+			b, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, err
+			}
+			config.DisableGatewayDNS = b
 		case MacPool:
 			config.MacPools = make([]hcsshim.MacPool, 0)
 			s := strings.Split(value, ",")
@@ -585,7 +592,14 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 
 	endpointStruct.DNSServerList = strings.Join(epOption.DNSServers, ",")
 
+	// overwrite the ep DisableDNS option if DisableGatewayDNS was set to true during the network creation option
+	if n.config.DisableGatewayDNS {
+		logrus.Debugf("n.config.DisableGatewayDNS[%v] overwrites epOption.DisableDNS[%v]", n.config.DisableGatewayDNS, epOption.DisableDNS)
+		epOption.DisableDNS = n.config.DisableGatewayDNS
+	}
+
 	if n.driver.name == "nat" && !epOption.DisableDNS {
+		logrus.Debugf("endpointStruct.EnableInternalDNS =[%v]", endpointStruct.EnableInternalDNS)
 		endpointStruct.EnableInternalDNS = true
 	}
 

--- a/drivers/windows/windows_store.go
+++ b/drivers/windows/windows_store.go
@@ -64,7 +64,7 @@ func (d *driver) populateNetworks() error {
 		if err = d.createNetwork(ncfg); err != nil {
 			logrus.Warnf("could not create windows network for id %s hnsid %s while booting up from persistent state: %v", ncfg.ID, ncfg.HnsID, err)
 		}
-		logrus.Debugf("Network (%s) restored", ncfg.ID[0:7])
+		logrus.Debugf("Network  %v (%s) restored", d.name, ncfg.ID[0:7])
 	}
 
 	return nil

--- a/drivers_windows.go
+++ b/drivers_windows.go
@@ -16,5 +16,6 @@ func getInitializers(experimental bool) []initializer {
 		{windows.GetInit("l2bridge"), "l2bridge"},
 		{windows.GetInit("l2tunnel"), "l2tunnel"},
 		{windows.GetInit("nat"), "nat"},
+		{windows.GetInit("ics"), "ics"},
 	}
 }


### PR DESCRIPTION
This backports:

https://github.com/docker/libnetwork/pull/1755 "Changes to support ICS network on windows" (adds `com.docker.network.windowsshim.macpool` option)
https://github.com/docker/libnetwork/pull/2021 "Added a new network creation driver option (disable_gatewaydns) for the Windows driver" (adds `com.docker.network.windowsshim.disable_gatewaydns` option)



```bash
git checkout -b 17.06-backport-disable_gatewaydns upstream/bump_17.06
git cherry-pick -s -S -x a35f24ae0b90504562e3fad899342152605fd82c
git cherry-pick -s -S -x 884eaa0157709a3197b9696981c4f1ce0d86120b
```

No conflicts


NOTE: when just backporting https://github.com/docker/libnetwork/pull/2021, the conflict below occurs (due to `MacPool` missing):


```patch
diff --cc drivers/windows/windows.go
index 014e93c7,964099cc..00000000
--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@@ -168,6 -178,24 +169,27 @@@ func (d *driver) parseNetworkOptions(i
                        config.DNSSuffix = value
                case DNSServers:
                        config.DNSServers = value
++<<<<<<< HEAD
++=======
+               case DisableGatewayDNS:
+                       b, err := strconv.ParseBool(value)
+                       if err != nil {
+                               return nil, err
+                       }
+                       config.DisableGatewayDNS = b
+               case MacPool:
+                       config.MacPools = make([]hcsshim.MacPool, 0)
+                       s := strings.Split(value, ",")
+                       if len(s)%2 != 0 {
+                               return nil, types.BadRequestErrorf("Invalid mac pool. You must specify both a start range and an end range")
+                       }
+                       for i := 0; i < len(s)-1; i += 2 {
+                               config.MacPools = append(config.MacPools, hcsshim.MacPool{
+                                       StartMacAddress: s[i],
+                                       EndMacAddress:   s[i+1],
+                               })
+                       }
++>>>>>>> 884eaa01... Added a new network creation driver option (disable_gatewaydns) for the Windows driver
                case VLAN:
                        vlan, err := strconv.ParseUint(value, 10, 32)
                        if err != nil {
```
