### PR TITLE
controller: Check if IPTables is enabled for arrangeUserFilterRule

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -679,29 +679,6 @@ func (c *controller) isAgent() bool {
 	return c.cfg.Daemon.ClusterProvider.IsAgent()
 }
 
-func (c *controller) hasIPTablesEnabled() bool {
-	c.Lock()
-	defer c.Unlock()
-
-	if c.cfg == nil || c.cfg.Daemon.DriverCfg[netlabel.GenericData] == nil {
-		return false
-	}
-
-	genericData, ok := c.cfg.Daemon.DriverCfg[netlabel.GenericData]
-	if !ok {
-		return false
-	}
-
-	optMap := genericData.(map[string]interface{})
-
-	enabled, ok := optMap["EnableIPTables"].(bool)
-	if !ok {
-		return false
-	}
-
-	return enabled
-}
-
 func (c *controller) isDistributedControl() bool {
 	return !c.isManager() && !c.isAgent()
 }
@@ -925,9 +902,7 @@ addToStore:
 		c.Unlock()
 	}
 
-	if c.hasIPTablesEnabled() {
-		c.arrangeUserFilterRule()
-	}
+	c.arrangeUserFilterRule()
 
 	return network, nil
 }

--- a/controller.go
+++ b/controller.go
@@ -679,6 +679,29 @@ func (c *controller) isAgent() bool {
 	return c.cfg.Daemon.ClusterProvider.IsAgent()
 }
 
+func (c *controller) hasIPTablesEnabled() bool {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.cfg == nil || c.cfg.Daemon.DriverCfg[netlabel.GenericData] == nil {
+		return false
+	}
+
+	genericData, ok := c.cfg.Daemon.DriverCfg[netlabel.GenericData]
+	if !ok {
+		return false
+	}
+
+	optMap := genericData.(map[string]interface{})
+
+	enabled, ok := optMap["EnableIPTables"].(bool)
+	if !ok {
+		return false
+	}
+
+	return enabled
+}
+
 func (c *controller) isDistributedControl() bool {
 	return !c.isManager() && !c.isAgent()
 }
@@ -902,7 +925,9 @@ addToStore:
 		c.Unlock()
 	}
 
-	c.arrangeUserFilterRule()
+	if c.hasIPTablesEnabled() {
+		c.arrangeUserFilterRule()
+	}
 
 	return network, nil
 }


### PR DESCRIPTION
This allows the `--iptables=false` argument to the `dockerd` to work correctly
by checking if IPTables is enabled before creating the user filter rules
in the controller.

This probably fixes: 
  - #2158 
  - https://github.com/moby/moby/issues/35777
  - https://github.com/docker/for-linux/issues/136

and possibly more. I didn't dig too deep.

