### PR TITLE
Fix internal macvlan network to work in swarm

### DIFF
--- a/drivers/ipvlan/ipvlan_network.go
+++ b/drivers/ipvlan/ipvlan_network.go
@@ -194,12 +194,9 @@ func parseNetworkOptions(id string, option options.Generic) (*configuration, err
 			return nil, err
 		}
 	}
-	// setting the parent to "" will trigger an isolated network dummy parent link
 	if val, ok := option[netlabel.Internal]; ok {
 		if internal, ok := val.(bool); ok && internal {
 			config.Internal = true
-			// empty --parent= and --internal are handled the same.
-			config.Parent = ""
 		}
 	}
 	return config, nil

--- a/drivers/macvlan/macvlan_network.go
+++ b/drivers/macvlan/macvlan_network.go
@@ -198,12 +198,9 @@ func parseNetworkOptions(id string, option options.Generic) (*configuration, err
 			return nil, err
 		}
 	}
-	// setting the parent to "" will trigger an isolated network dummy parent link
 	if val, ok := option[netlabel.Internal]; ok {
 		if internal, ok := val.(bool); ok && internal {
 			config.Internal = true
-			// empty --parent= and --internal are handled the same.
-			config.Parent = ""
 		}
 	}
 


### PR DESCRIPTION
Using dummy interface allows communication beween containers only if
they are running on the same node in swam.

Signed-off-by: Pavel Matěja <pavel@verotel.cz>