### PR TITLE
Forcing a nil IP specified in PortBindings to IPv4zero (0.0.0.0).

### DIFF
--- a/drivers/windows/port_mapping.go
+++ b/drivers/windows/port_mapping.go
@@ -48,6 +48,12 @@ func allocatePort(portMapper *portmapper.PortMapper, bnd *types.PortBinding, con
 		err  error
 	)
 
+	// Windows does not support a host ip for port bindings (this is validated in ConvertPortBindings()).
+	// If the HostIP is nil, force it to be 0.0.0.0 for use as the key in portMapper.
+	if bnd.HostIP == nil {
+		bnd.HostIP = net.IPv4zero
+	}
+
 	// Store the container interface address in the operational binding
 	bnd.IP = containerIP
 

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -462,7 +462,7 @@ func ConvertPortBindings(portBindings []types.PortBinding) ([]json.RawMessage, e
 			return nil, fmt.Errorf("Windows does not support more than one host port in NAT settings")
 		}
 
-		if len(elem.HostIP) != 0 {
+		if len(elem.HostIP) != 0 && !elem.HostIP.IsUnspecified() {
 			return nil, fmt.Errorf("Windows does not support host IP addresses in NAT settings")
 		}
 


### PR DESCRIPTION
We were using a different key for the port mapper.
During AllocatePorts, the portbindings hostIP was nil.  So, the key to the port mapper was <HostIP:nil, host port, etc...>
However, during ReleasePorts, the portbindings hostIP was 0.0.0.0.  So, the key to port mapper was <HostIP:0.0.0.0, host port, etc...>
Since thoe HostIP was different (nil vs 0.0.0.0), we never removed the entry from the port mapper.  This resulted in us leaking all the port bindings in port mapper.

Signed-off-by: Pradip Dhara <pradipd@microsoft.com>