### PR TITLE
docker-proxy-close-dangling-sockets

### DIFF
--- a/cmd/proxy/tcp_proxy.go
+++ b/cmd/proxy/tcp_proxy.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"log"
 	"net"
-	"sync"
+	"time"
 )
 
 // TCPProxy is a proxy for TCP connections. It implements the Proxy interface to
@@ -38,21 +38,36 @@ func (proxy *TCPProxy) clientLoop(client *net.TCPConn, quit chan bool) {
 		return
 	}
 
-	var wg sync.WaitGroup
+	// Use this channel to follow the execution status
+	// of our goroutines :D
+	done := make(chan bool)
+
 	var broker = func(to, from *net.TCPConn) {
 		io.Copy(to, from)
 		from.CloseRead()
 		to.CloseWrite()
-		wg.Done()
+		done <- true
+
 	}
 
-	wg.Add(2)
 	go broker(client, backend)
 	go broker(backend, client)
 
 	finish := make(chan struct{})
 	go func() {
-		wg.Wait()
+
+		//Wait until at least one function exits
+		<-done
+
+		//After one end of the connection is closed wait for max 30 sec
+		//until the other end is closed as well
+		//This is to prevent that CLOSE_WAIT and SYN_WAIT2 socket states
+		//accumulate the open sockets by docker-proxy
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+		}
+
 		close(finish)
 	}()
 


### PR DESCRIPTION
Make docker-proxy more resilient to CLOSE_WAIT and FIN_WAIT2 socket states.
In case of unexpected connection terminations, do not wait indefinitely until both ends are closed.