### PR TITLE
Fix panic in drivers/overlay/encryption.go

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -378,7 +378,7 @@ func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) 
 			}
 		}
 		if err := d.updateKeys(newKey, priKey, delKey); err != nil {
-			logrus.Warn(err)
+			return err
 		}
 	default:
 	}


### PR DESCRIPTION
Issue - "index out of range" panic in drivers/overlay/encryption.go:539
due to a mismatch in indices between curKeys and spis due to
case where updateKeys might bail out due to an error and
not update the spis

Context - This issue can be hit when a worker node gets disconnected from the manager, for more than 1 key rotation interval (12h), that in itself its something to worry about, and even though the workloads get shifted to a new node, once the worker node reconnects, due to the issue mentioned above, causes dockerd to panic

Fix - Reconfigure keys when there is a key update failure

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>