### PR TITLE
Support for com.docker.network.host_ipv4 driver label

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -71,6 +71,7 @@ type networkConfiguration struct {
 	Mtu                  int
 	DefaultBindingIP     net.IP
 	DefaultBridge        bool
+	HostIP               net.IP
 	ContainerIfacePrefix string
 	// Internal fields set after ipam data parsing
 	AddressIPv4        *net.IPNet
@@ -253,6 +254,10 @@ func (c *networkConfiguration) fromLabels(labels map[string]string) error {
 			}
 		case netlabel.ContainerIfacePrefix:
 			c.ContainerIfacePrefix = value
+		case netlabel.HostIP:
+			if c.HostIP = net.ParseIP(value); c.HostIP == nil {
+				return parseErr(label, value, "nil ip")
+			}
 		}
 	}
 

--- a/drivers/bridge/bridge_store.go
+++ b/drivers/bridge/bridge_store.go
@@ -141,6 +141,7 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap["Internal"] = ncfg.Internal
 	nMap["DefaultBridge"] = ncfg.DefaultBridge
 	nMap["DefaultBindingIP"] = ncfg.DefaultBindingIP.String()
+	nMap["HostIP"] = ncfg.HostIP.String()
 	nMap["DefaultGatewayIPv4"] = ncfg.DefaultGatewayIPv4.String()
 	nMap["DefaultGatewayIPv6"] = ncfg.DefaultGatewayIPv6.String()
 	nMap["ContainerIfacePrefix"] = ncfg.ContainerIfacePrefix
@@ -181,6 +182,10 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 
 	if v, ok := nMap["ContainerIfacePrefix"]; ok {
 		ncfg.ContainerIfacePrefix = v.(string)
+	}
+
+	if v, ok := nMap["HostIP"]; ok {
+		ncfg.HostIP = net.ParseIP(v.(string))
 	}
 
 	ncfg.DefaultBridge = nMap["DefaultBridge"].(bool)

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -264,6 +264,7 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 	}
 
 	bndIPs := "127.0.0.1"
+	testHostIP := "1.2.3.4"
 	nwV6s := "2001:db8:2600:2700:2800::/80"
 	gwV6s := "2001:db8:2600:2700:2800::25/80"
 	nwV6, _ := types.ParseCIDR(nwV6s)
@@ -275,6 +276,7 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 		EnableICC:          "true",
 		EnableIPMasquerade: "true",
 		DefaultBindingIP:   bndIPs,
+		netlabel.HostIP:    testHostIP,
 	}
 
 	netOption := make(map[string]interface{})
@@ -320,6 +322,11 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 	bndIP := net.ParseIP(bndIPs)
 	if !bndIP.Equal(nw.config.DefaultBindingIP) {
 		t.Fatalf("Unexpected: %v", nw.config.DefaultBindingIP)
+	}
+
+	hostIP := net.ParseIP(testHostIP)
+	if !hostIP.Equal(nw.config.HostIP) {
+		t.Fatalf("Unexpected: %v", nw.config.HostIP)
 	}
 
 	if !types.CompareIPNet(nw.config.AddressIPv6, nwV6) {

--- a/netlabel/labels.go
+++ b/netlabel/labels.go
@@ -53,6 +53,9 @@ const (
 
 	// ContainerIfacePrefix can be used to override the interface prefix used inside the container
 	ContainerIfacePrefix = Prefix + ".container_iface_prefix"
+
+	// HostIP is the Source-IP Address used to SNAT container traffic
+	HostIP = Prefix + ".host_ipv4"
 )
 
 var (


### PR DESCRIPTION
This commit allows a user to specify a Host IP via the
com.docker.network.host_ipv4 label which is used as the
Source IP during SNAT for bridge networks .

The use case is for hosts with multiple interfaces and
this label can dictate which IP will be used as Source IP
for North-South traffic

In the absence of this label, MASQUERADE is used which picks the Source IP
based on Next Hop from the Route Table

Addresses: https://github.com/moby/moby/issues/30053

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>