### PR TITLE
test: update tests to use sub-benchmarks

### DIFF
--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -1141,19 +1141,21 @@ func benchMarkRequest(subnet string, b *testing.B) {
 	}
 }
 
-func BenchmarkRequest_24(b *testing.B) {
-	a, _ := getAllocator(true)
-	benchmarkRequest(b, a, "10.0.0.0/24")
-}
+func BenchmarkRequest(b *testing.B) {
 
-func BenchmarkRequest_16(b *testing.B) {
-	a, _ := getAllocator(true)
-	benchmarkRequest(b, a, "10.0.0.0/16")
-}
+	subnets := []string{
+		"10.0.0.0/24",
+		"10.0.0.0/16",
+		"10.0.0.0/8",
+	}
 
-func BenchmarkRequest_8(b *testing.B) {
-	a, _ := getAllocator(true)
-	benchmarkRequest(b, a, "10.0.0.0/8")
+	for _, subnet := range subnets {
+		name := fmt.Sprintf("%vSubnet", subnet)
+		b.Run(name, func(b *testing.B) {
+			a, _ := getAllocator(true)
+			benchmarkRequest(b, a, subnet)
+		})
+	}
 }
 
 func TestAllocateRandomDeallocate(t *testing.T) {


### PR DESCRIPTION
Go 1.7 added the subtest feature which can make table-driven tests much easier to run and debug. Some tests are not using this feature.

Further reading: [Using Subtests and Sub-benchmarks](https://blog.golang.org/subtests)
