### PR TITLE
Fix net driver response loss on createEndpoint

### DIFF
--- a/network.go
+++ b/network.go
@@ -1156,18 +1156,6 @@ func (n *network) createEndpoint(name string, options ...EndpointOption) (Endpoi
 			ep.releaseAddress()
 		}
 	}()
-	// Moving updateToSTore before calling addEndpoint so that we shall clean up VETH interfaces in case
-	// DockerD get killed between addEndpoint and updateSTore call
-	if err = n.getController().updateToStore(ep); err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err != nil {
-			if e := n.getController().deleteFromStore(ep); e != nil {
-				logrus.Warnf("error rolling back endpoint %s from store: %v", name, e)
-			}
-		}
-	}()
 
 	if err = n.addEndpoint(ep); err != nil {
 		return nil, err
@@ -1176,6 +1164,19 @@ func (n *network) createEndpoint(name string, options ...EndpointOption) (Endpoi
 		if err != nil {
 			if e := ep.deleteEndpoint(false); e != nil {
 				logrus.Warnf("cleaning up endpoint failed %s : %v", name, e)
+			}
+		}
+	}()
+
+	// We should perform updateToStore call right after addEndpoint
+	// in order to have iface properly configured
+	if err = n.getController().updateToStore(ep); err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			if e := n.getController().deleteFromStore(ep); e != nil {
+				logrus.Warnf("error rolling back endpoint %s from store: %v", name, e)
 			}
 		}
 	}()


### PR DESCRIPTION
Fix related to bug: https://github.com/docker/for-linux/issues/348
We should perform updateToStore(ep) after n.addEndpoint or do update twice, otherwise response from network plugin will not be written to KV storage. This results in container creation with broken network config.

Signed-off-by: Siarhei Rasiukevich <raskintech@gmail.com>