### PR TITLE
[18.09 backport] Fix possible nil pointer exception

### DIFF
--- a/default_gateway.go
+++ b/default_gateway.go
@@ -181,10 +181,8 @@ func (c *controller) defaultGwNetwork() (Network, error) {
 	defer func() { <-procGwNetwork }()
 
 	n, err := c.NetworkByName(libnGWNetwork)
-	if err != nil {
-		if _, ok := err.(types.NotFoundError); ok {
-			n, err = c.createGWNetwork()
-		}
+	if _, ok := err.(types.NotFoundError); ok {
+		n, err = c.createGWNetwork()
 	}
 	return n, err
 }

--- a/network.go
+++ b/network.go
@@ -396,11 +396,9 @@ func (n *network) validateConfiguration() error {
 					driverOptions map[string]string
 					opts          interface{}
 				)
-				switch data.(type) {
-				case map[string]interface{}:
-					opts = data.(map[string]interface{})
-				case map[string]string:
-					opts = data.(map[string]string)
+				switch t := data.(type) {
+				case map[string]interface{}, map[string]string:
+					opts = t
 				}
 				ba, err := json.Marshal(opts)
 				if err != nil {

--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -288,7 +288,12 @@ func (nDB *NetworkDB) rejoinClusterBootStrap() {
 		return
 	}
 
-	myself, _ := nDB.nodes[nDB.config.NodeID]
+	myself, ok := nDB.nodes[nDB.config.NodeID]
+	if !ok {
+		nDB.RUnlock()
+		logrus.Warnf("rejoinClusterBootstrap unable to find local node info using ID:%v", nDB.config.NodeID)
+		return
+	}
 	bootStrapIPs := make([]string, 0, len(nDB.bootStrapIP))
 	for _, bootIP := range nDB.bootStrapIP {
 		// botostrap IPs are usually IP:port from the Join


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2325 for 18.09
relates to https://github.com/moby/moby/issues/38618

```
git checkout -b 18.09_backport_fix_crash upstream/bump_18.09
git cherry-pick -s -S -x 1954e1c4b2cbdac2ef851acba12ead3ff6791290
git push -u origin
```

cherry-pick was clean; no conflicts

It is possible that the node is not yet present in
the node list map. In this case just print a warning
and return. The next iteration would be fine
