### PR TITLE
vendor: update netns to 7109fa855

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -42,7 +42,7 @@ github.com/samuel/go-zookeeper          d0e0d8e11f318e000a8cc434616d69e329edc374
 github.com/sirupsen/logrus              f006c2ac4710855cf0f916dd6b77acf6b048dc6e # v1.0.3
 github.com/ugorji/go                    b4c50a2b199d93b13dc15e78929cfb23bfdf21ab # v1.1.1
 github.com/vishvananda/netlink          a2ad57a690f3caf3015351d2d6e1c0b95c349752 # v1.0.0
-github.com/vishvananda/netns            13995c7128ccc8e51e9a6bd2b551020a27180abd
+github.com/vishvananda/netns            7109fa855b0ff1ebef7fbd2f6aa613e8db7cfbc0
 golang.org/x/crypto                     b7391e95e576cacdcdd422573063bc057239113d
 golang.org/x/net                        a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1
 golang.org/x/sys                        d455e41777fca6e8a5a79e34a14b8368bc11d9ba

--- a/vendor/github.com/gogo/protobuf/go.mod
+++ b/vendor/github.com/gogo/protobuf/go.mod
@@ -1,0 +1,3 @@
+module github.com/gogo/protobuf
+
+require github.com/kisielk/errcheck v1.1.0 // indirect

--- a/vendor/github.com/gorilla/mux/go.mod
+++ b/vendor/github.com/gorilla/mux/go.mod
@@ -1,0 +1,1 @@
+module github.com/gorilla/mux

--- a/vendor/github.com/vishvananda/netns/README.md
+++ b/vendor/github.com/vishvananda/netns/README.md
@@ -37,7 +37,6 @@ func main() {
 
     // Create a new network namespace
     newns, _ := netns.New()
-    netns.Set(newns)
     defer newns.Close()
 
     // Do something with the network namespace

--- a/vendor/github.com/vishvananda/netns/netns_linux.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux.go
@@ -21,8 +21,10 @@ var SYS_SETNS = map[string]uintptr{
 	"arm":     375,
 	"mips":    4344,
 	"mipsle":  4344,
+	"mips64le":  4344,
 	"ppc64":   350,
 	"ppc64le": 350,
+	"riscv64": 268,
 	"s390x":   339,
 }[runtime.GOARCH]
 
@@ -52,7 +54,8 @@ func Set(ns NsHandle) (err error) {
 	return Setns(ns, CLONE_NEWNET)
 }
 
-// New creates a new network namespace and returns a handle to it.
+// New creates a new network namespace, sets it as current and returns
+// a handle to it.
 func New() (ns NsHandle, err error) {
 	if err := syscall.Unshare(CLONE_NEWNET); err != nil {
 		return -1, err

--- a/vendor/golang.org/x/crypto/go.mod
+++ b/vendor/golang.org/x/crypto/go.mod
@@ -1,0 +1,3 @@
+module golang.org/x/crypto
+
+require golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a

--- a/vendor/golang.org/x/sys/go.mod
+++ b/vendor/golang.org/x/sys/go.mod
@@ -1,0 +1,1 @@
+module golang.org/x/sys


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>

cc @tonistiigi 	@carlosedp I'm surprised this was not needed for https://github.com/moby/moby/pull/39423 or was it an oversight?
