### PR TITLE
Bumps the GO Version to 1.12.8 which contains security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG GO_VERSION=1.12.6
+ARG GO_VERSION=1.12.8
 
-FROM golang:${GO_VERSION} as dev
+FROM golang:${GO_VERSION}-stretch as dev
 RUN apt-get update && apt-get -y install iptables \
 		protobuf-compiler
 

--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -681,7 +681,7 @@ func (n *networkNamespace) ApplyOSTweaks(types []SandboxType) {
 	for _, t := range types {
 		switch t {
 		case SandboxTypeLoadBalancer:
-			n.InvokeFunc(func() { kernel.ApplyOSTweaks(loadBalancerConfig) })
+			kernel.ApplyOSTweaks(loadBalancerConfig)
 		}
 	}
 }


### PR DESCRIPTION
More info at - 
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/golang-announce/65QixT3tcmg/DrFiG6vvCwAJ