### PR TITLE
phantom ip/mac vlan network after a powercycle

### DIFF
--- a/drivers/ipvlan/ipvlan_network.go
+++ b/drivers/ipvlan/ipvlan_network.go
@@ -60,10 +60,14 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 		// empty parent and --internal are handled the same. Set here to update k/v
 		config.Internal = true
 	}
-	err = d.createNetwork(config)
+	foundExisting, err := d.createNetwork(config)
 	if err != nil {
 		return err
 	}
+
+    if foundExisting {
+        return nil
+    }
 	// update persistent db, rollback on fail
 	err = d.storeUpdate(config)
 	if err != nil {
@@ -76,22 +80,33 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 }
 
 // createNetwork is used by new network callbacks and persistent network cache
-func (d *driver) createNetwork(config *configuration) error {
+func (d *driver) createNetwork(config *configuration) (bool, error) {
+    foundExisting := false
 	networkList := d.getNetworks()
 	for _, nw := range networkList {
 		if config.Parent == nw.config.Parent {
-			return fmt.Errorf("network %s is already using parent interface %s",
-				getDummyName(stringid.TruncateID(nw.config.ID)), config.Parent)
+            if config.ID != nw.config.ID {
+				return false, fmt.Errorf("network %s is already using parent interface %s",
+					getDummyName(stringid.TruncateID(nw.config.ID)), config.Parent)
+            } else {
+                logrus.Debugf("Create Network for the same ID %s\n", config.ID)
+                foundExisting = true
+                break
+            }
+
 		}
 	}
 	if !parentExists(config.Parent) {
 		// if the --internal flag is set, create a dummy link
 		if config.Internal {
-			err := createDummyLink(config.Parent, getDummyName(stringid.TruncateID(config.ID)))
-			if err != nil {
-				return err
-			}
-			config.CreatedSlaveLink = true
+            if !dummyLinkExists(getDummyName(stringid.TruncateID(config.ID)))  {
+		 	   err := createDummyLink(config.Parent, getDummyName(stringid.TruncateID(config.ID)))
+		 	   if err != nil {
+		 	   	return false, err
+		 	   }
+		 	   config.CreatedSlaveLink = true
+            }
+
 			// notify the user in logs they have limited communications
 			if config.Parent == getDummyName(stringid.TruncateID(config.ID)) {
 				logrus.Debugf("Empty -o parent= and --internal flags limit communications to other containers inside of network: %s",
@@ -100,24 +115,28 @@ func (d *driver) createNetwork(config *configuration) error {
 		} else {
 			// if the subinterface parent_iface.vlan_id checks do not pass, return err.
 			//  a valid example is 'eth0.10' for a parent iface 'eth0' with a vlan id '10'
-			err := createVlanLink(config.Parent)
-			if err != nil {
-				return err
-			}
-			// if driver created the networks slave link, record it for future deletion
-			config.CreatedSlaveLink = true
+            if !vlanLinkExists(config.Parent) {
+				err := createVlanLink(config.Parent)
+				if err != nil {
+					return false, err
+				}
+				// if driver created the networks slave link, record it for future deletion
+				config.CreatedSlaveLink = true
+            }
 		}
 	}
-	n := &network{
-		id:        config.ID,
-		driver:    d,
-		endpoints: endpointTable{},
-		config:    config,
-	}
-	// add the *network
-	d.addNetwork(n)
+    if !foundExisting {
+		n := &network{
+			id:        config.ID,
+			driver:    d,
+			endpoints: endpointTable{},
+			config:    config,
+		}
+		// add the *network
+		d.addNetwork(n)
+    }
 
-	return nil
+	return foundExisting, nil
 }
 
 // DeleteNetwork the network for the specified driver type

--- a/drivers/ipvlan/ipvlan_setup.go
+++ b/drivers/ipvlan/ipvlan_setup.go
@@ -70,6 +70,14 @@ func parentExists(ifaceStr string) bool {
 	return true
 }
 
+func vlanLinkExists(linkStr string) bool {
+   _, err := ns.NlHandle().LinkByName(linkStr)
+   if err != nil {
+       return false
+   }          
+   return true
+} 
+
 // createVlanLink parses sub-interfaces and vlan id for creation
 func createVlanLink(parentName string) error {
 	if strings.Contains(parentName, ".") {
@@ -155,6 +163,15 @@ func parseVlan(linkName string) (string, int, error) {
 
 	return parent, vidInt, nil
 }
+
+func dummyLinkExists(dummyName string) bool {
+   _, err := ns.NlHandle().LinkByName(dummyName)
+   if err != nil {
+      return false
+   } 
+   return true
+}
+
 
 // createDummyLink creates a dummy0 parent link
 func createDummyLink(dummyName, truncNetID string) error {

--- a/drivers/ipvlan/ipvlan_store.go
+++ b/drivers/ipvlan/ipvlan_store.go
@@ -55,7 +55,14 @@ func (d *driver) initStore(option map[string]interface{}) error {
 			return types.InternalErrorf("ipvlan driver failed to initialize data store: %v", err)
 		}
 
-		return d.populateNetworks()
+        err = d.populateNetworks()
+        if err != nil {
+            return err
+        }
+        err = d.populateEndpoints()
+        if err != nil {
+            return err
+        }
 	}
 
 	return nil
@@ -73,7 +80,7 @@ func (d *driver) populateNetworks() error {
 	}
 	for _, kvo := range kvol {
 		config := kvo.(*configuration)
-		if err = d.createNetwork(config); err != nil {
+		if _, err = d.createNetwork(config); err != nil {
 			logrus.Warnf("could not create ipvlan network for id %s from persistent state", config.ID)
 		}
 	}

--- a/drivers/macvlan/macvlan_network.go
+++ b/drivers/macvlan/macvlan_network.go
@@ -64,10 +64,15 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 		// empty parent and --internal are handled the same. Set here to update k/v
 		config.Internal = true
 	}
-	err = d.createNetwork(config)
+	foundExisting, err := d.createNetwork(config)
 	if err != nil {
 		return err
 	}
+
+    if foundExisting {
+        return nil
+    }
+
 	// update persistent db, rollback on fail
 	err = d.storeUpdate(config)
 	if err != nil {
@@ -80,22 +85,33 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 }
 
 // createNetwork is used by new network callbacks and persistent network cache
-func (d *driver) createNetwork(config *configuration) error {
+func (d *driver) createNetwork(config *configuration) (bool, error) {
+    foundExisting := false
 	networkList := d.getNetworks()
 	for _, nw := range networkList {
 		if config.Parent == nw.config.Parent {
-			return fmt.Errorf("network %s is already using parent interface %s",
-				getDummyName(stringid.TruncateID(nw.config.ID)), config.Parent)
+               if config.ID != nw.config.ID {
+                   return false, fmt.Errorf("network %s is already using parent interface %s",
+                       getDummyName(stringid.TruncateID(nw.config.ID)), config.Parent)
+               } else {
+                   logrus.Debugf("Create Network for the same ID %s\n", config.ID)
+                   foundExisting = true
+                   break
+               }
 		}
 	}
 	if !parentExists(config.Parent) {
 		// if the --internal flag is set, create a dummy link
 		if config.Internal {
-			err := createDummyLink(config.Parent, getDummyName(stringid.TruncateID(config.ID)))
-			if err != nil {
-				return err
+            if !dummyLinkExists(getDummyName(stringid.TruncateID(config.ID))) {
+                err := createDummyLink(config.Parent, getDummyName(stringid.TruncateID(config.ID)))
+                if err != nil {
+                    return false, err
+                }
+			    config.CreatedSlaveLink = true
+            } else {
+               logrus.Debugf("Dummy Link %s for Mac Vlan already exists", getDummyName(stringid.TruncateID(config.ID)))
 			}
-			config.CreatedSlaveLink = true
 			// notify the user in logs they have limited communications
 			if config.Parent == getDummyName(stringid.TruncateID(config.ID)) {
 				logrus.Debugf("Empty -o parent= and --internal flags limit communications to other containers inside of network: %s",
@@ -104,24 +120,33 @@ func (d *driver) createNetwork(config *configuration) error {
 		} else {
 			// if the subinterface parent_iface.vlan_id checks do not pass, return err.
 			//  a valid example is 'eth0.10' for a parent iface 'eth0' with a vlan id '10'
-			err := createVlanLink(config.Parent)
-			if err != nil {
-				return err
-			}
-			// if driver created the networks slave link, record it for future deletion
-			config.CreatedSlaveLink = true
+
+            if !vlanLinkExists(config.Parent) {
+                // if the subinterface parent_iface.vlan_id checks do not pass, return err.
+                //  a valid example is 'eth0.10' for a parent iface 'eth0' with a vlan id '10'
+                err := createVlanLink(config.Parent)
+                if err != nil {
+                    return false, err
+                }
+				// if driver created the networks slave link, record it for future deletion
+				config.CreatedSlaveLink = true
+            } else {
+                logrus.Debugf("Parent Sub Interface %s already Exists NetID %s", config.Parent, config.ID)
+            }
 		}
 	}
-	n := &network{
-		id:        config.ID,
-		driver:    d,
-		endpoints: endpointTable{},
-		config:    config,
-	}
-	// add the *network
-	d.addNetwork(n)
+    if !foundExisting {
+		n := &network{
+			id:        config.ID,
+			driver:    d,
+			endpoints: endpointTable{},
+			config:    config,
+		}
+		// add the *network
+		d.addNetwork(n)
+    }
 
-	return nil
+	return foundExisting, nil
 }
 
 // DeleteNetwork deletes the network for the specified driver type

--- a/drivers/macvlan/macvlan_setup.go
+++ b/drivers/macvlan/macvlan_setup.go
@@ -74,6 +74,14 @@ func parentExists(ifaceStr string) bool {
 	return true
 }
 
+func vlanLinkExists(linkStr string) bool {
+   _, err := ns.NlHandle().LinkByName(linkStr)
+   if err != nil {
+       return false
+   }          
+   return true
+}  
+
 // createVlanLink parses sub-interfaces and vlan id for creation
 func createVlanLink(parentName string) error {
 	if strings.Contains(parentName, ".") {
@@ -159,6 +167,15 @@ func parseVlan(linkName string) (string, int, error) {
 
 	return parent, vidInt, nil
 }
+
+func dummyLinkExists(dummyName string) bool {
+   _, err := ns.NlHandle().LinkByName(dummyName)
+   if err != nil {
+       return false
+   }  
+   return true
+} 
+
 
 // createDummyLink creates a dummy0 parent link
 func createDummyLink(dummyName, truncNetID string) error {

--- a/drivers/macvlan/macvlan_store.go
+++ b/drivers/macvlan/macvlan_store.go
@@ -55,7 +55,15 @@ func (d *driver) initStore(option map[string]interface{}) error {
 			return types.InternalErrorf("macvlan driver failed to initialize data store: %v", err)
 		}
 
-		return d.populateNetworks()
+        err = d.populateNetworks()
+        if err != nil {
+            return err
+        }
+        err = d.populateEndpoints()
+        if err != nil {
+            return err
+        }
+
 	}
 
 	return nil
@@ -73,7 +81,7 @@ func (d *driver) populateNetworks() error {
 	}
 	for _, kvo := range kvol {
 		config := kvo.(*configuration)
-		if err = d.createNetwork(config); err != nil {
+		if _, err = d.createNetwork(config); err != nil {
 			logrus.Warnf("Could not create macvlan network for id %s from persistent state", config.ID)
 		}
 	}

--- a/endpoint_cnt.go
+++ b/endpoint_cnt.go
@@ -180,3 +180,8 @@ func (ec *endpointCnt) IncEndpointCnt() error {
 func (ec *endpointCnt) DecEndpointCnt() error {
 	return ec.atomicIncDecEpCnt(false)
 }
+
+func (ec *endpointCnt) SetEndpointCnt(cnt uint64) error {
+    return ec.setCnt(cnt)
+}
+


### PR DESCRIPTION
I am trying to address  https://github.com/docker/libnetwork/issues/1743 as part of this PR. 

There are two issues as part of this

1. When a node is power cycled unplanned or dockerd goes through a restart (unplanned), swarm scope networks are not cleaned up, Infact they are recreated when the docker daemon starts. This recreate does not work as there is already a swarmScope network has been restored and uses the same uplink. 
     FIX: there was an earlier PR that tackled this problem by simply deleting the network if its created with same ID. As per comments in that PR, it was preferred to re-use instead of delete.  In this PR, I am trying to essentially re-use the same network ID. 

2. Even if the swarm Scope network can be recreated there is still a problem with config-only network. As there is an additional createNetwork after the docker daemon restarts. The endpoint count on the configOnly network becomes more than what it should be. Consider the case where node has been kicked out of swarm during this unplanned reboot and added back in. 
I believe a swarm scope network to its config-only network is a one to one mapping for a particular worker node. If thats not the case, then more work is required for this PR. But if that is the case, there is no real need to track the endpoint count. 
FIX: Upon deleteNetwork of a swarm scope network, the correspnding configOnly Network endpoint count is zeroed out essentially making configOnly network as deleteable. 

