### PR TITLE
Add getter function for Default Address Pools

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -45,9 +45,10 @@ func NewAllocator(lcDs, glDs datastore.DataStore) (*Allocator, error) {
 	a := &Allocator{}
 
 	// Load predefined subnet pools
+
 	a.predefined = map[string][]*net.IPNet{
-		localAddressSpace:  ipamutils.PredefinedLocalScopeDefaultNetworks,
-		globalAddressSpace: ipamutils.PredefinedGlobalScopeDefaultNetworks,
+		localAddressSpace:  ipamutils.GetLocalScopeDefaultNetworks(),
+		globalAddressSpace: ipamutils.GetGlobalScopeDefaultNetworks(),
 	}
 
 	// Initialize asIndices map

--- a/ipamutils/utils.go
+++ b/ipamutils/utils.go
@@ -56,6 +56,20 @@ func configDefaultNetworks(defaultAddressPool []*NetworkToSplit, result *[]*net.
 	return nil
 }
 
+// GetGlobalScopeDefaultNetworks returns PredefinedGlobalScopeDefaultNetworks
+func GetGlobalScopeDefaultNetworks() []*net.IPNet {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return PredefinedGlobalScopeDefaultNetworks
+}
+
+// GetLocalScopeDefaultNetworks returns PredefinedLocalScopeDefaultNetworks
+func GetLocalScopeDefaultNetworks() []*net.IPNet {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return PredefinedLocalScopeDefaultNetworks
+}
+
 // ConfigGlobalScopeDefaultNetworks configures global default pool.
 // Ideally this will be called from SwarmKit as part of swarm init
 func ConfigGlobalScopeDefaultNetworks(defaultAddressPool []*NetworkToSplit) error {


### PR DESCRIPTION
ipamutils has two default address pool. Instead of allowing them to
be accessed directly, adding get functions so that other packages
can use get APIs.

Signed-off-by: selansen <elango.siva@docker.com>