### PR TITLE
[18.09 backport] remove gosimple - package is gone and it's not important

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ RUN go get golang.org/x/lint/golint \
 		golang.org/x/tools/cmd/cover \
 		github.com/mattn/goveralls \
 		github.com/gordonklaus/ineffassign \
-		github.com/client9/misspell/cmd/misspell \
-		honnef.co/go/tools/cmd/gosimple
+		github.com/client9/misspell/cmd/misspell
 
 WORKDIR /go/src/github.com/docker/libnetwork
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all all-local build build-local clean cross cross-local gosimple vet lint misspell check check-local check-code check-format unit-tests protobuf protobuf-local check-protobuf
+.PHONY: all all-local build build-local clean cross cross-local vet lint misspell check check-local check-code check-format unit-tests protobuf protobuf-local check-protobuf
 SHELL=/bin/bash
 
 dockerbuildargs ?= --target dev - < Dockerfile
@@ -115,7 +115,7 @@ check: builder
 
 check-local: check-code check-format
 
-check-code: check-protobuf lint gosimple vet ineffassign
+check-code: check-protobuf lint vet ineffassign
 
 check-format: fmt misspell
 
@@ -163,10 +163,6 @@ lint: ## run go lint
 ineffassign: ## run ineffassign
 	@echo "🐳 $@"
 	@test -z "$$(ineffassign . | grep -v vendor/ | grep -v ".pb.go:" | grep -v ".mock.go" | tee /dev/stderr)"
-
-gosimple: ## run gosimple
-	@echo "🐳 $@"
-	@test -z "$$(gosimple . | grep -v vendor/ | grep -v ".pb.go:" | grep -v ".mock.go" | tee /dev/stderr)"
 
 # check-protobuf rebuilds .pb.go files and fails if they have changed
 check-protobuf: PROTOC_CHECK=1

--- a/controller.go
+++ b/controller.go
@@ -339,7 +339,6 @@ func (c *controller) clusterAgentInit() {
 				}
 			}
 		case cluster.EventNodeLeave:
-			keysAvailable = false
 			c.agentOperationStart()
 			c.Lock()
 			c.keys = nil


### PR DESCRIPTION
Also fixes issue reported by ineffassign

taken from https://github.com/docker/libnetwork/pull/2385