### PR TITLE
[18.09 backport] Bump Go to 1.10.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.2 as dev
+FROM golang:1.10.7 as dev
 RUN apt-get update && apt-get -y install iptables \
 		protobuf-compiler
 


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2332 for the 18.09 branch


ping @fcrisciani ptal