### PR TITLE
[18.09 backport] Update Golang 1.12.12 (CVE-2019-17596)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.8
+ARG GO_VERSION=1.12.12
 
 FROM golang:${GO_VERSION}-stretch as dev
 RUN apt-get update && apt-get -y install iptables \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG GO_VERSION=1.12.6
+ARG GO_VERSION=1.12.8
 
-FROM golang:${GO_VERSION} as dev
+FROM golang:${GO_VERSION}-stretch as dev
 RUN apt-get update && apt-get -y install iptables \
 		protobuf-compiler
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.12.6 as dev
+ARG GO_VERSION=1.12.6
+
+FROM golang:${GO_VERSION} as dev
 RUN apt-get update && apt-get -y install iptables \
 		protobuf-compiler
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ all-local: build-local check-local clean
 # builder builds the libnetworkbuild container.  All wrapper targets
 # must depend on this to ensure that the container exists.
 builder:
-	docker build -t ${build_image} ${dockerbuildargs}
+	docker build -t ${build_image} --build-arg=GO_VERSION ${dockerbuildargs}
 
 build: builder
 	@echo "🐳 $@"


### PR DESCRIPTION
Backports of:

- https://github.com/docker/libnetwork/pull/2420 Dockerfile: use GO_VERSION build-arg for overriding Go version
- https://github.com/docker/libnetwork/pull/2434 Bumps the GO Version to 1.12.8 which contains security fixes
- https://github.com/docker/libnetwork/pull/2472 Update Golang 1.12.12 (CVE-2019-17596)