### PR TITLE
controller.loadIPAMDriver: Unwrap error type returned by PluginGetter

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -1298,7 +1298,7 @@ func (c *controller) loadIPAMDriver(name string) error {
 	}
 
 	if err != nil {
-		if err == plugins.ErrNotFound {
+		if errors.Cause(err) == plugins.ErrNotFound {
 			return types.NotFoundErrorf(err.Error())
 		}
 		return err


### PR DESCRIPTION
splitting this of https://github.com/docker/libnetwork/pull/2118, but a similar change was already merged in https://github.com/docker/libnetwork/pull/2183, which had a nice description so I blatantly copied that 😂 


moby/moby commit https://github.com/moby/moby/commit/b27f70d45 (https://github.com/moby/moby/pull/36119) wraps the ErrNotFound error returned when
a plugin cannot be found, to include a backtrace.   This changes the type of the error, so contoller.loadIPAMDriver no longer converts it to a
 ibnetwork plugin.NotFoundError.

This is a similar patch as was merged in aacec8e1adb71934c7fa56404c024eb74ad7fdc0 (https://github.com/docker/libnetwork/pull/2183)
