### PR TITLE
Allow bridge net driver to skip IPv4 configuration of bridge interface

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -68,6 +68,7 @@ type networkConfiguration struct {
 	EnableIPv6           bool
 	EnableIPMasquerade   bool
 	EnableICC            bool
+	InhibitIPv4          bool
 	Mtu                  int
 	DefaultBindingIP     net.IP
 	DefaultBridge        bool
@@ -241,6 +242,10 @@ func (c *networkConfiguration) fromLabels(labels map[string]string) error {
 			}
 		case EnableICC:
 			if c.EnableICC, err = strconv.ParseBool(value); err != nil {
+				return parseErr(label, value, err.Error())
+			}
+		case InhibitIPv4:
+			if c.InhibitIPv4, err = strconv.ParseBool(value); err != nil {
 				return parseErr(label, value, err.Error())
 			}
 		case DefaultBridge:
@@ -699,7 +704,7 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 
 		// We ensure that the bridge has the expectedIPv4 and IPv6 addresses in
 		// the case of a previously existing device.
-		{bridgeAlreadyExists, setupVerifyAndReconcile},
+		{bridgeAlreadyExists && !config.InhibitIPv4, setupVerifyAndReconcile},
 
 		// Enable IPv6 Forwarding
 		{enableIPv6Forwarding, setupIPv6Forwarding},

--- a/drivers/bridge/bridge_store.go
+++ b/drivers/bridge/bridge_store.go
@@ -137,6 +137,7 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap["EnableIPv6"] = ncfg.EnableIPv6
 	nMap["EnableIPMasquerade"] = ncfg.EnableIPMasquerade
 	nMap["EnableICC"] = ncfg.EnableICC
+	nMap["InhibitIPv4"] = ncfg.InhibitIPv4
 	nMap["Mtu"] = ncfg.Mtu
 	nMap["Internal"] = ncfg.Internal
 	nMap["DefaultBridge"] = ncfg.DefaultBridge
@@ -192,6 +193,7 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 	ncfg.EnableIPv6 = nMap["EnableIPv6"].(bool)
 	ncfg.EnableIPMasquerade = nMap["EnableIPMasquerade"].(bool)
 	ncfg.EnableICC = nMap["EnableICC"].(bool)
+	ncfg.InhibitIPv4 = nMap["InhibitIPv4"].(bool)
 	ncfg.Mtu = int(nMap["Mtu"].(float64))
 	if v, ok := nMap["Internal"]; ok {
 		ncfg.Internal = v.(bool)

--- a/drivers/bridge/labels.go
+++ b/drivers/bridge/labels.go
@@ -10,6 +10,9 @@ const (
 	// EnableICC label
 	EnableICC = "com.docker.network.bridge.enable_icc"
 
+	// InhibitIPv4 label
+	InhibitIPv4 = "com.docker.network.bridge.inhibit_ipv4"
+
 	// DefaultBindingIP label
 	DefaultBindingIP = "com.docker.network.bridge.host_binding_ipv4"
 


### PR DESCRIPTION
Introduce "com.docker.network.bridge.inhibit_ipv4" option to the bridge
network driver. If set, this option will prevent docker from setting or
modifying Layer-3 (IP) configuration on the bridge interface in any way.

This option should allow connecting containers to pre-existing network
segments (with e.g., pre-existing default gateways) while simultaneously
preserving our ability to communicate with the host and/or configure the
properties of the host-side container virtual network interface (e.g.,
delay/loss/jitter via netem), which can not be done using macvlan.

Also see following Moby project issue: https://github.com/moby/moby/issues/37430