### PR TITLE
log the actual error when failing to add IPv6 route

### DIFF
--- a/drivers/bridge/setup_ipv6.go
+++ b/drivers/bridge/setup_ipv6.go
@@ -70,7 +70,7 @@ func setupBridgeIPv6(config *networkConfiguration, i *bridgeInterface) error {
 		Dst:       config.AddressIPv6,
 	})
 	if err != nil && !os.IsExist(err) {
-		logrus.Errorf("Could not add route to IPv6 network %s via device %s", config.AddressIPv6.String(), config.BridgeName)
+		logrus.Errorf("Could not add route to IPv6 network %s via device %s: %s", config.AddressIPv6.String(), config.BridgeName, err)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Kamil Domański <kamil@domanski.co>

Currently the error message `Could not add route to IPv6 network %s via device %s` obscures the cause of the issue by not logging the original error as well.