### PR TITLE
Bump Go to 1.10.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.2 as dev
+FROM golang:1.10.7 as dev
 RUN apt-get update && apt-get -y install iptables \
 		protobuf-compiler
 


### PR DESCRIPTION
I'll backport this to the release branches (which use Go 1.10). Perhaps bump master to Go 1.11 after that