### PR TITLE
Always configure iptables forward policy

### DIFF
--- a/drivers/bridge/setup_ip_forwarding.go
+++ b/drivers/bridge/setup_ip_forwarding.go
@@ -34,11 +34,11 @@ func setupIPForwarding(enableIPTables bool) error {
 		if err := configureIPForwarding(true); err != nil {
 			return fmt.Errorf("Enabling IP forwarding failed: %v", err)
 		}
-		// When enabling ip_forward set the default policy on forward chain to
-		// drop only if the daemon option iptables is not set to false.
-		if !enableIPTables {
-			return nil
-		}
+	}
+
+	// Set the default policy on forward chain to drop only if the
+	// daemon option iptables is not set to false.
+	if enableIPTables {
 		if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
 			if err := configureIPForwarding(false); err != nil {
 				logrus.Errorf("Disabling IP forwarding failed, %v", err)


### PR DESCRIPTION
Follow-up email to security@docker.com, ping @justincormack
Related to https://github.com/moby/moby/issues/14041 and https://github.com/docker/libnetwork/pull/1526

By default, when Docker starts up (to configure the bridge network driver) it enables `ip_forward` flag and it sets iptables `FORWARD` chain policy to `DROP` (unless daemon's `iptables` option is set to `false`). Then Docker inserts `ACCEPT` rules based on the configured networks.

If another software (or an administrator) enables `ip_forward` flag _before_ Docker boot, iptables policy configuration is skipped, resulting in the default policy being `ACCEPT`. Docker still configures all other rules, but they have no meaning because they are only `ACCEPT` rules (and the default is `ACCEPT` anyway). These lead to a local attacker being able to access all containers by setting the host as gateway for the (guessable) Docker subnets (as shown in https://github.com/moby/moby/issues/14041).

Accessing all containers can be a security vulnerability, especially when unauthenticated private services are running (e.g., Redis). An example software that interferes with Docker is OpenVPN, because it enables `ip_forward` flag at boot before Docker has a change of reading it. OpenVPN has the increased problem of allowing all clients connected to the vpn server the ability of abusing this vulnerability acting as local nodes in the network (I've found this scenario multiple times in the wild), but it is not the only software causing this issue.
To reproduce it, you can use a fresh copy of Ubuntu 18.04, install Docker and then install OpenVPN (Official APT repository, no need to configure VPN server/clients) and reboot the server. On next boot, iptables forward policy remains `ACCEPT`.

Because Docker's `iptables` flag is still `true`, and because Docker is still configuring all other iptables' rules, I think it should configure iptables forward policy even when `ip_forward` flag is `1`. This would ensure a secure setup by default, and if the user wants more control over iptables, he should explicitly disable Docker's iptables management.