### PR TITLE
Fix error handling about bridgeSetup

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -614,9 +614,7 @@ func (d *driver) checkConflict(config *networkConfiguration) error {
 	return nil
 }
 
-func (d *driver) createNetwork(config *networkConfiguration) error {
-	var err error
-
+func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 	defer osl.InitOSContext()()
 
 	networkList := d.getNetworks()


### PR DESCRIPTION
Fix the error from bridgeSetup doesn't handle by the defer function in the createNetwork function.

Signed-off-by: Terry Chu <chut.twn@gmail.com>