### PR TITLE
[17.06 backport] remove gosimple - package is gone and it's not important

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN go get github.com/golang/lint/golint \
 		golang.org/x/tools/cmd/cover \
 		github.com/mattn/goveralls \
 		github.com/gordonklaus/ineffassign \
-		github.com/client9/misspell/cmd/misspell \
-		honnef.co/go/tools/cmd/gosimple
+		github.com/client9/misspell/cmd/misspell
 
 WORKDIR /go/src/github.com/docker/libnetwork
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all all-local build build-local clean cross cross-local gosimple vet lint misspell check check-local check-code check-format unit-tests
+.PHONY: all all-local build build-local clean cross cross-local vet lint misspell check check-local check-code check-format unit-tests
 SHELL=/bin/bash
 dockerbuildargs ?= --target dev - < Dockerfile
 dockerargs ?= --privileged -v $(shell pwd):/go/src/github.com/docker/libnetwork -w /go/src/github.com/docker/libnetwork
@@ -55,7 +55,7 @@ check: builder
 
 check-local: check-code check-format
 
-check-code: lint gosimple vet ineffassign
+check-code: lint vet ineffassign
 
 check-format: fmt misspell
 
@@ -103,10 +103,6 @@ lint: ## run go lint
 ineffassign: ## run ineffassign
 	@echo "🐳 $@"
 	@test -z "$$(ineffassign . | grep -v vendor/ | grep -v ".pb.go:" | grep -v ".mock.go" | tee /dev/stderr)"
-
-gosimple: ## run gosimple
-	@echo "🐳 $@"
-	@test -z "$$(gosimple . | grep -v vendor/ | grep -v ".pb.go:" | grep -v ".mock.go" | tee /dev/stderr)"
 
 shell: builder
 	@${docker} ${SHELL}

--- a/controller.go
+++ b/controller.go
@@ -327,7 +327,6 @@ func (c *controller) clusterAgentInit() {
 				}
 			}
 		case cluster.EventNodeLeave:
-			keysAvailable = false
 			c.agentOperationStart()
 			c.Lock()
 			c.keys = nil

--- a/resolver.go
+++ b/resolver.go
@@ -264,7 +264,7 @@ func (r *resolver) handleIPQuery(name string, query *dns.Msg, ipType int) (*dns.
 }
 
 func (r *resolver) handlePTRQuery(ptr string, query *dns.Msg) (*dns.Msg, error) {
-	parts := []string{}
+	var parts []string
 
 	if strings.HasSuffix(ptr, ptrIPv4domain) {
 		parts = strings.Split(ptr, ptrIPv4domain)


### PR DESCRIPTION
Also fixes issue reported by ineffassign

Signed-off-by: Tibor Vass <tibor@docker.com>
Signed-off-by: Euan Harris <euan.harris@docker.com>

We have some other PRs to merge to 17.06 and without this it won't build.