### PR TITLE
Use fewer modprobes

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -72,11 +72,13 @@ func (e ChainError) Error() string {
 }
 
 func probe() {
-	if out, err := exec.Command("modprobe", "-va", "nf_nat").CombinedOutput(); err != nil {
-		logrus.Warnf("Running modprobe nf_nat failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+	path, err := exec.LookPath("iptables")
+	if err != nil {
+		logrus.Warnf("Failed to find iptables: %v", err)
+		return
 	}
-	if out, err := exec.Command("modprobe", "-va", "xt_conntrack").CombinedOutput(); err != nil {
-		logrus.Warnf("Running modprobe xt_conntrack failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+	if out, err := exec.Command(path, "--wait", "-t", "nat", "-L", "-n").CombinedOutput(); err != nil {
+		logrus.Warnf("Running iptables --wait -t nat -L -n failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
 	}
 }
 

--- a/ns/init_linux.go
+++ b/ns/init_linux.go
@@ -76,12 +76,8 @@ func NlHandle() *netlink.Handle {
 func getSupportedNlFamilies() []int {
 	fams := []int{syscall.NETLINK_ROUTE}
 	// NETLINK_XFRM test
-	if err := loadXfrmModules(); err != nil {
-		if checkXfrmSocket() != nil {
-			logrus.Warnf("Could not load necessary modules for IPSEC rules: %v", err)
-		} else {
-			fams = append(fams, syscall.NETLINK_XFRM)
-		}
+	if err := checkXfrmSocket(); err != nil {
+		logrus.Warnf("Could not load necessary modules for IPSEC rules: %v", err)
 	} else {
 		fams = append(fams, syscall.NETLINK_XFRM)
 	}
@@ -97,16 +93,6 @@ func getSupportedNlFamilies() []int {
 	}
 
 	return fams
-}
-
-func loadXfrmModules() error {
-	if out, err := exec.Command("modprobe", "-va", "xfrm_user").CombinedOutput(); err != nil {
-		return fmt.Errorf("Running modprobe xfrm_user failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
-	}
-	if out, err := exec.Command("modprobe", "-va", "xfrm_algo").CombinedOutput(); err != nil {
-		return fmt.Errorf("Running modprobe xfrm_algo failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
-	}
-	return nil
 }
 
 // API check on required xfrm modules (xfrm_user, xfrm_algo)


### PR DESCRIPTION
It's not customary for user space programs to modprobe stuff in general. Modern distributions will autoload modules (if it is indeed a module and not built-in) on access anyway, so it's also not necessary to manually modprobe stuff.

Therefore, this replaces modprobe by actual accesses of the devices. See also https://github.com/moby/moby/pull/38930