### PR TITLE
Fixed getNetworkFromStore, which returned an incorrect struct

### DIFF
--- a/store.go
+++ b/store.go
@@ -81,9 +81,12 @@ func (c *controller) getStores() []datastore.DataStore {
 
 func (c *controller) getNetworkFromStore(nid string) (*network, error) {
 	ns, err := c.getNetworksFromStore()
+	if err != nil {
+		return nil, err
+	}
 	for _, n := range ns {
 		if n.id == nid {
-			return n, err
+			return n, nil
 		}
 	}
 	return nil, fmt.Errorf("network %s not found", nid)

--- a/store.go
+++ b/store.go
@@ -80,30 +80,12 @@ func (c *controller) getStores() []datastore.DataStore {
 }
 
 func (c *controller) getNetworkFromStore(nid string) (*network, error) {
-	for _, store := range c.getStores() {
-		n := &network{id: nid, ctrlr: c}
-		err := store.GetObject(datastore.Key(n.Key()...), n)
-		// Continue searching in the next store if the key is not found in this store
-		if err != nil {
-			if err != datastore.ErrKeyNotFound {
-				logrus.Debugf("could not find network %s: %v", nid, err)
-			}
-			continue
+	ns, err := c.getNetworksFromStore()
+	for _, n := range ns {
+		if n.id == nid {
+			return n, err
 		}
-
-		ec := &endpointCnt{n: n}
-		err = store.GetObject(datastore.Key(ec.Key()...), ec)
-		if err != nil && !n.inDelete {
-			return nil, fmt.Errorf("could not find endpoint count for network %s: %v", n.Name(), err)
-		}
-
-		n.epCnt = ec
-		if n.scope == "" {
-			n.scope = store.Scope()
-		}
-		return n, nil
 	}
-
 	return nil, fmt.Errorf("network %s not found", nid)
 }
 


### PR DESCRIPTION
Fixed getNetworkFromStore, which returned incorrect network information - notably, the 'resolver' field was empty.

This fixes https://github.com/moby/moby/issues/38901

Signed-off-by: Espen Suenson <mail@espensuenson.dk>