### PR TITLE
Do not add IP to name records for aliases

### DIFF
--- a/service_common.go
+++ b/service_common.go
@@ -64,7 +64,7 @@ func (c *controller) addContainerNameResolution(nID, eID, containerName string, 
 
 	// Add resolution for taskaliases
 	for _, alias := range taskAliases {
-		n.(*network).addSvcRecords(eID, alias, eID, ip, nil, true, method)
+		n.(*network).addSvcRecords(eID, alias, eID, ip, nil, false, method)
 	}
 
 	return nil


### PR DESCRIPTION
**- What I did**
Do not add IP to name records for aliases so IP to name resolution will always reply container name.

**- How I did it**
Send ipMapUpdate = false to addSvcRecords function so it will not add IP to name records https://github.com/docker/libnetwork/blob/09e39d99d5c769cb7d167058504581d1cfc779e3/network.go#L1422-L1427

**- How to verify it**
This can be easily tested with commands:
```
docker network create --internal --attachable --driver overlay --scope swarm foo-network
docker run -it --name bar-container --rm --network foo-network nicolaka/netshoot
for i in {1..1000}
do
  nslookup $(hostname -i) | grep "arpa" | grep -v "bar-container"
done
```
without this one about 100-150 / 1000 tests fails.


Fixes moby/moby#34882