### PR TITLE
[Backport 17.06] NetworkDB qlen optimization

### DIFF
--- a/networkdb/cluster.go
+++ b/networkdb/cluster.go
@@ -29,6 +29,9 @@ const (
 	nodeReapPeriod        = 2 * time.Hour
 	rejoinClusterDuration = 10 * time.Second
 	rejoinInterval        = 60 * time.Second
+	// considering a cluster with > 20 nodes and a drain speed of 100 msg/s
+	// the following is roughly 1 minute
+	maxQueueLenBroadcastOnSync = 500
 )
 
 type logWriter struct{}
@@ -555,6 +558,7 @@ func (nDB *NetworkDB) bulkSync(nodes []string, all bool) ([]string, error) {
 
 	var err error
 	var networks []string
+	var success bool
 	for _, node := range nodes {
 		if node == nDB.config.NodeName {
 			continue
@@ -562,21 +566,25 @@ func (nDB *NetworkDB) bulkSync(nodes []string, all bool) ([]string, error) {
 		logrus.Debugf("%s: Initiating bulk sync with node %v", nDB.config.NodeName, node)
 		networks = nDB.findCommonNetworks(node)
 		err = nDB.bulkSyncNode(networks, node, true)
-		// if its periodic bulksync stop after the first successful sync
-		if !all && err == nil {
-			break
-		}
 		if err != nil {
 			err = fmt.Errorf("bulk sync to node %s failed: %v", node, err)
 			logrus.Warn(err.Error())
+		} else {
+			// bulk sync succeeded
+			success = true
+			// if its periodic bulksync stop after the first successful sync
+			if !all {
+				break
+			}
 		}
 	}
 
-	if err != nil {
-		return nil, err
+	if success {
+		// if at least one node sync succeeded
+		return networks, nil
 	}
 
-	return networks, nil
+	return nil, err
 }
 
 // Bulk sync all the table entries belonging to a set of networks to a


### PR DESCRIPTION
Backport of #2216 to 17.06.  This should be considered a starting point.  Behaves as expected.  Needs further review from a logic standpoint.

```
git checkout -b 17.06-netdb-qlen-issue origin/bump_17.06
git cherry-pick -sx 5ed38221164e04c78d20f17839aab52fafd7fe88
```

## Cherry-Pick Conflicts
|Location|Conflict Reason|Resolution|
|--|--|--|
|`networkdb/broadcast.go:113`,`networkdb/broadcast.go:171`|`node` was removed by #2216. `nDB.config.NodeName` changed to `nDB.config.NodeID` via #1936 and was then removed in #2216|"ours". Keeping this message in since I don't know when and why it became unnecessary. See https://github.com/docker/libnetwork/pull/2216/commits/5ed38221164e04c78d20f17839aab52fafd7fe88#r200441648. Decision to leave this in amenable to further research into why it was removed with #2216, which removed it to make networkdb more efficient.|
|`networkdb/cluster.go:30`|Order of variables in patch context does not match following #2169 which backported #2134.|"both". Keep `rejoinClusterDuration` and `rejoinInterval` as in 17.06 and bring in `maxQueueLenBroadcastOnSync` from #2216.|
|`networkdb/delegate.go:277`|`reapEntryInterval` moved to networkdb.go:Config in #1957|Stay with 17.06 const convention for `reapEntryInterval`|

## Logical Conflicts

|Location|Conflict Reason|Resolution|
|--|--|--|
|`networkdb/delegate.go:179`|#2040 not in 17.06. `fatal error: sync: Unlock of unlocked RWMutex`|"ours". Don't need to unlock for a lock that 17.06 does not have. Do not take this line from #2216.|


## How I tested

1. Vendor this PR onto github.com/docker/docker-ee tag v17.06.2-ee-21 and change networkdb `StatsPrintPeriod` from 5 minutes to 15 seconds to improve observability in test.

2. In a separate build backport the networkdb diagnostic API to libnetwork 9a47f8d2780614c1cfb2572bd713a222402f6420 and docker-ee cd8d740be0c048f156438d21975af753ac1b5225 (v17.06.2-ee-20).  Use this build to stress networkdb in steps 6 and 8.

	* https://github.com/docker/libnetwork/pull/2027
	* https://github.com/docker/libnetwork/pull/2216
	* https://github.com/docker/libnetwork/pull/2032
	* https://github.com/moby/moby/pull/35677

3. Bring up a 31 node dind cluster (one manager 30 workers) with the build from step 1.

4. Join one worker on 17.06 build from step 2 with networkdb diagnostic API.

5. Create an overlay network and deploy a mode global service to it.

6. Use the diagnostic API to introduce a "static load" of 1400 additional entries, half in `endpoint_table`, and half in `overlay_peer_table` on the test network.

7. Wait for test network qLen to reach 0 on all nodes according to `NetworkDB stats` in dockerd logs.

8. Use the diagnostic node to introduce a "dynamic load" by adding and 0.5s later removing an `endpoint_table` entry, doing this three times a second continuously.  This seems to be about the max rate the cluster can sustain under otherwise quiet conditions before qLen begins to grow without bound. 

9. Restart one of the non-diagnostic workers, and observe its qLen.  Prior to this PR, qLen on the joining node initially rises to the total number of entries, then steadily increases from there over minutes.  With this PR qLen on the joining node matches that of other nodes on the first sample after rejoining (within 15s `StatsPrintPeriod`).


### Test tooling
Scripts developed for testing this pr provided for reference below.  They probably won't work flawlessly in your environment.

[test.sh.txt](https://github.com/docker/libnetwork/files/3193168/test.sh.txt) brings up dind cluster.  provide argument `down` to remove the nodes.

[stressndb.sh.txt](https://github.com/docker/libnetwork/files/3193171/stressndb.sh.txt) requires arguments either `static` to introduce 1400 entries or `dynamic` to produce the load noted in steps 6 and 8 above, respectively.