### PR TITLE
Dockerfile: use GO_VERSION build-arg for overriding Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.12.6 as dev
+ARG GO_VERSION=1.12.6
+
+FROM golang:${GO_VERSION} as dev
 RUN apt-get update && apt-get -y install iptables \
 		protobuf-compiler
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ all-local: build-local check-local clean
 # builder builds the libnetworkbuild container.  All wrapper targets
 # must depend on this to ensure that the container exists.
 builder:
-	docker build -t ${build_image} ${dockerbuildargs}
+	docker build -t ${build_image} --build-arg=GO_VERSION ${dockerbuildargs}
 
 build: builder
 	@echo "🐳 $@"


### PR DESCRIPTION
This allows overriding the version of Go without making modifications in the
source code, which can be useful to test against multiple versions.

For example:

    make GO_VERSION=1.13beta1 build

