### PR TITLE
Touch-up error-message and godoc for ConfigVXLANUDPPort

### DIFF
--- a/drivers/overlay/overlayutils/utils.go
+++ b/drivers/overlay/overlayutils/utils.go
@@ -17,9 +17,10 @@ func init() {
 	vxlanUDPPort = defaultVXLANUDPPort
 }
 
-// ConfigVXLANUDPPort configures vxlan udp port number.
+// ConfigVXLANUDPPort configures the VXLAN UDP port (data path port) number.
+// If no port is set, the default (4789) is returned. Valid port numbers are
+// between 1024 and 49151.
 func ConfigVXLANUDPPort(vxlanPort uint32) error {
-	// if the value comes as 0 by any reason we set it to default value 4789
 	if vxlanPort == 0 {
 		vxlanPort = defaultVXLANUDPPort
 	}
@@ -29,7 +30,7 @@ func ConfigVXLANUDPPort(vxlanPort uint32) error {
 	// The Dynamic Ports, aka the Private Ports, from 49152-65535
 	// So we can allow range between 1024 to 49151
 	if vxlanPort < 1024 || vxlanPort > 49151 {
-		return fmt.Errorf("ConfigVxlanUDPPort Vxlan UDP port number is not in valid range %d", vxlanPort)
+		return fmt.Errorf("VXLAN UDP port number is not in valid range (1024-49151): %d", vxlanPort)
 	}
 	mutex.Lock()
 	vxlanUDPPort = vxlanPort


### PR DESCRIPTION
Minor changes following review of the engine pull request
for this feature;

- Remove the name of the function from the error message as it's not a debug message.
- Add the valid range to the error message, so that a user has sufficient information to address the problem.
- Update GoDoc for the function to describe the default port, and valid port-ranges.
