### PR TITLE
Add support for Internal and Private network types on windows

### DIFF
--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -109,7 +109,10 @@ const (
 
 // IsBuiltinLocalDriver validates if network-type is a builtin local-scoped driver
 func IsBuiltinLocalDriver(networkType string) bool {
-	if "l2bridge" == networkType || "l2tunnel" == networkType || "nat" == networkType || "ics" == networkType || "transparent" == networkType {
+	if "l2bridge" == networkType || "l2tunnel" == networkType ||
+		"nat" == networkType || "ics" == networkType ||
+		"transparent" == networkType || "internal" == networkType ||
+		"private" == networkType {
 		return true
 	}
 

--- a/drivers_windows.go
+++ b/drivers_windows.go
@@ -16,6 +16,8 @@ func getInitializers(experimental bool) []initializer {
 		{windows.GetInit("l2bridge"), "l2bridge"},
 		{windows.GetInit("l2tunnel"), "l2tunnel"},
 		{windows.GetInit("nat"), "nat"},
+		{windows.GetInit("internal"), "internal"},
+		{windows.GetInit("private"), "private"},
 		{windows.GetInit("ics"), "ics"},
 	}
 }


### PR DESCRIPTION
In windows we have supported these two additional types since RS1.

Internal network allows inter container connectivity with support for host/container communication.
Private network allows just inter container connectivity.

This PR enables these two networking modes on windows