### PR TITLE
[18.09 backport] Cleanup the cluster provider when the agent is closed

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -378,6 +378,9 @@ func (c *controller) agentClose() {
 	c.agent = nil
 	c.Unlock()
 
+	// when the agent is closed the cluster provider should be cleaned up
+	c.SetClusterProvider(nil)
+
 	if agent == nil {
 		return
 	}


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2307 for the  18.09 branch