### PR TITLE
[18.09 backport] Fix panic in drivers/overlay/encryption.go

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -379,7 +379,7 @@ func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) 
 			}
 		}
 		if err := d.updateKeys(newKey, priKey, delKey); err != nil {
-			logrus.Warn(err)
+			return err
 		}
 	default:
 	}


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2462

Issue - "index out of range" panic in drivers/overlay/encryption.go:539
due to a mismatch in indices between curKeys and spis due to
case where updateKeys might bail out due to an error and
not update the spis

Fix - Reconfigure keys when there is a key update failure

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>
(cherry picked from commit 4420ee92f5b3b951f98a36b2bc8144a19b560a22)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>