### PR TITLE
Remove non-service cluster info on sbLeave

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -748,10 +748,8 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 		}
 	}
 
-	if ep.svcID != "" {
-		if err := ep.deleteServiceInfoFromCluster(sb, true, "sbLeave"); err != nil {
-			logrus.Warnf("Failed to clean up service info on container %s disconnect: %v", ep.name, err)
-		}
+	if err := ep.deleteServiceInfoFromCluster(sb, true, "sbLeave"); err != nil {
+		logrus.Warnf("Failed to clean up service info on container %s disconnect: %v", ep.name, err)
 	}
 
 	if err := sb.clearNetworkResources(ep); err != nil {


### PR DESCRIPTION
Libnetwork should remove cluster service info including networkDB entries and DNS entries for container endpoints that are not part of a service as well as those that are part of a service.  This used to be the normal mode of operation.  However cluster info removal moved to sandbox.DisableService() in an effort to more gracefully handle endpoint removal from a service (which proved insufficient).  Subsequent changes that did peroperly handle graceful endpoint removal unfortunately also got rid of the newly-mandatory call to sandbox.DisableService() preventing proper cleanup for non-service container endpoints.

Signed-off-by: Chris Telfer <ctelfer@docker.com>