### PR TITLE
Fix for problem where agent is stopped and does not restart

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -378,6 +378,9 @@ func (c *controller) agentClose() {
 	c.agent = nil
 	c.Unlock()
 
+	// when the agent is closed the cluster provider should be cleaned up
+	c.SetClusterProvider(nil)
+
 	if agent == nil {
 		return
 	}


### PR DESCRIPTION
This fixes a problem where the agent on a controller is stopped when a node leaves a swarm and is never restarted. By adding a check to see if the agent is nil the agent init routine will run and the other checks that guard against multiple agents will still function as intended. Here's some more information about how this problem presents itself https://github.com/docker/for-linux/issues/495.