### PR TITLE
Revert "debian has iptables-legacy and iptables-nft now"

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -87,16 +87,11 @@ func initFirewalld() {
 }
 
 func detectIptables() {
-	path, err := exec.LookPath("iptables-legacy") // debian has iptables-legacy and iptables-nft now
+	path, err := exec.LookPath("iptables")
 	if err != nil {
-		path, err = exec.LookPath("iptables")
-		if err != nil {
-			return
-		}
+		return
 	}
-
 	iptablesPath = path
-
 	supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
 	mj, mn, mc, err := GetVersion()
 	if err != nil {


### PR DESCRIPTION
This reverts commit 7da66eea9f68e4abc83ed2892114ec565eddd66a.

Libnetwork should only use the iptables binary. Iptables v1.8 and above
uses the nftables backend. The translations for all the rules used by
libnetwork is supported by the new iptables binary.