### PR TITLE
Do not fail with an empty transparent IPv4 address

### DIFF
--- a/drivers/windows/windows_store.go
+++ b/drivers/windows/windows_store.go
@@ -261,7 +261,7 @@ func (ep *hnsEndpoint) UnmarshalJSON(b []byte) error {
 	}
 	if v, ok := epMap["Addr"]; ok {
 		if ep.addr, err = types.ParseCIDR(v.(string)); err != nil {
-			return types.InternalErrorf("failed to decode endpoint IPv4 address (%s) after json unmarshal: %v", v.(string), err)
+			logrus.Warnf("failed to decode endpoint IPv4 address (%s) after json unmarshal: %v", v.(string), err)
 		}
 	}
 	if v, ok := epMap["gateway"]; ok {


### PR DESCRIPTION
When dockerd.exe is not stopped cleanly (such as when Windows is
restarted), the endpoints are not cleaned up. When using a transparent
network, the endpoint IPv4 address is blank. When dockerd.exe starts up
again, libnetwork restores the endpoint, which would not have been
stored on a clean shutdown of dockerd.exe. That fails because the IPv4
address is blank. This change warns instead of failing.

Signed-off-by: John Stephens <johnstep@docker.com>