### PR TITLE
Add `Stats` to the `Destination`

### DIFF
--- a/ipvs/ipvs.go
+++ b/ipvs/ipvs.go
@@ -62,8 +62,11 @@ type Destination struct {
 	LowerThreshold      uint32
 	ActiveConnections   int
 	InactiveConnections int
-	Stats               SvcStats
+	Stats               DstStats
 }
+
+// DstStats defines IPVS destination (real server) statistics
+type DstStats SvcStats
 
 // Handle provides a namespace specific ipvs handle to program ipvs
 // rules.

--- a/ipvs/ipvs.go
+++ b/ipvs/ipvs.go
@@ -62,6 +62,7 @@ type Destination struct {
 	LowerThreshold      uint32
 	ActiveConnections   int
 	InactiveConnections int
+	Stats               SvcStats
 }
 
 // Handle provides a namespace specific ipvs handle to program ipvs

--- a/ipvs/netlink.go
+++ b/ipvs/netlink.go
@@ -448,7 +448,7 @@ func assembleDestination(attrs []syscall.NetlinkRouteAttr) (*Destination, error)
 			if err != nil {
 				return nil, err
 			}
-			d.Stats = stats
+			d.Stats = DstStats(stats)
 		}
 	}
 	return &d, nil

--- a/ipvs/netlink.go
+++ b/ipvs/netlink.go
@@ -443,6 +443,12 @@ func assembleDestination(attrs []syscall.NetlinkRouteAttr) (*Destination, error)
 			d.ActiveConnections = int(native.Uint16(attr.Value))
 		case ipvsDestAttrInactiveConnections:
 			d.InactiveConnections = int(native.Uint16(attr.Value))
+		case ipvsSvcAttrStats:
+			stats, err := assembleStats(attr.Value)
+			if err != nil {
+				return nil, err
+			}
+			d.Stats = stats
 		}
 	}
 	return &d, nil


### PR DESCRIPTION
This patch modifies the `Destination` struct so that the stats for
that destination are also reported.