### PR TITLE
Macvlan network handles netlabel.Internal wrong

### DIFF
--- a/drivers/ipvlan/ipvlan_network.go
+++ b/drivers/ipvlan/ipvlan_network.go
@@ -182,10 +182,12 @@ func parseNetworkOptions(id string, option options.Generic) (*configuration, err
 		}
 	}
 	// setting the parent to "" will trigger an isolated network dummy parent link
-	if _, ok := option[netlabel.Internal]; ok {
-		config.Internal = true
-		// empty --parent= and --internal are handled the same.
-		config.Parent = ""
+	if val, ok := option[netlabel.Internal]; ok {
+		if internal, ok := val.(bool); ok && internal {
+			config.Internal = true
+			// empty --parent= and --internal are handled the same.
+			config.Parent = ""
+		}
 	}
 	return config, nil
 }

--- a/drivers/macvlan/macvlan_network.go
+++ b/drivers/macvlan/macvlan_network.go
@@ -186,10 +186,12 @@ func parseNetworkOptions(id string, option options.Generic) (*configuration, err
 		}
 	}
 	// setting the parent to "" will trigger an isolated network dummy parent link
-	if _, ok := option[netlabel.Internal]; ok {
-		config.Internal = true
-		// empty --parent= and --internal are handled the same.
-		config.Parent = ""
+	if val, ok := option[netlabel.Internal]; ok {
+		if internal, ok := val.(bool); ok && internal {
+			config.Internal = true
+			// empty --parent= and --internal are handled the same.
+			config.Parent = ""
+		}
 	}
 
 	return config, nil


### PR DESCRIPTION
check value of netlabel.Internal not just it's existence

Signed-off-by: Pavel Matěja <pavel@verotel.cz>

fixes #2410 