### PR TITLE
Dockerfile.build: Bump Go to 1.10.2

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.10
+FROM golang:1.10.2
 RUN apt-get update && apt-get -y install iptables
 
 RUN go get github.com/tools/godep \


### PR DESCRIPTION
This brings libnetwork up to date with moby/moby.

Signed-off-by: Euan Harris <euan.harris@docker.com>