### PR TITLE
Global Default Address Pool support

### DIFF
--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/docker/libnetwork/driverapi"
-	"github.com/docker/libnetwork/ipamutils"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/netutils"
@@ -19,10 +18,6 @@ import (
 	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 )
-
-func init() {
-	ipamutils.InitNetworks(nil)
-}
 
 func TestEndpointMarshalling(t *testing.T) {
 	ip1, _ := types.ParseCIDR("172.22.0.9/16")

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -46,8 +46,8 @@ func NewAllocator(lcDs, glDs datastore.DataStore) (*Allocator, error) {
 
 	// Load predefined subnet pools
 	a.predefined = map[string][]*net.IPNet{
-		localAddressSpace:  ipamutils.PredefinedBroadNetworks,
-		globalAddressSpace: ipamutils.PredefinedGranularNetworks,
+		localAddressSpace:  ipamutils.PredefinedLocalScopeDefaultNetworks,
+		globalAddressSpace: ipamutils.PredefinedGlobalScopeDefaultNetworks,
 	}
 
 	// Initialize asIndices map

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/libnetwork/bitseq"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/ipamapi"
-	"github.com/docker/libnetwork/ipamutils"
 	_ "github.com/docker/libnetwork/testutils"
 	"github.com/docker/libnetwork/types"
 	"gotest.tools/assert"
@@ -57,7 +56,6 @@ func randomLocalStore(needStore bool) (datastore.DataStore, error) {
 }
 
 func getAllocator(store bool) (*Allocator, error) {
-	ipamutils.InitNetworks(nil)
 	ds, err := randomLocalStore(store)
 	if err != nil {
 		return nil, err

--- a/ipams/builtin/builtin_unix.go
+++ b/ipams/builtin/builtin_unix.go
@@ -35,7 +35,7 @@ func Init(ic ipamapi.Callback, l, g interface{}) error {
 		}
 	}
 
-	ipamutils.InitNetworks(GetDefaultIPAddressPool())
+	ipamutils.ConfigLocalScopeDefaultNetworks(GetDefaultIPAddressPool())
 
 	a, err := ipam.NewAllocator(localDs, globalDs)
 	if err != nil {

--- a/ipams/builtin/builtin_windows.go
+++ b/ipams/builtin/builtin_windows.go
@@ -37,7 +37,7 @@ func InitDockerDefault(ic ipamapi.Callback, l, g interface{}) error {
 		}
 	}
 
-	ipamutils.InitNetworks(nil)
+	ipamutils.ConfigLocalScopeDefaultNetworks(nil)
 
 	a, err := ipam.NewAllocator(localDs, globalDs)
 	if err != nil {

--- a/netutils/utils_linux.go
+++ b/netutils/utils_linux.go
@@ -94,8 +94,8 @@ func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
 	}
 
 	if link == nil || len(v4Nets) == 0 {
-		// Choose from predefined broad networks
-		v4Net, err := FindAvailableNetwork(ipamutils.PredefinedBroadNetworks)
+		// Choose from predefined local scope  networks
+		v4Net, err := FindAvailableNetwork(ipamutils.PredefinedLocalScopeDefaultNetworks)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/netutils/utils_test.go
+++ b/netutils/utils_test.go
@@ -212,15 +212,14 @@ func TestUtilGenerateRandomMAC(t *testing.T) {
 
 func TestNetworkRequest(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
-	ipamutils.InitNetworks(nil)
 
-	nw, err := FindAvailableNetwork(ipamutils.PredefinedBroadNetworks)
+	nw, err := FindAvailableNetwork(ipamutils.PredefinedLocalScopeDefaultNetworks)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var found bool
-	for _, exp := range ipamutils.PredefinedBroadNetworks {
+	for _, exp := range ipamutils.PredefinedLocalScopeDefaultNetworks {
 		if types.CompareIPNet(exp, nw) {
 			found = true
 			break
@@ -231,13 +230,13 @@ func TestNetworkRequest(t *testing.T) {
 		t.Fatalf("Found unexpected broad network %s", nw)
 	}
 
-	nw, err = FindAvailableNetwork(ipamutils.PredefinedGranularNetworks)
+	nw, err = FindAvailableNetwork(ipamutils.PredefinedGlobalScopeDefaultNetworks)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	found = false
-	for _, exp := range ipamutils.PredefinedGranularNetworks {
+	for _, exp := range ipamutils.PredefinedGlobalScopeDefaultNetworks {
 		if types.CompareIPNet(exp, nw) {
 			found = true
 			break
@@ -255,7 +254,7 @@ func TestNetworkRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	nw, err = FindAvailableNetwork(ipamutils.PredefinedBroadNetworks)
+	nw, err = FindAvailableNetwork(ipamutils.PredefinedLocalScopeDefaultNetworks)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +265,6 @@ func TestNetworkRequest(t *testing.T) {
 
 func TestElectInterfaceAddressMultipleAddresses(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
-	ipamutils.InitNetworks(nil)
 
 	nws := []string{"172.101.202.254/16", "172.102.202.254/16"}
 	createInterface(t, "test", nws...)
@@ -303,7 +301,6 @@ func TestElectInterfaceAddressMultipleAddresses(t *testing.T) {
 
 func TestElectInterfaceAddress(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
-	ipamutils.InitNetworks(nil)
 
 	nws := "172.101.202.254/16"
 	createInterface(t, "test", nws)


### PR DESCRIPTION
This change brings global default address pool feature into
libnetwork. Idea is to reuse same code flow and functions that were
implemented for local scope default address pool.
Function InitNetworks carries most of the changes. local scope default
address pool init should always happen only once. But Global scope
default address pool can be initialized multiple times.

Signed-off-by: selansen <elango.siva@docker.com>