### PR TITLE
[18.03] Possible race on ingress programming

### DIFF
--- a/service_linux.go
+++ b/service_linux.go
@@ -279,7 +279,7 @@ const ingressChain = "DOCKER-INGRESS"
 
 var (
 	ingressOnce     sync.Once
-	ingressProxyMu  sync.Mutex
+	ingressMu       sync.Mutex // lock for operations on ingress
 	ingressProxyTbl = make(map[string]io.Closer)
 	portConfigMu    sync.Mutex
 	portConfigTbl   = make(map[PortConfig]int)
@@ -327,6 +327,9 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 	if isDelete {
 		addDelOpt = "-D"
 	}
+
+	ingressMu.Lock()
+	defer ingressMu.Unlock()
 
 	chainExists := iptables.ExistChain(ingressChain, iptables.Nat)
 	filterChainExists := iptables.ExistChain(ingressChain, iptables.Filter)
@@ -497,13 +500,11 @@ func plumbProxy(iPort *PortConfig, isDelete bool) error {
 
 	portSpec := fmt.Sprintf("%d/%s", iPort.PublishedPort, strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)]))
 	if isDelete {
-		ingressProxyMu.Lock()
 		if listener, ok := ingressProxyTbl[portSpec]; ok {
 			if listener != nil {
 				listener.Close()
 			}
 		}
-		ingressProxyMu.Unlock()
 
 		return nil
 	}
@@ -523,9 +524,7 @@ func plumbProxy(iPort *PortConfig, isDelete bool) error {
 		return err
 	}
 
-	ingressProxyMu.Lock()
 	ingressProxyTbl[portSpec] = l
-	ingressProxyMu.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2178 for the bump18.03 branch

```
git checkout -b 18.03-backport-race-ingress upstream/bump_18.03
git cherry-pick -s -S -x 7bb62d0172f8e676388d4d78e510c4d9fd4c1d06
git push -u origin
```

no conflicts

Make sure that iptables operations on ingress
are serialized.
Before 2 racing routines trying to create the ingress chain
were allowed and one was failing reporting the chain as
already existing.
The lock guarantees that this condition does not happen anymore

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>
(cherry picked from commit 7bb62d0172f8e676388d4d78e510c4d9fd4c1d06)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>