### PR TITLE
[17.06] Updated handling of disable_ipv6 file

### DIFF
--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -590,6 +590,15 @@ func reexecSetIPv6() {
 		value = byte('0')
 	}
 
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			logrus.Warnf("file does not exist: %s : %v Has IPv6 been disabled in this node's kernel?", path, err)
+			os.Exit(0)
+		}
+		logrus.Errorf("failed to stat %s : %v", path, err)
+		os.Exit(5)
+	}
+
 	if err = ioutil.WriteFile(path, []byte{value, '\n'}, 0644); err != nil {
 		logrus.Errorf("failed to %s IPv6 forwarding for container's interface %s: %v", action, os.Args[2], err)
 		os.Exit(4)


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2122 for 17.06


```
git checkout -b 17.06-backport-esc-509 upstream/bump_17.06
git cherry-pick -s -S -x 618db13202f7f510dab67f54ddd879c6828eb761
git push -u origin
```

cherry-pick was clean, no conflicts


ping @quadespresso @fcrisciani @ctelfer PTAL