### PR TITLE
[17.06 backport] Fix gosimple, and update to Golang 1.10.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.7 as dev
+FROM golang:1.10.7 as dev
 RUN apt-get update && apt-get -y install iptables
 
 RUN go get github.com/golang/lint/golint \

--- a/default_gateway.go
+++ b/default_gateway.go
@@ -179,10 +179,8 @@ func (c *controller) defaultGwNetwork() (Network, error) {
 	defer func() { <-procGwNetwork }()
 
 	n, err := c.NetworkByName(libnGWNetwork)
-	if err != nil {
-		if _, ok := err.(types.NotFoundError); ok {
-			n, err = c.createGWNetwork()
-		}
+	if _, ok := err.(types.NotFoundError); ok {
+		n, err = c.createGWNetwork()
 	}
 	return n, err
 }

--- a/network.go
+++ b/network.go
@@ -388,11 +388,9 @@ func (n *network) validateConfiguration() error {
 					driverOptions map[string]string
 					opts          interface{}
 				)
-				switch data.(type) {
-				case map[string]interface{}:
-					opts = data.(map[string]interface{})
-				case map[string]string:
-					opts = data.(map[string]string)
+				switch t := data.(type) {
+				case map[string]interface{}, map[string]string:
+					opts = t
 				}
 				ba, err := json.Marshal(opts)
 				if err != nil {


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2320 for the 17.06 branch


```
git checkout -b 17.06_backport_fix_build upstream/bump_17.06
git cherry-pick -s -S -x fd6be31abb9a44a61286cbc4671519086cc313cb
```