### PR TITLE
[18.09 backport] Fix gosimple

### DIFF
--- a/default_gateway.go
+++ b/default_gateway.go
@@ -181,10 +181,8 @@ func (c *controller) defaultGwNetwork() (Network, error) {
 	defer func() { <-procGwNetwork }()
 
 	n, err := c.NetworkByName(libnGWNetwork)
-	if err != nil {
-		if _, ok := err.(types.NotFoundError); ok {
-			n, err = c.createGWNetwork()
-		}
+	if _, ok := err.(types.NotFoundError); ok {
+		n, err = c.createGWNetwork()
 	}
 	return n, err
 }


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2320 for the 18.09 branch


```
git checkout -b 18.09_backport_fix_build upstream/bump_18.09
git cherry-pick -s -S -x fd6be31abb9a44a61286cbc4671519086cc313cb
```