### PR TITLE
Fix duplicate ndots:0, and improve validation

### DIFF
--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -369,7 +369,7 @@ dnsOpt:
 						return fmt.Errorf("invalid ndots option %v", option)
 					}
 					if num, err := strconv.Atoi(parts[1]); err != nil {
-						return fmt.Errorf("invalid number for ndots option %v", option)
+						return fmt.Errorf("invalid number for ndots option: %v", parts[1])
 					} else if num >= 0 {
 						// if the user sets ndots, use the user setting
 						sb.ndotsSet = true

--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -370,7 +370,7 @@ dnsOpt:
 					}
 					if num, err := strconv.Atoi(parts[1]); err != nil {
 						return fmt.Errorf("invalid number for ndots option %v", option)
-					} else if num > 0 {
+					} else if num >= 0 {
 						// if the user sets ndots, use the user setting
 						sb.ndotsSet = true
 						break dnsOpt

--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -374,6 +374,8 @@ dnsOpt:
 						// if the user sets ndots, use the user setting
 						sb.ndotsSet = true
 						break dnsOpt
+					} else {
+						return fmt.Errorf("invalid number for ndots option: %v", num)
 					}
 				}
 			}

--- a/service_common_test.go
+++ b/service_common_test.go
@@ -97,4 +97,10 @@ func TestDNSOptions(t *testing.T) {
 	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
 	assert.Equal(t, 1, len(dnsOptionsList))
 	assert.Equal(t, "ndots:0", dnsOptionsList[0])
+
+	sb2.(*sandbox).config.dnsOptionsList = []string{"ndots:foobar"}
+	err = sb2.(*sandbox).setupDNS()
+	require.NoError(t, err)
+	err = sb2.(*sandbox).rebuildDNS()
+	require.EqualError(t, err, "invalid number for ndots option: foobar")
 }

--- a/service_common_test.go
+++ b/service_common_test.go
@@ -62,8 +62,8 @@ func TestDNSOptions(t *testing.T) {
 	currRC, err := resolvconf.GetSpecific(sb.(*sandbox).config.resolvConfPath)
 	require.NoError(t, err)
 	dnsOptionsList := resolvconf.GetOptions(currRC.Content)
-	assert.Equal(t, 1, len(dnsOptionsList), "There should be only 1 option instead:", dnsOptionsList)
-	assert.Equal(t, "ndots:0", dnsOptionsList[0], "The option must be ndots:0 instead:", dnsOptionsList[0])
+	assert.Equal(t, 1, len(dnsOptionsList))
+	assert.Equal(t, "ndots:0", dnsOptionsList[0])
 
 	sb.(*sandbox).config.dnsOptionsList = []string{"ndots:5"}
 	err = sb.(*sandbox).setupDNS()
@@ -71,14 +71,14 @@ func TestDNSOptions(t *testing.T) {
 	currRC, err = resolvconf.GetSpecific(sb.(*sandbox).config.resolvConfPath)
 	require.NoError(t, err)
 	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
-	assert.Equal(t, 1, len(dnsOptionsList), "There should be only 1 option instead:", dnsOptionsList)
-	assert.Equal(t, "ndots:5", dnsOptionsList[0], "The option must be ndots:5 instead:", dnsOptionsList[0])
+	assert.Equal(t, 1, len(dnsOptionsList))
+	assert.Equal(t, "ndots:5", dnsOptionsList[0])
 
 	err = sb.(*sandbox).rebuildDNS()
 	require.NoError(t, err)
 	currRC, err = resolvconf.GetSpecific(sb.(*sandbox).config.resolvConfPath)
 	require.NoError(t, err)
 	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
-	assert.Equal(t, 1, len(dnsOptionsList), "There should be only 1 option instead:", dnsOptionsList)
-	assert.Equal(t, "ndots:5", dnsOptionsList[0], "The option must be ndots:5 instead:", dnsOptionsList[0])
+	assert.Equal(t, 1, len(dnsOptionsList))
+	assert.Equal(t, "ndots:5", dnsOptionsList[0])
 }

--- a/service_common_test.go
+++ b/service_common_test.go
@@ -81,4 +81,20 @@ func TestDNSOptions(t *testing.T) {
 	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
 	assert.Equal(t, 1, len(dnsOptionsList))
 	assert.Equal(t, "ndots:5", dnsOptionsList[0])
+
+	sb2, err := c.(*controller).NewSandbox("cnt2", nil)
+	require.NoError(t, err)
+	defer sb2.Delete()
+	sb2.(*sandbox).startResolver(false)
+
+	sb2.(*sandbox).config.dnsOptionsList = []string{"ndots:0"}
+	err = sb2.(*sandbox).setupDNS()
+	require.NoError(t, err)
+	err = sb2.(*sandbox).rebuildDNS()
+	require.NoError(t, err)
+	currRC, err = resolvconf.GetSpecific(sb2.(*sandbox).config.resolvConfPath)
+	require.NoError(t, err)
+	dnsOptionsList = resolvconf.GetOptions(currRC.Content)
+	assert.Equal(t, 1, len(dnsOptionsList))
+	assert.Equal(t, "ndots:0", dnsOptionsList[0])
 }

--- a/service_common_test.go
+++ b/service_common_test.go
@@ -103,4 +103,10 @@ func TestDNSOptions(t *testing.T) {
 	require.NoError(t, err)
 	err = sb2.(*sandbox).rebuildDNS()
 	require.EqualError(t, err, "invalid number for ndots option: foobar")
+
+	sb2.(*sandbox).config.dnsOptionsList = []string{"ndots:-1"}
+	err = sb2.(*sandbox).setupDNS()
+	require.NoError(t, err)
+	err = sb2.(*sandbox).rebuildDNS()
+	require.EqualError(t, err, "invalid number for ndots option: -1")
 }


### PR DESCRIPTION
Addresses https://github.com/moby/moby/issues/37349

This PR has a couple of changes:

### 1. Remove redundant and faulty assert messages

The "message" argument in assert.Equal expects a format string; the current string was not that, resulting in an incorrect message being printed;

    --- FAIL: TestDNSOptions (1.28s)
            Location:       service_common_test.go:92
    	Error:  	Not equal: "ndots:5" (expected)
    			        != "ndots:0" (actual)
    	Messages:	The option must be ndots:5 instead:%!(EXTRA string=ndots:0)

This patch removes the message altogether, because assert.Equal already prints enough information to catch the error;

    --- FAIL: TestDNSOptions (1.28s)
            Location:       service_common_test.go:92
    	Error:  	Not equal: "ndots:5" (expected)
    			        != "ndots:0" (actual)


### 2. do not ignore user-provided "ndots:0" option

This is the actual fix: `ndots:0` is a valid DNS option; previously, `ndots:0` was ignored, leading to the default (`ndots:0`) also being applied;

Before this change:

    docker network create foo
    docker run --rm --network foo --dns-opt ndots:0 alpine cat /etc/resolv.conf
    nameserver 127.0.0.11
    options ndots:0 ndots:0

After this change:

    docker network create foo
    docker run --rm --network foo --dns-opt ndots:0 alpine cat /etc/resolv.conf
    nameserver 127.0.0.11
    options ndots:0

### 3. improve error message for invalid ndots number

Just a minor enhancement; instead of printing the whole option, print the _number_ only, because that's what the error-message is pointing at;

Before this change:

    invalid number for ndots option ndots:foobar

After this change:

    invalid number for ndots option: foobar


### 4. ndots: produce error on negative numbers

Prevent (e.g.) `ndots:-1` being silently ignored

