### PR TITLE
Resolve "bridge fdb show" hang issue

### DIFF
--- a/support/Dockerfile
+++ b/support/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --no-cache \
     iproute2 \
     ipvsadm \
     conntrack-tools \
+    jq \
     bash
 
 WORKDIR /bin


### PR DESCRIPTION
The output of "bridge fdb show" command invoked under a network
namespace is unpredicable. Sometime it returns empty, and sometime
non-stop rolling output. This perhaps is a bug in kernel
and/or iproute2 implementation. To work around, display fdb  for
 each bridge.