### PR TITLE
Fix Error Check in NewNetwork

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -825,7 +825,7 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 
 	err = c.addNetwork(network)
 	if err != nil {
-		if strings.Contains(err.Error(), "restoring existing network") {
+		if _, ok := err.(types.MaskableError); ok {
 			// This error can be ignored and set this boolean
 			// value to skip a refcount increment for configOnly networks
 			skipCfgEpCount = true


### PR DESCRIPTION
Use types.MaskableError instead of doing a string comparison

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>