### PR TITLE
(windows) Pick a random host port if the user does not specify a host port. 

### DIFF
--- a/drivers/windows/overlay/ov_network_windows.go
+++ b/drivers/windows/overlay/ov_network_windows.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Microsoft/hcsshim"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netlabel"
+	"github.com/docker/libnetwork/portmapper"
 	"github.com/docker/libnetwork/types"
 	"github.com/sirupsen/logrus"
 )
@@ -46,6 +47,7 @@ type network struct {
 	initErr         error
 	subnets         []*subnet
 	secure          bool
+	portMapper      *portmapper.PortMapper
 	sync.Mutex
 }
 
@@ -89,10 +91,11 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 	}
 
 	n := &network{
-		id:        id,
-		driver:    d,
-		endpoints: endpointTable{},
-		subnets:   []*subnet{},
+		id:         id,
+		driver:     d,
+		endpoints:  endpointTable{},
+		subnets:    []*subnet{},
+		portMapper: portmapper.New(""),
 	}
 
 	genData, ok := option[netlabel.GenericData].(map[string]string)

--- a/drivers/windows/port_mapping.go
+++ b/drivers/windows/port_mapping.go
@@ -1,0 +1,125 @@
+// +build windows
+
+package windows
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/docker/libnetwork/portmapper"
+	"github.com/docker/libnetwork/types"
+	"github.com/ishidawataru/sctp"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	maxAllocatePortAttempts = 10
+)
+
+// ErrUnsupportedAddressType is returned when the specified address type is not supported.
+type ErrUnsupportedAddressType string
+
+func (uat ErrUnsupportedAddressType) Error() string {
+	return fmt.Sprintf("unsupported address type: %s", string(uat))
+}
+
+// AllocatePorts allocates ports specified in bindings from the portMapper
+func AllocatePorts(portMapper *portmapper.PortMapper, bindings []types.PortBinding, containerIP net.IP) ([]types.PortBinding, error) {
+	bs := make([]types.PortBinding, 0, len(bindings))
+	for _, c := range bindings {
+		b := c.GetCopy()
+		if err := allocatePort(portMapper, &b, containerIP); err != nil {
+			// On allocation failure, release previously allocated ports. On cleanup error, just log a warning message
+			if cuErr := ReleasePorts(portMapper, bs); cuErr != nil {
+				logrus.Warnf("Upon allocation failure for %v, failed to clear previously allocated port bindings: %v", b, cuErr)
+			}
+			return nil, err
+		}
+		bs = append(bs, b)
+	}
+	return bs, nil
+}
+
+func allocatePort(portMapper *portmapper.PortMapper, bnd *types.PortBinding, containerIP net.IP) error {
+	var (
+		host net.Addr
+		err  error
+	)
+
+	// Store the container interface address in the operational binding
+	bnd.IP = containerIP
+
+	// Adjust HostPortEnd if this is not a range.
+	if bnd.HostPortEnd == 0 {
+		bnd.HostPortEnd = bnd.HostPort
+	}
+
+	// Construct the container side transport address
+	container, err := bnd.ContainerAddr()
+	if err != nil {
+		return err
+	}
+
+	// Try up to maxAllocatePortAttempts times to get a port that's not already allocated.
+	for i := 0; i < maxAllocatePortAttempts; i++ {
+		if host, err = portMapper.MapRange(container, bnd.HostIP, int(bnd.HostPort), int(bnd.HostPortEnd), false); err == nil {
+			break
+		}
+		// There is no point in immediately retrying to map an explicitly chosen port.
+		if bnd.HostPort != 0 {
+			logrus.Warnf("Failed to allocate and map port %d-%d: %s", bnd.HostPort, bnd.HostPortEnd, err)
+			break
+		}
+		logrus.Warnf("Failed to allocate and map port: %s, retry: %d", err, i+1)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Save the host port (regardless it was or not specified in the binding)
+	switch netAddr := host.(type) {
+	case *net.TCPAddr:
+		bnd.HostPort = uint16(host.(*net.TCPAddr).Port)
+		break
+	case *net.UDPAddr:
+		bnd.HostPort = uint16(host.(*net.UDPAddr).Port)
+		break
+	case *sctp.SCTPAddr:
+		bnd.HostPort = uint16(host.(*sctp.SCTPAddr).Port)
+		break
+	default:
+		// For completeness
+		return ErrUnsupportedAddressType(fmt.Sprintf("%T", netAddr))
+	}
+	//Windows does not support host port ranges.
+	bnd.HostPortEnd = bnd.HostPort
+	return nil
+}
+
+// ReleasePorts releases ports specified in bindings from the portMapper
+func ReleasePorts(portMapper *portmapper.PortMapper, bindings []types.PortBinding) error {
+	var errorBuf bytes.Buffer
+
+	// Attempt to release all port bindings, do not stop on failure
+	for _, m := range bindings {
+		if err := releasePort(portMapper, m); err != nil {
+			errorBuf.WriteString(fmt.Sprintf("\ncould not release %v because of %v", m, err))
+		}
+	}
+
+	if errorBuf.Len() != 0 {
+		return errors.New(errorBuf.String())
+	}
+	return nil
+}
+
+func releasePort(portMapper *portmapper.PortMapper, bnd types.PortBinding) error {
+	// Construct the host side transport address
+	host, err := bnd.HostAddr()
+	if err != nil {
+		return err
+	}
+	return portMapper.Unmap(host)
+}

--- a/portallocator/portallocator.go
+++ b/portallocator/portallocator.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package portallocator
 
 import (

--- a/portallocator/portallocator_windows.go
+++ b/portallocator/portallocator_windows.go
@@ -1,1 +1,10 @@
 package portallocator
+
+const (
+	StartPortRange = 60000
+	EndPortRange   = 65000
+)
+
+func getDynamicPortRange() (start int, end int, err error) {
+	return StartPortRange, EndPortRange, nil
+}

--- a/portmapper/mapper_linux.go
+++ b/portmapper/mapper_linux.go
@@ -1,0 +1,46 @@
+package portmapper
+
+import (
+	"net"
+	"sync"
+
+	"github.com/docker/libnetwork/iptables"
+	"github.com/docker/libnetwork/portallocator"
+)
+
+// PortMapper manages the network address translation
+type PortMapper struct {
+	bridgeName string
+
+	// udp:ip:port
+	currentMappings map[string]*mapping
+	lock            sync.Mutex
+
+	proxyPath string
+
+	Allocator *portallocator.PortAllocator
+	chain     *iptables.ChainInfo
+}
+
+// SetIptablesChain sets the specified chain into portmapper
+func (pm *PortMapper) SetIptablesChain(c *iptables.ChainInfo, bridgeName string) {
+	pm.chain = c
+	pm.bridgeName = bridgeName
+}
+
+// AppendForwardingTableEntry adds a port mapping to the forwarding table
+func (pm *PortMapper) AppendForwardingTableEntry(proto string, sourceIP net.IP, sourcePort int, containerIP string, containerPort int) error {
+	return pm.forward(iptables.Append, proto, sourceIP, sourcePort, containerIP, containerPort)
+}
+
+// DeleteForwardingTableEntry removes a port mapping from the forwarding table
+func (pm *PortMapper) DeleteForwardingTableEntry(proto string, sourceIP net.IP, sourcePort int, containerIP string, containerPort int) error {
+	return pm.forward(iptables.Delete, proto, sourceIP, sourcePort, containerIP, containerPort)
+}
+
+func (pm *PortMapper) forward(action iptables.Action, proto string, sourceIP net.IP, sourcePort int, containerIP string, containerPort int) error {
+	if pm.chain == nil {
+		return nil
+	}
+	return pm.chain.Forward(action, sourceIP, sourcePort, proto, containerIP, containerPort, pm.bridgeName)
+}

--- a/portmapper/mapper_windows.go
+++ b/portmapper/mapper_windows.go
@@ -1,0 +1,31 @@
+package portmapper
+
+import (
+	"net"
+	"sync"
+
+	"github.com/docker/libnetwork/portallocator"
+)
+
+// PortMapper manages the network address translation
+type PortMapper struct {
+	bridgeName string
+
+	// udp:ip:port
+	currentMappings map[string]*mapping
+	lock            sync.Mutex
+
+	proxyPath string
+
+	Allocator *portallocator.PortAllocator
+}
+
+// AppendForwardingTableEntry adds a port mapping to the forwarding table
+func (pm *PortMapper) AppendForwardingTableEntry(proto string, sourceIP net.IP, sourcePort int, containerIP string, containerPort int) error {
+	return nil
+}
+
+// DeleteForwardingTableEntry removes a port mapping from the forwarding table
+func (pm *PortMapper) DeleteForwardingTableEntry(proto string, sourceIP net.IP, sourcePort int, containerIP string, containerPort int) error {
+	return nil
+}

--- a/portmapper/proxy_windows.go
+++ b/portmapper/proxy_windows.go
@@ -1,0 +1,10 @@
+package portmapper
+
+import (
+	"errors"
+	"net"
+)
+
+func newProxyCommand(proto string, hostIP net.IP, hostPort int, containerIP net.IP, containerPort int, proxyPath string) (userlandProxy, error) {
+	return nil, errors.New("proxy is unsupported on windows")
+}


### PR DESCRIPTION
For overlay, l2bridge, and l2tunnel, if the user does not specify a host port, windows driver will select a random port for them.  This matches linux behavior.
For ics and nat networks the windows OS will choose the port.

Signed-off-by: Pradip Dhara <pradipd@microsoft.com>