### PR TITLE
Fix InhibitIPv4 nil panic

### DIFF
--- a/drivers/bridge/bridge_store.go
+++ b/drivers/bridge/bridge_store.go
@@ -198,7 +198,10 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 	ncfg.EnableIPv6 = nMap["EnableIPv6"].(bool)
 	ncfg.EnableIPMasquerade = nMap["EnableIPMasquerade"].(bool)
 	ncfg.EnableICC = nMap["EnableICC"].(bool)
-	ncfg.InhibitIPv4 = nMap["InhibitIPv4"].(bool)
+	if v, ok := nMap["InhibitIPv4"]; ok {
+		ncfg.InhibitIPv4 = v.(bool)
+	}
+
 	ncfg.Mtu = int(nMap["Mtu"].(float64))
 	if v, ok := nMap["Internal"]; ok {
 		ncfg.Internal = v.(bool)


### PR DESCRIPTION
**- What I did**
When I upgrade the docker of my laptop from 19.03 to the latest master branch, docker.service startup failed with panic:
```
Feb 27 01:44:56 localhost systemd: Starting Docker Application Container Engine...
Feb 27 01:44:57 localhost dockerd: panic: interface conversion: interface {} is nil, not bool
Feb 27 01:44:57 localhost dockerd: goroutine 1 [running]:
Feb 27 01:44:57 localhost dockerd: github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/bridge.(*networkConfiguration).UnmarshalJSON(0xc0006ee410, 0xc00097b1e0, 0x189, 0x189, 0x7f9979d15510, 0xc0006ee410)
Feb 27 01:44:57 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/docker/libnetwork/drivers/bridge/bridge_store.go:201 +0xb9a
Feb 27 01:44:57 localhost dockerd: encoding/json.(*decodeState).object(0xc000c2b550, 0x55f9eff967c0, 0xc0006ee410, 0x16, 0xc000c2b578, 0xc00051537b)
Feb 27 01:44:57 localhost dockerd: /usr/local/go/src/encoding/json/decode.go:667 +0x220d
```
and this PR will fix it.

**- How I did it**

There is no "InhibitIPv4" field in the json string of `Bridge` before PR #2317, so I just add a nil check before the type cast
