### PR TITLE
Fix hardcoded AF_INET for IPv6 address handling

### DIFF
--- a/ipvs/netlink.go
+++ b/ipvs/netlink.go
@@ -422,8 +422,11 @@ func assembleDestination(attrs []syscall.NetlinkRouteAttr) (*Destination, error)
 		attrType := int(attr.Attr.Type)
 
 		switch attrType {
+
+		case ipvsDestAttrAddressFamily:
+			d.AddressFamily = native.Uint16(attr.Value)
 		case ipvsDestAttrAddress:
-			ip, err := parseIP(attr.Value, syscall.AF_INET)
+			ip, err := parseIP(attr.Value, d.AddressFamily)
 			if err != nil {
 				return nil, err
 			}
@@ -438,8 +441,6 @@ func assembleDestination(attrs []syscall.NetlinkRouteAttr) (*Destination, error)
 			d.UpperThreshold = native.Uint32(attr.Value)
 		case ipvsDestAttrLowerThreshold:
 			d.LowerThreshold = native.Uint32(attr.Value)
-		case ipvsDestAttrAddressFamily:
-			d.AddressFamily = native.Uint16(attr.Value)
 		case ipvsDestAttrActiveConnections:
 			d.ActiveConnections = int(native.Uint16(attr.Value))
 		case ipvsDestAttrInactiveConnections:


### PR DESCRIPTION
Providing fix for hardcoded AF_INET argument in parseIP function call for "destinations". This leads to issues with IPv6 addresses thus they handled as IPv4. 

This patch provides a solution equivalent as its is used for "services":
https://github.com/herrwagner/libnetwork/blob/217bc0e7296b474afb5318b609dee673e819a00e/ipvs/netlink.go#L323-L334
