### PR TITLE
Increase max concurrent requests for DNS from 100 to 1024

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -67,7 +67,7 @@ const (
 	maxExtDNS       = 3 //max number of external servers to try
 	extIOTimeout    = 4 * time.Second
 	defaultRespSize = 512
-	maxConcurrent   = 100
+	maxConcurrent   = 1024
 	logInterval     = 2 * time.Second
 )
 


### PR DESCRIPTION
This addresses/alleviates https://github.com/docker/libnetwork/issues/2082 and https://github.com/docker/libnetwork/issues/2214

The new proposed limit (1024) should remediate the issue for most users.