### PR TITLE
cherry-pick #2356

### DIFF
--- a/drivers/windows/overlay/peerdb_windows.go
+++ b/drivers/windows/overlay/peerdb_windows.go
@@ -67,8 +67,7 @@ func (d *driver) peerAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask,
 		}
 
 		n.removeEndpointWithAddress(addr)
-
-		hnsresponse, err := hcsshim.HNSEndpointRequest("POST", "", string(configurationb))
+		hnsresponse, err := endpointRequest("POST", "", string(configurationb))
 		if err != nil {
 			return err
 		}
@@ -108,7 +107,7 @@ func (d *driver) peerDelete(nid, eid string, peerIP net.IP, peerIPMask net.IPMas
 	}
 
 	if updateDb {
-		_, err := hcsshim.HNSEndpointRequest("DELETE", ep.profileID, "")
+		_, err := endpointRequest("DELETE", ep.profileID, "")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When multiple networks are present in a Swarm Cluster, multiple peerAdd or peerDelete calls are an issue for different remote endpoints. These threads are updating the remote endpoint to HNS parallelly. In 2016 HNS code base, we don't have synchronization around remoteEndpoint addition and deletion. So serializing the peerAdd and peerDelete calls from docker network driver.

Signed-off-by: Pradip Dhara <pradipd@microsoft.com>