### PR TITLE
Possible race on ingress programming

### DIFF
--- a/service_linux.go
+++ b/service_linux.go
@@ -279,7 +279,7 @@ const ingressChain = "DOCKER-INGRESS"
 
 var (
 	ingressOnce     sync.Once
-	ingressProxyMu  sync.Mutex
+	ingressMu       sync.Mutex // lock for operations on ingress
 	ingressProxyTbl = make(map[string]io.Closer)
 	portConfigMu    sync.Mutex
 	portConfigTbl   = make(map[PortConfig]int)
@@ -327,6 +327,9 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 	if isDelete {
 		addDelOpt = "-D"
 	}
+
+	ingressMu.Lock()
+	defer ingressMu.Unlock()
 
 	chainExists := iptables.ExistChain(ingressChain, iptables.Nat)
 	filterChainExists := iptables.ExistChain(ingressChain, iptables.Filter)
@@ -497,13 +500,11 @@ func plumbProxy(iPort *PortConfig, isDelete bool) error {
 
 	portSpec := fmt.Sprintf("%d/%s", iPort.PublishedPort, strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)]))
 	if isDelete {
-		ingressProxyMu.Lock()
 		if listener, ok := ingressProxyTbl[portSpec]; ok {
 			if listener != nil {
 				listener.Close()
 			}
 		}
-		ingressProxyMu.Unlock()
 
 		return nil
 	}
@@ -523,9 +524,7 @@ func plumbProxy(iPort *PortConfig, isDelete bool) error {
 		return err
 	}
 
-	ingressProxyMu.Lock()
 	ingressProxyTbl[portSpec] = l
-	ingressProxyMu.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
Make sure that iptables operations on ingress
are serialized.
Before 2 racing routines trying to create the ingress chain
were allowed and one was failing reporting the chain as
already existing.
The lock guarantees that this condition does not happen anymore

example log:
```
d4f707da69923fc1cbe4070efe65572cbe4b69e98ca228191fd p:0xc42144d600 nid:zgifl0o3uk6kdbn1321fe6agn skey:{3dwedosh75dk5cisy7iq3zpso 30000:80/TCP}"
Jun 07 07:07:37 master-1 dockerd[2758]: time="2018-06-07T07:07:37.133068284Z" level=debug msg="Firewalld passthrough: ipv4, [-t nat -nL DOCKER-INGRESS]"
Jun 07 07:07:37 master-1 dockerd[2758]: time="2018-06-07T07:07:37.134315246Z" level=debug msg="Firewalld passthrough: ipv4, [-t filter -nL DOCKER-INGRESS]"
Jun 07 07:07:37 master-1 dockerd[2758]: time="2018-06-07T07:07:37.139106851Z" level=debug msg="Firewalld passthrough: ipv4, [-t filter -nL DOCKER-INGRESS]"
Jun 07 07:07:37 master-1 dockerd[2758]: time="2018-06-07T07:07:37.142172440Z" level=debug msg="Firewalld passthrough: ipv4, [-t nat -N DOCKER-INGRESS]"
Jun 07 07:07:37 master-1 dockerd[2758]: time="2018-06-07T07:07:37.151081510Z" level=debug msg="Firewalld passthrough: ipv4, [-t nat -N DOCKER-INGRESS]"
Jun 07 07:07:37 master-1 dockerd[2758]: time="2018-06-07T07:07:37.153672170Z" level=debug msg="Firewalld passthrough: ipv4, [-N DOCKER-INGRESS]"
Jun 07 07:07:37 master-1 dockerd[2758]: time="2018-06-07T07:07:37.159365730Z" level=error msg="Failed to add ingress: failed to create ingress chain:  (COMMAND_FAILED: '/usr/sbin/iptables -w2 -t nat -N DOCKER-INGRESS' failed: iptables: Chain already exists.\n)"
```

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>