### PR TITLE
Give LB sandboxes predictable names

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -1107,6 +1107,8 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 		sb.config.hostsPath = filepath.Join(c.cfg.Daemon.DataDir, "/network/files/hosts")
 		sb.config.resolvConfPath = filepath.Join(c.cfg.Daemon.DataDir, "/network/files/resolv.conf")
 		sb.id = "ingress_sbox"
+	} else if sb.loadBalancerNID != "" {
+		sb.id = "lb_" + sb.loadBalancerNID
 	}
 	c.Unlock()
 

--- a/network.go
+++ b/network.go
@@ -2126,7 +2126,7 @@ func (n *network) lbEndpointName() string {
 func (n *network) createLoadBalancerSandbox() (retErr error) {
 	sandboxName := n.lbSandboxName()
 	// Mark the sandbox to be a load balancer
-	sbOptions := []SandboxOption{OptionLoadBalancer()}
+	sbOptions := []SandboxOption{OptionLoadBalancer(n.id)}
 	if n.ingress {
 		sbOptions = append(sbOptions, OptionIngress())
 	}

--- a/sandbox.go
+++ b/sandbox.go
@@ -84,6 +84,7 @@ type sandbox struct {
 	ingress            bool
 	ndotsSet           bool
 	oslTypes           []osl.SandboxType // slice of properties of this sandbox
+	loadBalancerNID    string            // NID that this SB is a load balancer for
 	sync.Mutex
 	// This mutex is used to serialize service related operation for an endpoint
 	// The lock is here because the endpoint is saved into the store so is not unique
@@ -1169,8 +1170,9 @@ func OptionIngress() SandboxOption {
 
 // OptionLoadBalancer function returns an option setter for marking a
 // sandbox as a load balancer sandbox.
-func OptionLoadBalancer() SandboxOption {
+func OptionLoadBalancer(nid string) SandboxOption {
 	return func(sb *sandbox) {
+		sb.loadBalancerNID = nid
 		sb.oslTypes = append(sb.oslTypes, osl.SandboxTypeLoadBalancer)
 	}
 }


### PR DESCRIPTION
Change the sandbox IDs for the sandboxes of load-balancing endpoints to be "lb_XXXXXXXXX" where XXXXXXXXX is the first 9 characters of the network ID that this sandbox load balances for.  This makes it easier to find these sandboxes in /var/run/docker/netns and thus makes debugging easier.

Signed-off-by: Chris Telfer <ctelfer@docker.com>