### PR TITLE
Updating IPAM config with results from HNS create network call.

### DIFF
--- a/driverapi/driverapi.go
+++ b/driverapi/driverapi.go
@@ -95,6 +95,11 @@ type NetworkInfo interface {
 	// TableEventRegister registers driver interest in a given
 	// table name.
 	TableEventRegister(tableName string, objType ObjectType) error
+
+	// UpdateIPamConfig updates the networks IPAM configuration
+	// based on information from the driver.  In windows, the OS (HNS) chooses
+	// the IP address space if the user does not specify an address space.
+	UpdateIpamConfig(ipV4Data []IPAMData)
 }
 
 // InterfaceInfo provides a go interface for drivers to retrieve

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -255,7 +255,7 @@ func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (s
 	return "", nil
 }
 
-func (d *driver) createNetwork(config *networkConfiguration) error {
+func (d *driver) createNetwork(config *networkConfiguration) *hnsNetwork {
 	network := &hnsNetwork{
 		id:         config.ID,
 		endpoints:  make(map[string]*hnsEndpoint),
@@ -268,7 +268,7 @@ func (d *driver) createNetwork(config *networkConfiguration) error {
 	d.networks[config.ID] = network
 	d.Unlock()
 
-	return nil
+	return network
 }
 
 // Create a new network
@@ -293,11 +293,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		return err
 	}
 
-	err = d.createNetwork(config)
-
-	if err != nil {
-		return err
-	}
+	n := d.createNetwork(config)
 
 	// A non blank hnsid indicates that the network was discovered
 	// from HNS. No need to call HNS if this network was discovered
@@ -371,6 +367,36 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 
 		config.HnsID = hnsresponse.Id
 		genData[HNSID] = config.HnsID
+		n.created = true
+
+		defer func() {
+			if err != nil {
+				d.DeleteNetwork(n.id)
+			}
+		}()
+
+		hnsIPv4Data := make([]driverapi.IPAMData, len(hnsresponse.Subnets))
+
+		for i, subnet := range hnsresponse.Subnets {
+			var gwIP, subnetIP *net.IPNet
+
+			//The gateway returned from HNS is an IPAddress.
+			//We need to convert it to an IPNet to use as the Gateway of driverapi.IPAMData struct
+			gwCIDR := subnet.GatewayAddress + "/32"
+			_, gwIP, err = net.ParseCIDR(gwCIDR)
+			if err != nil {
+				return err
+			}
+
+			hnsIPv4Data[i].Gateway = gwIP
+			_, subnetIP, err = net.ParseCIDR(subnet.AddressPrefix)
+			if err != nil {
+				return err
+			}
+			hnsIPv4Data[i].Pool = subnetIP
+		}
+
+		nInfo.UpdateIpamConfig(hnsIPv4Data)
 
 	} else {
 		// Delete any stale HNS endpoints for this network.
@@ -387,13 +413,10 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		} else {
 			logrus.Warnf("Error listing HNS endpoints for network %s", config.HnsID)
 		}
+
+		n.created = true
 	}
 
-	n, err := d.getNetwork(id)
-	if err != nil {
-		return err
-	}
-	n.created = true
 	return d.storeUpdate(config)
 }
 

--- a/drivers/windows/windows_store.go
+++ b/drivers/windows/windows_store.go
@@ -61,9 +61,7 @@ func (d *driver) populateNetworks() error {
 		if ncfg.Type != d.name {
 			continue
 		}
-		if err = d.createNetwork(ncfg); err != nil {
-			logrus.Warnf("could not create windows network for id %s hnsid %s while booting up from persistent state: %v", ncfg.ID, ncfg.HnsID, err)
-		}
+		d.createNetwork(ncfg)
 		logrus.Debugf("Network  %v (%.7s) restored", d.name, ncfg.ID)
 	}
 

--- a/network.go
+++ b/network.go
@@ -1938,6 +1938,22 @@ func (n *network) TableEventRegister(tableName string, objType driverapi.ObjectT
 	return nil
 }
 
+func (n *network) UpdateIpamConfig(ipV4Data []driverapi.IPAMData) {
+
+	ipamV4Config := make([]*IpamConf, len(ipV4Data))
+
+	for i, data := range ipV4Data {
+		ic := &IpamConf{}
+		ic.PreferredPool = data.Pool.String()
+		ic.Gateway = data.Gateway.IP.String()
+		ipamV4Config[i] = ic
+	}
+
+	n.Lock()
+	defer n.Unlock()
+	n.ipamV4Config = ipamV4Config
+}
+
 // Special drivers are ones which do not need to perform any network plumbing
 func (n *network) hasSpecialDriver() bool {
 	return n.Type() == "host" || n.Type() == "null"


### PR DESCRIPTION
In windows HNS manages IPAM.  If the user does not specify a subnet, HNS will choose one
for them.  However, in order for the IPAM to show up in the output of "docker inspect",
we need to update the network IPAMv4Config field.

Signed-off-by: Pradip Dhara <pradipd@microsoft.com>