### PR TITLE
Avoid reusing subnets when allocating from pools

### DIFF
--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -590,6 +590,45 @@ func TestGetSameAddress(t *testing.T) {
 	}
 }
 
+func TestPoolAllocationReuse(t *testing.T) {
+	for _, store := range []bool{false, true} {
+		a, err := getAllocator(store)
+		assert.NoError(t, err)
+
+		// First get all pools until they are exhausted to
+		pList := []string{}
+		pool, _, _, err := a.RequestPool(localAddressSpace, "", "", nil, false)
+		for err == nil {
+			pList = append(pList, pool)
+			pool, _, _, err = a.RequestPool(localAddressSpace, "", "", nil, false)
+		}
+		nPools := len(pList)
+		for _, pool := range pList {
+			if err := a.ReleasePool(pool); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Now try to allocate then free nPool pools sequentially.
+		// Verify that we don't see any repeat networks even though
+		// we have freed them.
+		seen := map[string]bool{}
+		for i := 0; i < nPools; i++ {
+			pool, nw, _, err := a.RequestPool(localAddressSpace, "", "", nil, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := seen[nw.String()]; ok {
+				t.Fatalf("Network %s was reused before exhausing the pool list", nw.String())
+			}
+			seen[nw.String()] = true
+			if err := a.ReleasePool(pool); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
 func TestGetAddressSubPoolEqualPool(t *testing.T) {
 	for _, store := range []bool{false, true} {
 		a, err := getAllocator(store)


### PR DESCRIPTION
This patch changes the algorithm for selecting the next pool to allocate from an address space.   Previously, the list of potential subnets was fixed and the allocator always searched for an available subnet starting from the beginning of the list.  This means that as soon as libnetwork frees a network, it will likely use the same subnet range for the next network that it allocates.   There is nothing wrong with this in principle, but it does have the effect of making debugging a bit more tedious at times when subnets overlap frequently in the logs.

This patch keeps a cursor per address space pointing to the subnet to consider next for allocation and on each successful search of the predefined pools, sets it to the the following subnet.  The algorithm is robust against changing predefined pool lists, resetting the cursor to zero whenever it is found to be outside of the valid range of pool indices.  The patch does not attempt to reset roll back the cursor should the allocator select a subnet, but then fail to allocate it for other reasons.  This means that it is possible for some subnets to be *temporarily* skipped in the face of other allocation errors.   However the cursor will eventually wrap back around and these subnets will get a chance for allocation at that point.

This patch also includes a unit test to confirm the new behavior.