### PR TITLE
special DNS record for host.docker.internal + gateway.docker.internal

### DIFF
--- a/sandbox.go
+++ b/sandbox.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -135,6 +136,7 @@ type containerConfig struct {
 const (
 	resolverIPSandbox  = "127.0.0.11"
 	hostDockerInternal = "host.docker.internal"
+	gatewayDockerInternal = "gateway.docker.internal"
 )
 
 func (sb *sandbox) ID() string {
@@ -428,7 +430,10 @@ func (sb *sandbox) updateGateway(ep *endpoint) error {
 		return fmt.Errorf("failed to set IPv6 gateway while updating gateway: %v", err)
 	}
 
-	ep.network.addSvcRecords(ep.ID(), hostDockerInternal, ep.svcID, ep.Gateway(), ep.GatewayIPv6(), true, "updateGateway")
+	if ep.needResolver() && runtime.GOOS == "linux" {
+		ep.network.addSvcRecords(ep.ID(), hostDockerInternal, ep.svcID, ep.Gateway(), ep.GatewayIPv6(), true, "updateGateway")
+		ep.network.addSvcRecords(ep.ID(), gatewayDockerInternal, ep.svcID, ep.Gateway(), ep.GatewayIPv6(), true, "updateGateway")
+	}
 
 	return nil
 }

--- a/sandbox.go
+++ b/sandbox.go
@@ -133,7 +133,7 @@ type containerConfig struct {
 }
 
 const (
-	resolverIPSandbox = "127.0.0.11"
+	resolverIPSandbox  = "127.0.0.11"
 	hostDockerInternal = "host.docker.internal"
 )
 

--- a/sandbox.go
+++ b/sandbox.go
@@ -133,7 +133,8 @@ type containerConfig struct {
 }
 
 const (
-	resolverIPSandbox = "127.0.0.11"
+	resolverIPSandbox  = "127.0.0.11"
+	hostDockerInternal = "host.docker.internal"
 )
 
 func (sb *sandbox) ID() string {
@@ -703,6 +704,7 @@ func (sb *sandbox) EnableService() (err error) {
 				return fmt.Errorf("could not update state for endpoint %s into cluster: %v", ep.Name(), err)
 			}
 			ep.enableService()
+			ep.network.addSvcRecords(ep.ID(), hostDockerInternal, ep.svcID, ep.Gateway(), ep.GatewayIPv6(), true, "EnableService")
 		}
 	}
 	logrus.Debugf("EnableService %s DONE", sb.containerID)
@@ -723,6 +725,7 @@ func (sb *sandbox) DisableService() (err error) {
 				failedEps = append(failedEps, ep.Name())
 				logrus.Warnf("failed update state for endpoint %s into cluster: %v", ep.Name(), err)
 			}
+			ep.network.deleteSvcRecords(ep.ID(), hostDockerInternal, ep.svcID, ep.Gateway(), ep.GatewayIPv6(), true, "DisableService")
 			ep.disableService()
 		}
 	}

--- a/sandbox.go
+++ b/sandbox.go
@@ -134,8 +134,8 @@ type containerConfig struct {
 }
 
 const (
-	resolverIPSandbox  = "127.0.0.11"
-	hostDockerInternal = "host.docker.internal"
+	resolverIPSandbox     = "127.0.0.11"
+	hostDockerInternal    = "host.docker.internal"
 	gatewayDockerInternal = "gateway.docker.internal"
 )
 

--- a/sandbox.go
+++ b/sandbox.go
@@ -133,7 +133,7 @@ type containerConfig struct {
 }
 
 const (
-	resolverIPSandbox  = "127.0.0.11"
+	resolverIPSandbox = "127.0.0.11"
 	hostDockerInternal = "host.docker.internal"
 )
 
@@ -706,7 +706,6 @@ func (sb *sandbox) EnableService() (err error) {
 				return fmt.Errorf("could not update state for endpoint %s into cluster: %v", ep.Name(), err)
 			}
 			ep.enableService()
-
 		}
 	}
 	logrus.Debugf("EnableService %s DONE", sb.containerID)

--- a/sandbox.go
+++ b/sandbox.go
@@ -428,6 +428,8 @@ func (sb *sandbox) updateGateway(ep *endpoint) error {
 		return fmt.Errorf("failed to set IPv6 gateway while updating gateway: %v", err)
 	}
 
+	ep.network.addSvcRecords(ep.ID(), hostDockerInternal, ep.svcID, ep.Gateway(), ep.GatewayIPv6(), true, "updateGateway")
+
 	return nil
 }
 
@@ -704,7 +706,7 @@ func (sb *sandbox) EnableService() (err error) {
 				return fmt.Errorf("could not update state for endpoint %s into cluster: %v", ep.Name(), err)
 			}
 			ep.enableService()
-			ep.network.addSvcRecords(ep.ID(), hostDockerInternal, ep.svcID, ep.Gateway(), ep.GatewayIPv6(), true, "EnableService")
+
 		}
 	}
 	logrus.Debugf("EnableService %s DONE", sb.containerID)
@@ -725,7 +727,6 @@ func (sb *sandbox) DisableService() (err error) {
 				failedEps = append(failedEps, ep.Name())
 				logrus.Warnf("failed update state for endpoint %s into cluster: %v", ep.Name(), err)
 			}
-			ep.network.deleteSvcRecords(ep.ID(), hostDockerInternal, ep.svcID, ep.Gateway(), ep.GatewayIPv6(), true, "DisableService")
 			ep.disableService()
 		}
 	}


### PR DESCRIPTION
I was not able to find "magic" for mac and windows systems about 'host.docker.internal' and all solutions in the Net just workarounds. Here I am with my solution... Maybe it's not the best, but it works just fine.
Yes, this functionality can be implemented with dnsmasq, but not everyone can do it by themselves. That's why i find this PR useful