### PR TITLE
Improve error if auto-selecting IP-range failed

### DIFF
--- a/netutils/utils_linux.go
+++ b/netutils/utils_linux.go
@@ -94,10 +94,12 @@ func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
 	}
 
 	if link == nil || len(v4Nets) == 0 {
-		// Choose from predefined local scope  networks
+		// Choose from predefined local scope networks
 		v4Net, err := FindAvailableNetwork(ipamutils.PredefinedLocalScopeDefaultNetworks)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("%s, PredefinedLocalScopeDefaultNetworks List: %+v",
+				err.Error(),
+				ipamutils.PredefinedLocalScopeDefaultNetworks)
 		}
 		v4Nets = append(v4Nets, v4Net)
 	}


### PR DESCRIPTION
Improve error if auto-selecting IP-range failed.

Issue: #2305 
[Detailed information](https://github.com/moby/moby/issues/36512)
