### PR TITLE
Remove non-service cluster info on sbLeave

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -752,10 +752,8 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 		}
 	}
 
-	if ep.svcID != "" {
-		if err := ep.deleteServiceInfoFromCluster(sb, true, "sbLeave"); err != nil {
-			logrus.Warnf("Failed to clean up service info on container %s disconnect: %v", ep.name, err)
-		}
+	if err := ep.deleteServiceInfoFromCluster(sb, true, "sbLeave"); err != nil {
+		logrus.Warnf("Failed to clean up service info on container %s disconnect: %v", ep.name, err)
 	}
 
 	if err := sb.clearNetworkResources(ep); err != nil {


### PR DESCRIPTION
The system should remove cluster service info including networkDB entries and DNS entries for container endpoints that are not part of a service as well as those that are part of a service.  This used to be the normal sequence of operations but info removal moved to sandbox.DisableService() in an effort to more gracefully handle endpoint removal from a service (which proved insufficient).  Unfortunately, subsequent fixes for graceful LB removal also removed the newly-mandatory call to sandbox.DisableService() preventing proper cleanup for non-service container endpoints.  This patch restores the original logic of always removing cluster info.

Signed-off-by: Chris Telfer <ctelfer@docker.com>