### PR TITLE
support.sh: add host links

### DIFF
--- a/support.sh
+++ b/support.sh
@@ -49,13 +49,14 @@ else
     NETINSPECT_VERBOSE_SUPPORT=""
 fi
 
-echo "Host Configuration"
+echo "Host iptables"
 echo_and_run ${IPTABLES} -w1 -n -v -L -t filter | grep -v '^$'
 echo_and_run ${IPTABLES} -w1 -n -v -L -t nat | grep -v '^$'
 echo_and_run ${IPTABLES} -w1 -n -v -L -t mangle | grep -v '^$'
 printf "\n"
 
-echo "Host addresses and routes"
+echo "Host links addresses and routes"
+echo_and_run ${IP} -o link show
 echo_and_run ${IP} -o -4 address show
 echo_and_run ${IP} -4 route show
 printf "\n"


### PR DESCRIPTION
also made the heading for host iptables state clearer

this is to facilitate troubleshooting of the following error from the Docker daemon:

```
Error response from daemon:  subnet sandbox join failed for "10.0.2.0/24":  error creating vxlan interface:  file exists
```

... where the proximate cause is typically temporary `vx-` interfaces lingering in the host namespace after dockerd restart.

Signed-off-by: Trapier Marshall <trapier.marshall@docker.com>