### PR TITLE
[WIP][18.09 backport] Update to Golang 1.12.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.7 as dev
+FROM golang:1.12.6 as dev
 RUN apt-get update && apt-get -y install iptables \
 		protobuf-compiler
 

--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -302,7 +302,7 @@ func setINC(iface string, enable bool) error {
 				if i == 1 {
 					// Rollback the rule installed on first chain
 					if err2 := iptables.ProgramRule(iptables.Filter, chains[0], iptables.Delete, rules[0]); err2 != nil {
-						logrus.Warn("Failed to rollback iptables rule after failure (%v): %v", err, err2)
+						logrus.Warnf("Failed to rollback iptables rule after failure (%v): %v", err, err2)
 					}
 				}
 				return fmt.Errorf(msg)

--- a/drivers/overlay/ostweaks_linux.go
+++ b/drivers/overlay/ostweaks_linux.go
@@ -7,9 +7,9 @@ import (
 )
 
 var ovConfig = map[string]*kernel.OSValue{
-	"net.ipv4.neigh.default.gc_thresh1": {"8192", checkHigher},
-	"net.ipv4.neigh.default.gc_thresh2": {"49152", checkHigher},
-	"net.ipv4.neigh.default.gc_thresh3": {"65536", checkHigher},
+	"net.ipv4.neigh.default.gc_thresh1": {Value: "8192", CheckFn: checkHigher},
+	"net.ipv4.neigh.default.gc_thresh2": {Value: "49152", CheckFn: checkHigher},
+	"net.ipv4.neigh.default.gc_thresh3": {Value: "65536", CheckFn: checkHigher},
 }
 
 func checkHigher(val1, val2 string) bool {

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -433,7 +433,7 @@ func convertQosPolicies(qosPolicies []types.QosPolicy) ([]json.RawMessage, error
 	// understood by the HCS.
 	for _, elem := range qosPolicies {
 		encodedPolicy, err := json.Marshal(hcsshim.QosPolicy{
-			Type: "QOS",
+			Type:                            "QOS",
 			MaximumOutgoingBandwidthInBytes: elem.MaxEgressBandwidth,
 		})
 

--- a/network.go
+++ b/network.go
@@ -1054,7 +1054,7 @@ func (n *network) delete(force bool, rmLBEndpoint bool) error {
 					t.Name(), n.Name(), err)
 			}
 		} else {
-			logrus.Warnf("Could not find configuration network %q during removal of network %q", n.configOnly, n.Name())
+			logrus.Warnf("Could not find configuration network %q during removal of network %q", n.configFrom, n.Name())
 		}
 	}
 

--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -40,7 +40,7 @@ var (
 	loadBalancerConfig = map[string]*kernel.OSValue{
 		// expires connection from the IPVS connection table when the backend is not available
 		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L126:1
-		"net.ipv4.vs.expire_nodest_conn": {"1", nil},
+		"net.ipv4.vs.expire_nodest_conn": {Value: "1", CheckFn: nil},
 	}
 )
 

--- a/resolvconf/resolvconf_test.go
+++ b/resolvconf/resolvconf_test.go
@@ -41,7 +41,7 @@ search example.com`: {"1.2.3.4", "40.3.200.10"},
 		`nameserver 1.2.3.4
 search example.com
 nameserver 4.30.20.100`: {"1.2.3.4", "4.30.20.100"},
-		``: {},
+		``:                        {},
 		`  nameserver 1.2.3.4   `: {"1.2.3.4"},
 		`search example.com
 nameserver 1.2.3.4
@@ -65,7 +65,7 @@ search example.com`: {"1.2.3.4/32", "40.3.200.10/32"},
 		`nameserver 1.2.3.4
 search example.com
 nameserver 4.30.20.100`: {"1.2.3.4/32", "4.30.20.100/32"},
-		``: {},
+		``:                        {},
 		`  nameserver 1.2.3.4   `: {"1.2.3.4/32"},
 		`search example.com
 nameserver 1.2.3.4


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2408 for the 18.09 branch


note that 18.09 is not yet running on Go 1.12, so we might want to hold off until that is merged (work in progress PR to move to 1.11; https://github.com/docker/engine/pull/168)

I'll add "WIP", but we can decide to already merge this if we think that's good to have

