### PR TITLE
Spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Fix the handling for default gateway Endpoint join/leave.
 
 ## 0.7.0-rc.3 (2016-04-05)
-- Revert fix for default gateway endoint join/leave. Needs to be reworked.
+- Revert fix for default gateway endpoint join/leave. Needs to be reworked.
 - Persist the network internal mode for bridge networks
 
 ## 0.7.0-rc.2 (2016-04-05)

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ PB_FILES=$(PROTO_FILES:.proto=.pb.go)
 # Pattern rule for protoc.   If PROTOC_CHECK is defined, it checks
 # whether the generated files are up to date and fails if they are not
 %.pb.go: %.proto
-	if [ ${PROTOC_CHECK} ]; then \
+	@if [ ${PROTOC_CHECK} ]; then \
 	protoc ${PROTOC_FLAGS} --gogo_out=/tmp $< ; \
 	diff -q $@ /tmp/$@ >/dev/null || (echo "👹 $@ is out of date; please run 'make protobuf' and check in updates" && exit 1) ; \
 	else \

--- a/agent.go
+++ b/agent.go
@@ -194,7 +194,7 @@ func (c *controller) handleKeyChange(keys []*types.EncryptionKey) error {
 func (c *controller) agentSetup(clusterProvider cluster.Provider) error {
 	agent := c.getAgent()
 
-	// If the agent is already present there is no need to try to initilize it again
+	// If the agent is already present there is no need to try to initialize it again
 	if agent != nil {
 		return nil
 	}

--- a/bitseq/sequence.go
+++ b/bitseq/sequence.go
@@ -372,7 +372,7 @@ func (h *Handle) set(ordinal, start, end uint64, any bool, release bool, serial 
 			h.Lock()
 		}
 
-		// Previous atomic push was succesfull. Save private copy to local copy
+		// Previous atomic push was successful. Save private copy to local copy
 		h.unselected = nh.unselected
 		h.head = nh.head
 		h.dbExists = nh.dbExists

--- a/client/mflag/flag.go
+++ b/client/mflag/flag.go
@@ -1225,7 +1225,7 @@ func (v mergeVal) IsBoolFlag() bool {
 
 // Name returns the name of a mergeVal.
 // If the original value had a name, return the original name,
-// otherwise, return the key asinged to this mergeVal.
+// otherwise, return the key assigned to this mergeVal.
 func (v mergeVal) Name() string {
 	type namedValue interface {
 		Name() string

--- a/client/service.go
+++ b/client/service.go
@@ -96,7 +96,7 @@ func lookupServiceID(cli *NetworkCli, nwName, svNameID string) (string, error) {
 
 func lookupContainerID(cli *NetworkCli, cnNameID string) (string, error) {
 	// Container is a Docker resource, ask docker about it.
-	// In case of connecton error, we assume we are running in dnet and return whatever was passed to us
+	// In case of connection error, we assume we are running in dnet and return whatever was passed to us
 	obj, _, err := readBody(cli.call("GET", fmt.Sprintf("/containers/%s/json", cnNameID), nil, nil))
 	if err != nil {
 		// We are probably running outside of docker

--- a/controller.go
+++ b/controller.go
@@ -121,7 +121,7 @@ type NetworkController interface {
 	// Stop network controller
 	Stop()
 
-	// ReloadCondfiguration updates the controller configuration
+	// ReloadConfiguration updates the controller configuration
 	ReloadConfiguration(cfgOptions ...config.Option) error
 
 	// SetClusterProvider sets cluster provider

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -185,7 +185,7 @@ func Key(key ...string) string {
 func ParseKey(key string) ([]string, error) {
 	chain := strings.Split(strings.Trim(key, "/"), "/")
 
-	// The key must atleast be equal to the rootChain in order to be considered as valid
+	// The key must at least be equal to the rootChain in order to be considered as valid
 	if len(chain) <= len(rootChain) || !reflect.DeepEqual(chain[0:len(rootChain)], rootChain) {
 		return nil, types.BadRequestErrorf("invalid Key : %s", key)
 	}
@@ -589,7 +589,7 @@ func (ds *datastore) DeleteObject(kvObject KVObject) error {
 		defer ds.Unlock()
 	}
 
-	// cleaup the cache first
+	// cleanup the cache first
 	if ds.cache != nil {
 		// If persistent store is skipped, sequencing needs to
 		// happen in cache.
@@ -645,7 +645,7 @@ func (ds *datastore) DeleteTree(kvObject KVObject) error {
 		defer ds.Unlock()
 	}
 
-	// cleaup the cache first
+	// cleanup the cache first
 	if ds.cache != nil {
 		// If persistent store is skipped, sequencing needs to
 		// happen in cache.

--- a/datastore/mock_store.go
+++ b/datastore/mock_store.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	// ErrNotImplmented exported
-	ErrNotImplmented = errors.New("Functionality not implemented")
+	// ErrNotImplemented exported
+	ErrNotImplemented = errors.New("Functionality not implemented")
 )
 
 // MockData exported
@@ -65,7 +65,7 @@ func (s *MockStore) Exists(key string) (bool, error) {
 
 // List gets a range of values at "directory"
 func (s *MockStore) List(prefix string) ([]*store.KVPair, error) {
-	return nil, ErrNotImplmented
+	return nil, ErrNotImplemented
 }
 
 // DeleteTree deletes a range of values at "directory"
@@ -76,17 +76,17 @@ func (s *MockStore) DeleteTree(prefix string) error {
 
 // Watch a single key for modifications
 func (s *MockStore) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
-	return nil, ErrNotImplmented
+	return nil, ErrNotImplemented
 }
 
 // WatchTree triggers a watch on a range of values at "directory"
 func (s *MockStore) WatchTree(prefix string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
-	return nil, ErrNotImplmented
+	return nil, ErrNotImplemented
 }
 
 // NewLock exposed
 func (s *MockStore) NewLock(key string, options *store.LockOptions) (store.Locker, error) {
-	return nil, ErrNotImplmented
+	return nil, ErrNotImplemented
 }
 
 // AtomicPut put a value at "key" if the key has not been

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -7,7 +7,7 @@ For the semantics of driver methods, which correspond to the protocol below, ple
 
 ## LibNetwork integration with the Docker `plugins` package
 
-When LibNetwork initialises the `drivers.remote` package with the `Init()` function, it passes a `DriverCallback` as a parameter, which implements `RegisterDriver()`. The remote driver package uses this interface to register remote drivers with LibNetwork's `NetworkController`, by supplying it in a `plugins.Handle` callback.
+When LibNetwork initializes the `drivers.remote` package with the `Init()` function, it passes a `DriverCallback` as a parameter, which implements `RegisterDriver()`. The remote driver package uses this interface to register remote drivers with LibNetwork's `NetworkController`, by supplying it in a `plugins.Handle` callback.
 
 The callback is invoked when a driver is loaded with the `plugins.Get` API call. How that comes about is out of scope here (but it might be, for instance, when that driver is mentioned by the user).
 

--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -75,10 +75,10 @@ type Driver interface {
 	// DecodeTableEntry passes the driver a key, value pair from table it registered
 	// with libnetwork. Driver should return {object ID, map[string]string} tuple.
 	// If DecodeTableEntry is called for a table associated with NetworkObject or
-	// EndpointObject the return object ID should be the network id or endppoint id
+	// EndpointObject the return object ID should be the network id or endpoint id
 	// associated with that entry. map should have information about the object that
 	// can be presented to the user.
-	// For exampe: overlay driver returns the VTEP IP of the host that has the endpoint
+	// For example: overlay driver returns the VTEP IP of the host that has the endpoint
 	// which is shown in 'network inspect --verbose'
 	DecodeTableEntry(tablename string, key string, value []byte) (string, map[string]string)
 
@@ -97,7 +97,7 @@ type NetworkInfo interface {
 	TableEventRegister(tableName string, objType ObjectType) error
 }
 
-// InterfaceInfo provides a go interface for drivers to retrive
+// InterfaceInfo provides a go interface for drivers to retrieve
 // network information to interface resources.
 type InterfaceInfo interface {
 	// SetMacAddress allows the driver to set the mac address to the endpoint interface

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -104,7 +104,7 @@ type containerConfiguration struct {
 	ChildEndpoints  []string
 }
 
-// cnnectivityConfiguration represents the user specified configuration regarding the external connectivity
+// connectivityConfiguration represents the user specified configuration regarding the external connectivity
 type connectivityConfiguration struct {
 	PortBindings []types.PortBinding
 	ExposedPorts []types.TransportPort

--- a/drivers/bridge/network_test.go
+++ b/drivers/bridge/network_test.go
@@ -53,7 +53,7 @@ func TestLinkCreate(t *testing.T) {
 		t.Fatalf("Failed to create a link: %s", err.Error())
 	}
 
-	// Verify sbox endoint interface inherited MTU value from bridge config
+	// Verify sbox endpoint interface inherited MTU value from bridge config
 	sboxLnk, err := netlink.LinkByName(te.iface.srcName)
 	if err != nil {
 		t.Fatal(err)
@@ -167,7 +167,7 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 
 	iface := te.iface
 	if iface.addrv6 != nil && iface.addrv6.IP.To16() != nil {
-		t.Fatalf("Expectd IPv6 address to be nil when IPv6 is not enabled. Got IPv6 = %s", iface.addrv6.String())
+		t.Fatalf("Expected IPv6 address to be nil when IPv6 is not enabled. Got IPv6 = %s", iface.addrv6.String())
 	}
 
 	if te.gw6.To16() != nil {

--- a/drivers/ipvlan/ipvlan_joinleave.go
+++ b/drivers/ipvlan/ipvlan_joinleave.go
@@ -84,7 +84,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 			}
 			v4gw, _, err := net.ParseCIDR(s.GwIP)
 			if err != nil {
-				return fmt.Errorf("gatway %s is not a valid ipv4 address: %v", s.GwIP, err)
+				return fmt.Errorf("gateway %s is not a valid ipv4 address: %v", s.GwIP, err)
 			}
 			err = jinfo.SetGateway(v4gw)
 			if err != nil {
@@ -101,7 +101,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 			}
 			v6gw, _, err := net.ParseCIDR(s.GwIP)
 			if err != nil {
-				return fmt.Errorf("gatway %s is not a valid ipv6 address: %v", s.GwIP, err)
+				return fmt.Errorf("gateway %s is not a valid ipv6 address: %v", s.GwIP, err)
 			}
 			err = jinfo.SetGatewayIPv6(v6gw)
 			if err != nil {

--- a/drivers/ipvlan/ipvlan_network.go
+++ b/drivers/ipvlan/ipvlan_network.go
@@ -68,7 +68,7 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 	err = d.storeUpdate(config)
 	if err != nil {
 		d.deleteNetwork(config.ID)
-		logrus.Debugf("encoutered an error rolling back a network create for %s : %v", config.ID, err)
+		logrus.Debugf("encountered an error rolling back a network create for %s : %v", config.ID, err)
 		return err
 	}
 
@@ -92,7 +92,7 @@ func (d *driver) createNetwork(config *configuration) error {
 				return err
 			}
 			config.CreatedSlaveLink = true
-			// notify the user in logs they have limited comunicatins
+			// notify the user in logs they have limited communications
 			if config.Parent == getDummyName(stringid.TruncateID(config.ID)) {
 				logrus.Debugf("Empty -o parent= and --internal flags limit communications to other containers inside of network: %s",
 					config.Parent)

--- a/drivers/ipvlan/ipvlan_setup.go
+++ b/drivers/ipvlan/ipvlan_setup.go
@@ -30,7 +30,7 @@ func createIPVlan(containerIfName, parent, ipvlanMode string) (string, error) {
 	// Get the link for the master index (Example: the docker host eth iface)
 	parentLink, err := ns.NlHandle().LinkByName(parent)
 	if err != nil {
-		return "", fmt.Errorf("error occoured looking up the %s parent iface %s error: %s", ipvlanType, parent, err)
+		return "", fmt.Errorf("error occurred looking up the %s parent iface %s error: %s", ipvlanType, parent, err)
 	}
 	// Create an ipvlan link
 	ipvlan := &netlink.IPVlan{
@@ -169,7 +169,7 @@ func createDummyLink(dummyName, truncNetID string) error {
 	}
 	parentDummyLink, err := ns.NlHandle().LinkByName(dummyName)
 	if err != nil {
-		return fmt.Errorf("error occoured looking up the %s parent iface %s error: %s", ipvlanType, dummyName, err)
+		return fmt.Errorf("error occurred looking up the %s parent iface %s error: %s", ipvlanType, dummyName, err)
 	}
 	// bring the new netlink iface up
 	if err := ns.NlHandle().LinkSetUp(parentDummyLink); err != nil {

--- a/drivers/ipvlan/ipvlan_state.go
+++ b/drivers/ipvlan/ipvlan_state.go
@@ -31,7 +31,7 @@ func (d *driver) deleteNetwork(nid string) {
 	d.Unlock()
 }
 
-// getNetworks Safely returns a slice of existng networks
+// getNetworks Safely returns a slice of existing networks
 func (d *driver) getNetworks() []*network {
 	d.Lock()
 	defer d.Unlock()

--- a/drivers/macvlan/macvlan_joinleave.go
+++ b/drivers/macvlan/macvlan_joinleave.go
@@ -46,7 +46,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		}
 		v4gw, _, err := net.ParseCIDR(s.GwIP)
 		if err != nil {
-			return fmt.Errorf("gatway %s is not a valid ipv4 address: %v", s.GwIP, err)
+			return fmt.Errorf("gateway %s is not a valid ipv4 address: %v", s.GwIP, err)
 		}
 		err = jinfo.SetGateway(v4gw)
 		if err != nil {
@@ -63,7 +63,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		}
 		v6gw, _, err := net.ParseCIDR(s.GwIP)
 		if err != nil {
-			return fmt.Errorf("gatway %s is not a valid ipv6 address: %v", s.GwIP, err)
+			return fmt.Errorf("gateway %s is not a valid ipv6 address: %v", s.GwIP, err)
 		}
 		err = jinfo.SetGatewayIPv6(v6gw)
 		if err != nil {

--- a/drivers/macvlan/macvlan_network.go
+++ b/drivers/macvlan/macvlan_network.go
@@ -72,7 +72,7 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 	err = d.storeUpdate(config)
 	if err != nil {
 		d.deleteNetwork(config.ID)
-		logrus.Debugf("encoutered an error rolling back a network create for %s : %v", config.ID, err)
+		logrus.Debugf("encountered an error rolling back a network create for %s : %v", config.ID, err)
 		return err
 	}
 
@@ -96,7 +96,7 @@ func (d *driver) createNetwork(config *configuration) error {
 				return err
 			}
 			config.CreatedSlaveLink = true
-			// notify the user in logs they have limited comunicatins
+			// notify the user in logs they have limited communications
 			if config.Parent == getDummyName(stringid.TruncateID(config.ID)) {
 				logrus.Debugf("Empty -o parent= and --internal flags limit communications to other containers inside of network: %s",
 					config.Parent)

--- a/drivers/macvlan/macvlan_setup.go
+++ b/drivers/macvlan/macvlan_setup.go
@@ -30,7 +30,7 @@ func createMacVlan(containerIfName, parent, macvlanMode string) (string, error) 
 	// Get the link for the master index (Example: the docker host eth iface)
 	parentLink, err := ns.NlHandle().LinkByName(parent)
 	if err != nil {
-		return "", fmt.Errorf("error occoured looking up the %s parent iface %s error: %s", macvlanType, parent, err)
+		return "", fmt.Errorf("error occurred looking up the %s parent iface %s error: %s", macvlanType, parent, err)
 	}
 	// Create a macvlan link
 	macvlan := &netlink.Macvlan{
@@ -173,7 +173,7 @@ func createDummyLink(dummyName, truncNetID string) error {
 	}
 	parentDummyLink, err := ns.NlHandle().LinkByName(dummyName)
 	if err != nil {
-		return fmt.Errorf("error occoured looking up the %s parent iface %s error: %s", macvlanType, dummyName, err)
+		return fmt.Errorf("error occurred looking up the %s parent iface %s error: %s", macvlanType, dummyName, err)
 	}
 	// bring the new netlink iface up
 	if err := ns.NlHandle().LinkSetUp(parentDummyLink); err != nil {

--- a/drivers/overlay/encryption.go
+++ b/drivers/overlay/encryption.go
@@ -601,7 +601,7 @@ func (n *network) maxMTU() int {
 	mtu -= vxlanEncap
 	if n.secure {
 		// In case of encryption account for the
-		// esp packet espansion and padding
+		// esp packet expansion and padding
 		mtu -= pktExpansion
 		mtu -= (mtu % 4)
 	}

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -115,11 +115,11 @@ func TestOverlayConfig(t *testing.T) {
 
 	d := dt.d
 	if d.notifyCh == nil {
-		t.Fatal("Driver notify channel wasn't initialzed after Config method")
+		t.Fatal("Driver notify channel wasn't initialized after Config method")
 	}
 
 	if d.exitCh == nil {
-		t.Fatal("Driver serfloop exit channel wasn't initialzed after Config method")
+		t.Fatal("Driver serfloop exit channel wasn't initialized after Config method")
 	}
 
 	if d.serfInstance == nil {

--- a/drivers/remote/api/api.go
+++ b/drivers/remote/api/api.go
@@ -150,7 +150,7 @@ type JoinRequest struct {
 	Options    map[string]interface{}
 }
 
-// InterfaceName is the struct represetation of a pair of devices with source
+// InterfaceName is the struct representation of a pair of devices with source
 // and destination, for the purposes of putting an endpoint into a container.
 type InterfaceName struct {
 	SrcName   string

--- a/drvregistry/drvregistry.go
+++ b/drvregistry/drvregistry.go
@@ -54,7 +54,7 @@ type IPAMNotifyFunc func(name string, driver ipamapi.Ipam, cap *ipamapi.Capabili
 // DriverNotifyFunc defines the notify function signature when a new network driver gets registered.
 type DriverNotifyFunc func(name string, driver driverapi.Driver, capability driverapi.Capability) error
 
-// New retruns a new driver registry handle.
+// New returns a new driver registry handle.
 func New(lDs, gDs interface{}, dfn DriverNotifyFunc, ifn IPAMNotifyFunc, pg plugingetter.PluginGetter) (*DrvRegistry, error) {
 	r := &DrvRegistry{
 		drivers:      make(driverTable),

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -1104,7 +1104,7 @@ func TestRelease(t *testing.T) {
 			{"192.168.1.254"},
 		}
 
-		// One by one, relase the address and request again. We should get the same IP
+		// One by one, release the address and request again. We should get the same IP
 		for i, inp := range toRelease {
 			ip0 := net.ParseIP(inp.address)
 			a.ReleaseAddress(pid, ip0)

--- a/iptables/firewalld.go
+++ b/iptables/firewalld.go
@@ -66,7 +66,7 @@ func newConnection() (*Conn, error) {
 	return c, nil
 }
 
-// Innitialize D-Bus connection.
+// Initialize D-Bus connection.
 func (c *Conn) initConnection() error {
 	var err error
 

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -477,7 +477,7 @@ func raw(args ...string) ([]byte, error) {
 	return filterOutput(startTime, output, args...), err
 }
 
-// RawCombinedOutput inernally calls the Raw function and returns a non nil
+// RawCombinedOutput internally calls the Raw function and returns a non nil
 // error if Raw returned a non nil error or a non empty output
 func RawCombinedOutput(args ...string) error {
 	if output, err := Raw(args...); err != nil || len(output) != 0 {

--- a/ipvs/netlink.go
+++ b/ipvs/netlink.go
@@ -100,7 +100,7 @@ func fillService(s *Service) nl.NetlinkRequestData {
 	return cmdAttr
 }
 
-func fillDestinaton(d *Destination) nl.NetlinkRequestData {
+func fillDestination(d *Destination) nl.NetlinkRequestData {
 	cmdAttr := nl.NewRtAttr(ipvsCmdAttrDest, nil)
 
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrAddress, rawIPData(d.Address))
@@ -134,7 +134,7 @@ func (i *Handle) doCmdwithResponse(s *Service, d *Destination, cmd uint8) ([][]b
 		}
 
 	} else {
-		req.AddData(fillDestinaton(d))
+		req.AddData(fillDestination(d))
 	}
 
 	res, err := execute(i.sock, req, 0)

--- a/libnetwork_linux_test.go
+++ b/libnetwork_linux_test.go
@@ -919,7 +919,7 @@ func runParallelTests(t *testing.T, thrNumber int) {
 			t.Fatal(err)
 		}
 	}
-	defer netns.Set(origns)
+	defer netns.Set(origins)
 
 	net1, err := controller.NetworkByName("testhost")
 	if err != nil {

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -1410,12 +1410,12 @@ func TestValidRemoteDriver(t *testing.T) {
 }
 
 var (
-	once   sync.Once
-	start  = make(chan struct{})
-	done   = make(chan chan struct{}, numThreads-1)
-	origns = netns.None()
-	testns = netns.None()
-	sboxes = make([]libnetwork.Sandbox, numThreads)
+	once    sync.Once
+	start   = make(chan struct{})
+	done    = make(chan chan struct{}, numThreads-1)
+	origins = netns.None()
+	testns  = netns.None()
+	sboxes  = make([]libnetwork.Sandbox, numThreads)
 )
 
 const (
@@ -1430,13 +1430,13 @@ func createGlobalInstance(t *testing.T) {
 	var err error
 	defer close(start)
 
-	origns, err = netns.Get()
+	origins, err = netns.Get()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if testutils.IsRunningInContainer() {
-		testns = origns
+		testns = origins
 	} else {
 		testns, err = netns.New()
 		if err != nil {

--- a/netutils/utils_test.go
+++ b/netutils/utils_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func TestNonOverlapingNameservers(t *testing.T) {
+func TestNonOverlappingNameservers(t *testing.T) {
 	network := &net.IPNet{
 		IP:   []byte{192, 168, 0, 1},
 		Mask: []byte{255, 255, 255, 0},
@@ -26,7 +26,7 @@ func TestNonOverlapingNameservers(t *testing.T) {
 	}
 }
 
-func TestOverlapingNameservers(t *testing.T) {
+func TestOverlappingNameservers(t *testing.T) {
 	network := &net.IPNet{
 		IP:   []byte{192, 168, 0, 1},
 		Mask: []byte{255, 255, 255, 0},
@@ -260,7 +260,7 @@ func TestNetworkRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !types.CompareIPNet(exp, nw) {
-		t.Fatalf("exected %s. got %s", exp, nw)
+		t.Fatalf("expected %s. got %s", exp, nw)
 	}
 }
 

--- a/network.go
+++ b/network.go
@@ -88,7 +88,7 @@ type NetworkInfo interface {
 type EndpointWalker func(ep Endpoint) bool
 
 // ipInfo is the reverse mapping from IP to service name to serve the PTR query.
-// extResolver is set if an externl server resolves a service name to this IP.
+// extResolver is set if an external server resolves a service name to this IP.
 // Its an indication to defer PTR queries also to that external server.
 type ipInfo struct {
 	name        string
@@ -1654,7 +1654,7 @@ func (n *network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {
 					return types.BadRequestErrorf("non parsable secondary ip address (%s:%s) passed for network %s", k, v, n.Name())
 				}
 				if !d.Pool.Contains(ip) {
-					return types.ForbiddenErrorf("auxilairy address: (%s:%s) must belong to the master pool: %s", k, v, d.Pool)
+					return types.ForbiddenErrorf("auxiliary address: (%s:%s) must belong to the master pool: %s", k, v, d.Pool)
 				}
 				// Attempt reservation in the container addressable pool, silent the error if address does not belong to that pool
 				if d.IPAMData.AuxAddresses[k], _, err = ipam.RequestAddress(d.PoolID, ip, nil); err != nil && err != ipamapi.ErrIPOutOfRange {
@@ -2036,7 +2036,7 @@ func (n *network) ResolveService(name string) ([]*net.SRV, []net.IP) {
 
 	logrus.Debugf("Service name To resolve: %v", name)
 
-	// There are DNS implementaions that allow SRV queries for names not in
+	// There are DNS implementations that allow SRV queries for names not in
 	// the format defined by RFC 2782. Hence specific validations checks are
 	// not done
 	parts := strings.Split(name, ".")

--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -243,7 +243,7 @@ func (nDB *NetworkDB) clusterLeave() error {
 }
 
 func (nDB *NetworkDB) triggerFunc(stagger time.Duration, C <-chan time.Time, f func()) {
-	// Use a random stagger to avoid syncronizing
+	// Use a random stagger to avoid synchronizing
 	randStagger := time.Duration(uint64(rnd.Int63()) % uint64(stagger))
 	select {
 	case <-time.After(randStagger):

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -58,7 +58,7 @@ type NetworkDB struct {
 	// List of all peer nodes which have left
 	leftNodes map[string]*node
 
-	// A multi-dimensional map of network/node attachmemts. The
+	// A multi-dimensional map of network/node attachments. The
 	// first key is a node name and the second key is a network ID
 	// for the network that node is participating in.
 	networks map[string]map[string]*network
@@ -153,7 +153,7 @@ type network struct {
 	entriesNumber int
 }
 
-// Config represents the configuration of the networdb instance and
+// Config represents the configuration of the networkdb instance and
 // can be passed by the caller.
 type Config struct {
 	// NodeID is the node unique identifier of the node when is part of the cluster

--- a/networkdb/networkdb.pb.go
+++ b/networkdb/networkdb.pb.go
@@ -48,7 +48,7 @@ type MessageType int32
 
 const (
 	MessageTypeInvalid MessageType = 0
-	// NetworEvent message type is used to communicate network
+	// NetworkEvent message type is used to communicate network
 	// attachments on the node.
 	MessageTypeNetworkEvent MessageType = 1
 	// TableEvent message type is used to communicate any table
@@ -66,7 +66,7 @@ const (
 	// which is a pack of many message of above types, packed into
 	// a single compound message.
 	MessageTypeCompound MessageType = 5
-	// NodeEvent message type is used to communicare node
+	// NodeEvent message type is used to communicate node
 	// join/leave events in the cluster
 	MessageTypeNodeEvent MessageType = 6
 )

--- a/networkdb/networkdb.proto
+++ b/networkdb/networkdb.proto
@@ -19,7 +19,7 @@ enum MessageType {
 
 	INVALID = 0 [(gogoproto.enumvalue_customname) = "MessageTypeInvalid"];
 
-	// NetworEvent message type is used to communicate network
+	// NetworkEvent message type is used to communicate network
 	// attachments on the node.
 	NETWORK_EVENT = 1 [(gogoproto.enumvalue_customname) = "MessageTypeNetworkEvent"];
 
@@ -42,7 +42,7 @@ enum MessageType {
 	// a single compound message.
 	COMPOUND = 5 [(gogoproto.enumvalue_customname) = "MessageTypeCompound"];
 
-	// NodeEvent message type is used to communicare node
+	// NodeEvent message type is used to communicate node
 	// join/leave events in the cluster
 	NODE_EVENT = 6 [(gogoproto.enumvalue_customname) = "MessageTypeNodeEvent"];
 }

--- a/osl/sandbox_linux_test.go
+++ b/osl/sandbox_linux_test.go
@@ -119,7 +119,7 @@ func newInfo(hnd *netlink.Handle, t *testing.T) (Sandbox, error) {
 func verifySandbox(t *testing.T, s Sandbox, ifaceSuffixes []string) {
 	_, ok := s.(*networkNamespace)
 	if !ok {
-		t.Fatalf("The sandox interface returned is not of type networkNamespace")
+		t.Fatalf("The sandbox interface returned is not of type networkNamespace")
 	}
 
 	sbNs, err := netns.GetFromPath(s.Key())

--- a/resolver.go
+++ b/resolver.go
@@ -35,7 +35,7 @@ type Resolver interface {
 }
 
 // DNSBackend represents a backend DNS resolver used for DNS name
-// resolution. All the queries to the resolver are forwared to the
+// resolution. All the queries to the resolver are forwarded to the
 // backend resolver.
 type DNSBackend interface {
 	// ResolveName resolves a service name to an IPv4 or IPv6 address by searching

--- a/sandbox.go
+++ b/sandbox.go
@@ -467,7 +467,7 @@ func (sb *sandbox) ResolveService(name string) ([]*net.SRV, []net.IP) {
 
 	logrus.Debugf("Service name To resolve: %v", name)
 
-	// There are DNS implementaions that allow SRV queries for names not in
+	// There are DNS implementations that allow SRV queries for names not in
 	// the format defined by RFC 2782. Hence specific validations checks are
 	// not done
 	parts := strings.Split(name, ".")

--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -241,7 +241,7 @@ func (sb *sandbox) setupDNS() error {
 		sb.setExternalResolvers(newRC.Content, types.IPv4, false)
 	} else {
 		// If the host resolv.conf file has 127.0.0.x container should
-		// use the host restolver for queries. This is supported by the
+		// use the host resolver for queries. This is supported by the
 		// docker embedded DNS server. Hence save the external resolvers
 		// before filtering it out.
 		sb.setExternalResolvers(currRC.Content, types.IPv4, true)

--- a/service_linux.go
+++ b/service_linux.go
@@ -27,7 +27,7 @@ import (
 
 func init() {
 	reexec.Register("fwmarker", fwMarker)
-	reexec.Register("redirecter", redirecter)
+	reexec.Register("redirector", redirector)
 }
 
 // Populate all loadbalancers on the network that the passed endpoint
@@ -431,7 +431,7 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 // DOCKER-USER so the user is able to filter packet first.
 // The second rule should be jump to INGRESS-CHAIN.
 // This chain has the rules to allow access to the published ports for swarm tasks
-// from local bridge networks and docker_gwbridge (ie:taks on other swarm netwroks)
+// from local bridge networks and docker_gwbridge (ie:taks on other swarm networks)
 func arrangeIngressFilterRule() {
 	if iptables.ExistChain(ingressChain, iptables.Filter) {
 		if iptables.Exists(iptables.Filter, "FORWARD", "-j", ingressChain) {
@@ -668,7 +668,7 @@ func addRedirectRules(path string, eIP *net.IPNet, ingressPorts []*PortConfig) e
 
 	cmd := &exec.Cmd{
 		Path:   reexec.Self(),
-		Args:   append([]string{"redirecter"}, path, eIP.String(), ingressPortsFile),
+		Args:   append([]string{"redirector"}, path, eIP.String(), ingressPortsFile),
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 	}
@@ -680,8 +680,8 @@ func addRedirectRules(path string, eIP *net.IPNet, ingressPorts []*PortConfig) e
 	return nil
 }
 
-// Redirecter reexec function.
-func redirecter() {
+// Redirector reexec function.
+func redirector() {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 

--- a/test/integration/dnet/bridge.bats
+++ b/test/integration/dnet/bridge.bats
@@ -289,17 +289,17 @@ function test_single_network_connectivity() {
     echo $(docker ps)
     dnet_cmd $(inst_id2port 1) network create -d bridge --internal internal
     dnet_cmd $(inst_id2port 1) container create container_1
-    # connects to internal network, confirm it can't conmunicate with outside world
+    # connects to internal network, confirm it can't communicate with outside world
     net_connect 1 container_1 internal
     run runc $(dnet_container_name 1 bridge) $(get_sbox_id 1 container_1) "ping -c 1 8.8.8.8"
     [[ "$output" == *"1 packets transmitted, 0 packets received, 100% packet loss"* ]]
     net_disconnect 1 container_1 internal
-    # connects to bridge network, confirm it can conmunicate with outside world
+    # connects to bridge network, confirm it can communicate with outside world
     net_connect 1 container_1 bridge
     runc $(dnet_container_name 1 bridge) $(get_sbox_id 1 container_1) "ping -c 1 8.8.8.8"
     net_disconnect 1 container_1 bridge
     dnet_cmd $(inst_id2port 1) container rm container_1
-    # test conmunications within internal network
+    # test communications within internal network
     test_single_network_connectivity internal 3
     dnet_cmd $(inst_id2port 1) network rm internal
 }


### PR DESCRIPTION
Carried over: https://github.com/docker/libnetwork/pull/1773
And hidden output of check-protobuf: 
```
if [ 1 ]; then \                                                                         
protoc -I=. -I=/go/src -I=/go/src/github.com/gogo/protobuf -I=/go/src/github.com/gogo/protobuf/protobuf --gogo_out=/tmp networkdb/networkdb.proto ; \
diff -q networkdb/networkdb.pb.go /tmp/networkdb/networkdb.pb.go >/dev/null || (echo "👹 networkdb/networkdb.pb.go is out of date; please run 'make protobuf' and check in updates" && exit 1) ; \
else \                                                                                                                                                                                                              protoc -I=. -I=/go/src -I=/go/src/github.com/gogo/protobuf -I=/go/src/github.com/gogo/protobuf/protobuf --gogo_out=./ networkdb/networkdb.proto ; \                                                                
fi                                                                               
if [ 1 ]; then \                                                             
protoc -I=. -I=/go/src -I=/go/src/github.com/gogo/protobuf -I=/go/src/github.com/gogo/protobuf/protobuf --gogo_out=/tmp drivers/windows/overlay/overlay.proto ; \
diff -q drivers/windows/overlay/overlay.pb.go /tmp/drivers/windows/overlay/overlay.pb.go >/dev/null || (echo "👹 drivers/windows/overlay/overlay.pb.go is out of date; please run 'make protobuf' and check in updat
es" && exit 1) ; \                                                                       
else \                                                                       
protoc -I=. -I=/go/src -I=/go/src/github.com/gogo/protobuf -I=/go/src/github.com/gogo/protobuf/protobuf --gogo_out=./ drivers/windows/overlay/overlay.proto ; \                                                     
fi                                                                                                                                                                                                                  
if [ 1 ]; then \                                                                                                        
protoc -I=. -I=/go/src -I=/go/src/github.com/gogo/protobuf -I=/go/src/github.com/gogo/protobuf/protobuf --gogo_out=/tmp drivers/overlay/overlay.proto ; \
diff -q drivers/overlay/overlay.pb.go /tmp/drivers/overlay/overlay.pb.go >/dev/null || (echo "👹 drivers/overlay/overlay.pb.go is out of date; please run 'make protobuf' and check in updates" && exit 1) ; \
else \                                                                                   
protoc -I=. -I=/go/src -I=/go/src/github.com/gogo/protobuf -I=/go/src/github.com/gogo/protobuf/protobuf --gogo_out=./ drivers/overlay/overlay.proto ; \
fi                                                             
if [ 1 ]; then \                                                                                                                                                                                                    
protoc -I=. -I=/go/src -I=/go/src/github.com/gogo/protobuf -I=/go/src/github.com/gogo/protobuf/protobuf --gogo_out=/tmp agent.proto ; \
diff -q agent.pb.go /tmp/agent.pb.go >/dev/null || (echo "👹 agent.pb.go is out of date; please run 'make protobuf' and check in updates" && exit 1) ; \
else \                                                              
protoc -I=. -I=/go/src -I=/go/src/github.com/gogo/protobuf -I=/go/src/github.com/gogo/protobuf/protobuf --gogo_out=./ agent.proto ; \
fi                                             
```