### PR TITLE
bridge: add riscv64 build tags

### DIFF
--- a/drivers/bridge/netlink_deprecated_linux_rawsockaddr_data_int8.go
+++ b/drivers/bridge/netlink_deprecated_linux_rawsockaddr_data_int8.go
@@ -1,4 +1,4 @@
-// +build !arm,!ppc64,!ppc64le
+// +build !arm,!ppc64,!ppc64le,!riscv64
 
 package bridge
 

--- a/drivers/bridge/netlink_deprecated_linux_rawsockaddr_data_uint8.go
+++ b/drivers/bridge/netlink_deprecated_linux_rawsockaddr_data_uint8.go
@@ -1,4 +1,4 @@
-// +build arm ppc64 ppc64le
+// +build arm ppc64 ppc64le riscv64
 
 package bridge
 


### PR DESCRIPTION
Add riscv64 build tags to unbreak the build. If needed I can rename the files cause they are not arm specific (even before this pr).

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>