### PR TITLE
Cherry-pick #2357 : Adding error log if peerAdd fails

### DIFF
--- a/drivers/windows/overlay/joinleave_windows.go
+++ b/drivers/windows/overlay/joinleave_windows.go
@@ -95,7 +95,10 @@ func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key stri
 		return
 	}
 
-	d.peerAdd(nid, eid, addr.IP, addr.Mask, mac, vtep, true)
+	err = d.peerAdd(nid, eid, addr.IP, addr.Mask, mac, vtep, true)
+	if err != nil {
+		logrus.Errorf("peerAdd failed (%v) for ip %s with mac %s", err, addr.IP.String(), mac.String())
+	}
 }
 
 func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (string, map[string]string) {


### PR DESCRIPTION


Signed-off-by: Madhu Venugopal <madhu@docker.com>