### PR TITLE
allow propagating custom exec-root (e.g. "/run/docker") to libnetwork-setkey

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type DaemonCfg struct {
 	Debug                  bool
 	Experimental           bool
 	DataDir                string
+	ExecRoot               string
 	DefaultNetwork         string
 	DefaultDriver          string
 	Labels                 []string
@@ -217,6 +218,7 @@ func OptionDataDir(dataDir string) Option {
 // OptionExecRoot function returns an option setter for exec root folder
 func OptionExecRoot(execRoot string) Option {
 	return func(c *Config) {
+		c.Daemon.ExecRoot = execRoot
 		osl.SetBasePath(execRoot)
 	}
 }

--- a/sandbox_externalkey_unix.go
+++ b/sandbox_externalkey_unix.go
@@ -4,24 +4,30 @@ package libnetwork
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 
 	"github.com/docker/libnetwork/types"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/sirupsen/logrus"
 )
 
-const udsBase = "/run/docker/libnetwork/"
-const success = "success"
+const (
+	execSubdir      = "libnetwork"
+	defaultExecRoot = "/run/docker"
+	success         = "success"
+)
 
 // processSetKeyReexec is a private function that must be called only on an reexec path
 // It expects 3 args { [0] = "libnetwork-setkey", [1] = <container-id>, [2] = <controller-id> }
 // It also expects configs.HookState as a json string in <stdin>
 // Refer to https://github.com/opencontainers/runc/pull/160/ for more information
+// The docker exec-root can be specified as "-exec-root" flag. The default value is "/run/docker".
 func processSetKeyReexec() {
 	var err error
 
@@ -32,12 +38,17 @@ func processSetKeyReexec() {
 		}
 	}()
 
-	// expecting 3 args {[0]="libnetwork-setkey", [1]=<container-id>, [2]=<controller-id> }
-	if len(os.Args) < 3 {
-		err = fmt.Errorf("Re-exec expects 3 args, received : %d", len(os.Args))
+	execRoot := flag.String("exec-root", defaultExecRoot, "docker exec root")
+	flag.Parse()
+
+	// expecting 3 os.Args {[0]="libnetwork-setkey", [1]=<container-id>, [2]=<controller-id> }
+	// (i.e. expecting 2 flag.Args())
+	args := flag.Args()
+	if len(args) < 2 {
+		err = fmt.Errorf("Re-exec expects 2 args (after parsing flags), received : %d", len(args))
 		return
 	}
-	containerID := os.Args[1]
+	containerID, controllerID := args[0], args[1]
 
 	// We expect configs.HookState as a json string in <stdin>
 	stateBuf, err := ioutil.ReadAll(os.Stdin)
@@ -49,18 +60,17 @@ func processSetKeyReexec() {
 		return
 	}
 
-	controllerID := os.Args[2]
-
-	err = SetExternalKey(controllerID, containerID, fmt.Sprintf("/proc/%d/ns/net", state.Pid))
+	err = SetExternalKey(controllerID, containerID, fmt.Sprintf("/proc/%d/ns/net", state.Pid), *execRoot)
 }
 
 // SetExternalKey provides a convenient way to set an External key to a sandbox
-func SetExternalKey(controllerID string, containerID string, key string) error {
+func SetExternalKey(controllerID string, containerID string, key string, execRoot string) error {
 	keyData := setKeyData{
 		ContainerID: containerID,
 		Key:         key}
 
-	c, err := net.Dial("unix", udsBase+controllerID+".sock")
+	uds := filepath.Join(execRoot, execSubdir, controllerID+".sock")
+	c, err := net.Dial("unix", uds)
 	if err != nil {
 		return err
 	}
@@ -102,10 +112,15 @@ func processReturn(r io.Reader) error {
 }
 
 func (c *controller) startExternalKeyListener() error {
+	execRoot := defaultExecRoot
+	if v := c.Config().Daemon.ExecRoot; v != "" {
+		execRoot = v
+	}
+	udsBase := filepath.Join(execRoot, execSubdir)
 	if err := os.MkdirAll(udsBase, 0600); err != nil {
 		return err
 	}
-	uds := udsBase + c.id + ".sock"
+	uds := filepath.Join(udsBase, c.id+".sock")
 	l, err := net.Listen("unix", uds)
 	if err != nil {
 		return err


### PR DESCRIPTION
part of https://github.com/moby/moby/issues/37375 (in rootless mode, exec-root should be like `/run/user/4242/docker` rather than `/run/docker`)

The docker daemon needs to be modified as follows:

    diff --git a/daemon/oci_linux.go b/daemon/oci_linux.go
    index 00ace320df..ea7daa72df 100644
    --- a/daemon/oci_linux.go
    +++ b/daemon/oci_linux.go
    @@ -809,7 +809,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
                        s.Hooks = &specs.Hooks{
                                Prestart: []specs.Hook{{
                                        Path: target,
    -                                   Args: []string{"libnetwork-setkey", c.ID, daemon.netController.ID()},
    +                                   Args: []string{"libnetwork-setkey", c.ID, daemon.netController.ID(), "-exec-root="+daemon.configStore.GetExecRoot()},
                                }},
                        }
                }

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

