### PR TITLE
[18.09 backport] Revert "Merge pull request #2286 from thaJeztah/18.09_backport_iptables_legacy"

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -87,16 +87,11 @@ func initFirewalld() {
 }
 
 func detectIptables() {
-	path, err := exec.LookPath("iptables-legacy") // debian has iptables-legacy and iptables-nft now
+	path, err := exec.LookPath("iptables")
 	if err != nil {
-		path, err = exec.LookPath("iptables")
-		if err != nil {
-			return
-		}
+		return
 	}
-
 	iptablesPath = path
-
 	supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
 	mj, mn, mc, err := GetVersion()
 	if err != nil {


### PR DESCRIPTION
reverts https://github.com/docker/libnetwork/pull/2286 (backport of https://github.com/docker/libnetwork/pull/2285)
relates to https://github.com/moby/moby/issues/38099
same as https://github.com/docker/libnetwork/pull/2343


This reverts commit f27ba28f7510103b118b54ae7fbfa00e8a3ed1ad, reversing
changes made to 6da50d1978302f04c3e2089e29112ea24812f05b.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>