### PR TITLE
Moving IPVLAN driver out of experimental

### DIFF
--- a/drivers_experimental_linux.go
+++ b/drivers_experimental_linux.go
@@ -1,9 +1,5 @@
 package libnetwork
 
-import "github.com/docker/libnetwork/drivers/ipvlan"
-
 func additionalDrivers() []initializer {
-	return []initializer{
-		{ipvlan.Init, "ipvlan"},
-	}
+	return []initializer{}
 }

--- a/drivers_experimental_linux.go
+++ b/drivers_experimental_linux.go
@@ -1,5 +1,0 @@
-package libnetwork
-
-func additionalDrivers() []initializer {
-	return []initializer{}
-}

--- a/drivers_linux.go
+++ b/drivers_linux.go
@@ -3,6 +3,7 @@ package libnetwork
 import (
 	"github.com/docker/libnetwork/drivers/bridge"
 	"github.com/docker/libnetwork/drivers/host"
+	"github.com/docker/libnetwork/drivers/ipvlan"
 	"github.com/docker/libnetwork/drivers/macvlan"
 	"github.com/docker/libnetwork/drivers/null"
 	"github.com/docker/libnetwork/drivers/overlay"
@@ -13,10 +14,11 @@ func getInitializers(experimental bool) []initializer {
 	in := []initializer{
 		{bridge.Init, "bridge"},
 		{host.Init, "host"},
+		{ipvlan.Init, "ipvlan"},
 		{macvlan.Init, "macvlan"},
 		{null.Init, "null"},
-		{remote.Init, "remote"},
 		{overlay.Init, "overlay"},
+		{remote.Init, "remote"},
 	}
 
 	if experimental {

--- a/drivers_linux.go
+++ b/drivers_linux.go
@@ -20,9 +20,5 @@ func getInitializers(experimental bool) []initializer {
 		{overlay.Init, "overlay"},
 		{remote.Init, "remote"},
 	}
-
-	if experimental {
-		in = append(in, additionalDrivers()...)
-	}
 	return in
 }


### PR DESCRIPTION
IPVLAN driver had been retained in experimental for multiple releases
with the requirement to have a proper L3 control-plane (such as BGP) to
go along with it which will make this driver much more useful. But
based on the community feedback,
https://github.com/moby/moby/issues/21735, am proposing to move this
driver out of experimental.

Signed-off-by: Madhu Venugopal <madhu@docker.com>