### PR TITLE
[18.09 backport] Correctly clean up --config-only networks

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -705,11 +705,17 @@ const overlayDSROptionString = "dsr"
 // NewNetwork creates a new network of the specified network type. The options
 // are network specific and modeled in a generic way.
 func (c *controller) NewNetwork(networkType, name string, id string, options ...NetworkOption) (Network, error) {
+	var (
+		cap *driverapi.Capability
+		err error
+		t   *network
+	)
+
 	if id != "" {
 		c.networkLocker.Lock(id)
 		defer c.networkLocker.Unlock(id)
 
-		if _, err := c.NetworkByID(id); err == nil {
+		if _, err = c.NetworkByID(id); err == nil {
 			return nil, NetworkNameError(id)
 		}
 	}
@@ -738,14 +744,9 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 	}
 
 	network.processOptions(options...)
-	if err := network.validateConfiguration(); err != nil {
+	if err = network.validateConfiguration(); err != nil {
 		return nil, err
 	}
-
-	var (
-		cap *driverapi.Capability
-		err error
-	)
 
 	// Reset network types, force local scope and skip allocation and
 	// plumbing for configuration networks. Reset of the config-only
@@ -793,11 +794,11 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 	// From this point on, we need the network specific configuration,
 	// which may come from a configuration-only network
 	if network.configFrom != "" {
-		t, err := c.getConfigNetwork(network.configFrom)
+		t, err = c.getConfigNetwork(network.configFrom)
 		if err != nil {
 			return nil, types.NotFoundErrorf("configuration network %q does not exist", network.configFrom)
 		}
-		if err := t.applyConfigurationTo(network); err != nil {
+		if err = t.applyConfigurationTo(network); err != nil {
 			return nil, types.InternalErrorf("Failed to apply configuration: %v", err)
 		}
 		defer func() {


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2373 for 18.09

The endpoint count for --config-only networks
was being incremented even when the respective --config-from
inherited network failed to create a network

This was due to a variable shadowing problem with err causing
the deferred function to not execute correctly.

Using the same err variable across the entire function fixes
the issue

Fixes: moby/moby#35101
