### PR TITLE
[17.06 backport] debian has iptables-legacy and iptables-nft now

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -87,11 +87,16 @@ func initFirewalld() {
 }
 
 func detectIptables() {
-	path, err := exec.LookPath("iptables")
+	path, err := exec.LookPath("iptables-legacy") // debian has iptables-legacy and iptables-nft now
 	if err != nil {
-		return
+		path, err = exec.LookPath("iptables")
+		if err != nil {
+			return
+		}
 	}
+
 	iptablesPath = path
+
 	supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
 	mj, mn, mc, err := GetVersion()
 	if err != nil {


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2285 for 17.06
addresses https://github.com/moby/moby/issues/38099

```
git checkout -b 17.06_backport_iptables_legacy upstream/bump_17.06
git cherry-pick -s -S -x 7da66eea9f68e4abc83ed2892114ec565eddd66a
git push -u origin
```

cherry-pick was clean; no conflicts