### PR TITLE
Dockerfile: Install a fixed version of gogoprotobuf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,17 @@ FROM golang:1.10.2 as dev
 RUN apt-get update && apt-get -y install iptables \
 		protobuf-compiler
 
+RUN go get -d github.com/gogo/protobuf/protoc-gen-gogo && \
+		cd /go/src/github.com/gogo/protobuf/protoc-gen-gogo && \
+		git reset --hard 30cf7ac33676b5786e78c746683f0d4cd64fa75b && \
+		go install
+
 RUN go get github.com/golang/lint/golint \
 		golang.org/x/tools/cmd/cover \
 		github.com/mattn/goveralls \
 		github.com/gordonklaus/ineffassign \
 		github.com/client9/misspell/cmd/misspell \
-		honnef.co/go/tools/cmd/gosimple \
-		github.com/gogo/protobuf/protoc-gen-gogo
+		honnef.co/go/tools/cmd/gosimple
 
 WORKDIR /go/src/github.com/docker/libnetwork
 


### PR DESCRIPTION
Gogoprotobuf has changed upstream and now generates different output.   Check out a specific commit to avoid this.

We may be able to do something like this with `go get` in 1.11 with 'module aware mode':
```
go get github.com/gogo/protobuf/protoc-gen-gogo@v1.0.0
```