### PR TITLE
[18.03] Revert "Merge pull request #2287 from thaJeztah/18.03_backport_iptables_legacy"

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -87,16 +87,11 @@ func initFirewalld() {
 }
 
 func detectIptables() {
-	path, err := exec.LookPath("iptables-legacy") // debian has iptables-legacy and iptables-nft now
+	path, err := exec.LookPath("iptables")
 	if err != nil {
-		path, err = exec.LookPath("iptables")
-		if err != nil {
-			return
-		}
+		return
 	}
-
 	iptablesPath = path
-
 	supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
 	mj, mn, mc, err := GetVersion()
 	if err != nil {


### PR DESCRIPTION
reverts https://github.com/docker/libnetwork/pull/2287 (backport of https://github.com/docker/libnetwork/pull/2285)
relates to https://github.com/moby/moby/issues/38099
same as https://github.com/docker/libnetwork/pull/2343

This reverts commit 5a2b0bd6a1e13562c6711c6a5c1f22c97a0ffac3, reversing
changes made to c2b3907ffccf3ffc6a5c19bbda08620b140cbe84.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>