### PR TITLE
[19.03 backport] Update Golang 1.12.12 (CVE-2019-17596)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.8
+ARG GO_VERSION=1.12.12
 
 FROM golang:${GO_VERSION}-stretch as dev
 RUN apt-get update && apt-get -y install iptables \


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2472

Golang 1.12.12
-------------------------------

full diff: https://github.com/golang/go/compare/go1.12.11...go1.12.12

go1.12.12 (released 2019/10/17) includes fixes to the go command, runtime,
syscall and net packages. See the Go 1.12.12 milestone on our issue tracker for
details.

https://github.com/golang/go/issues?q=milestone%3AGo1.12.12

Golang 1.12.11 (CVE-2019-17596)
-------------------------------

full diff: https://github.com/golang/go/compare/go1.12.10...go1.12.11

go1.12.11 (released 2019/10/17) includes security fixes to the crypto/dsa
package. See the Go 1.12.11 milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.12.11

    [security] Go 1.13.2 and Go 1.12.11 are released

    Hi gophers,

    We have just released Go 1.13.2 and Go 1.12.11 to address a recently reported
    security issue. We recommend that all affected users update to one of these
    releases (if you're not sure which, choose Go 1.13.2).

    Invalid DSA public keys can cause a panic in dsa.Verify. In particular, using
    crypto/x509.Verify on a crafted X.509 certificate chain can lead to a panic,
    even if the certificates don't chain to a trusted root. The chain can be
    delivered via a crypto/tls connection to a client, or to a server that accepts
    and verifies client certificates. net/http clients can be made to crash by an
    HTTPS server, while net/http servers that accept client certificates will
    recover the panic and are unaffected.

    Moreover, an application might crash invoking
    crypto/x509.(*CertificateRequest).CheckSignature on an X.509 certificate
    request, parsing a golang.org/x/crypto/openpgp Entity, or during a
    golang.org/x/crypto/otr conversation. Finally, a golang.org/x/crypto/ssh client
    can panic due to a malformed host key, while a server could panic if either
    PublicKeyCallback accepts a malformed public key, or if IsUserAuthority accepts
    a certificate with a malformed public key.

    The issue is CVE-2019-17596 and Go issue golang.org/issue/34960.

    Thanks to Daniel Mandragona for discovering and reporting this issue. We'd also
    like to thank regilero for a previous disclosure of CVE-2019-16276.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit f741dc9c305fea900b96b8a838f959395799cf78)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>